### PR TITLE
Remove module resolver

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,14 +2,5 @@
   "presets": [
     ["@babel/preset-env", { "targets": { "node": "current" } }],
     "@babel/preset-typescript"
-  ],
-  "plugins": [
-    [
-      "module-resolver",
-      {
-        "extensions": [".ts"],
-        "root": ["./src"]
-      }
-    ]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@babel/preset-typescript": "7.9.0",
     "@types/jest": "25.2.1",
     "babel-jest": "25.3.0",
-    "babel-plugin-module-resolver": "4.0.0",
     "concurrently": "5.1.0",
     "husky": "4.2.5",
     "jest": "25.3.0",

--- a/src/Events/Authentication/AuthImpression.ts
+++ b/src/Events/Authentication/AuthImpression.ts
@@ -5,7 +5,7 @@ import {
   AuthIntent,
   AuthModalType,
   AuthTrigger,
-} from "Schema"
+} from "../../Schema"
 
 export interface AuthImpressionArgs {
   copy?: string

--- a/src/Events/Authentication/CreatedAccount.ts
+++ b/src/Events/Authentication/CreatedAccount.ts
@@ -1,5 +1,5 @@
-import { ActionType } from "Schema"
-import { CreatedAccount } from "Schema/Event"
+import { ActionType } from "../../Schema"
+import { CreatedAccount } from "../../Schema/Event"
 import { AccountArgs } from "./Typings"
 
 /**

--- a/src/Events/Authentication/SuccessfullyLoggedIn.ts
+++ b/src/Events/Authentication/SuccessfullyLoggedIn.ts
@@ -1,5 +1,5 @@
-import { ActionType } from "Schema"
-import { SuccessfullyLoggedIn } from "Schema/Event"
+import { ActionType } from "../../Schema"
+import { SuccessfullyLoggedIn } from "../../Schema/Event"
 import { AccountArgs } from "./Typings"
 
 /**

--- a/src/Events/Authentication/Typings.ts
+++ b/src/Events/Authentication/Typings.ts
@@ -1,5 +1,5 @@
-import { AuthContextModule, AuthIntent, AuthTrigger } from "index"
-import { AuthService } from "Schema/Authentication"
+import { AuthContextModule, AuthIntent, AuthTrigger } from "../../Schema"
+import { AuthService } from "../../Schema/Authentication"
 
 export interface AccountArgs {
   authRedirect: string

--- a/src/Events/Authentication/__tests__/AuthImpression.test.ts
+++ b/src/Events/Authentication/__tests__/AuthImpression.test.ts
@@ -1,4 +1,4 @@
-import { ContextModule, AuthIntent, AuthModalType } from "Schema"
+import { ContextModule, AuthIntent, AuthModalType } from "../../../Schema"
 import { authImpression } from "../AuthImpression"
 
 describe("authImpression", () => {

--- a/src/Events/Authentication/__tests__/CreatedAccount.test.ts
+++ b/src/Events/Authentication/__tests__/CreatedAccount.test.ts
@@ -1,4 +1,4 @@
-import { ContextModule, AuthIntent } from "Schema"
+import { ContextModule, AuthIntent } from "../../../Schema"
 import { createdAccount } from "../CreatedAccount"
 
 describe("createdAccount", () => {

--- a/src/Events/Authentication/__tests__/SuccessfullyLoggedIn.test.ts
+++ b/src/Events/Authentication/__tests__/SuccessfullyLoggedIn.test.ts
@@ -1,4 +1,4 @@
-import { ContextModule, AuthIntent } from "Schema"
+import { ContextModule, AuthIntent } from "../../../Schema"
 import { successfullyLoggedIn } from "../SuccessfullyLoggedIn"
 
 describe("successfullyLoggedIn", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from "Events"
-export * from "Schema"
+export * from "./Events"
+export * from "./Schema"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
-    "baseUrl": "./src",
     "module": "es2015",
     "moduleResolution": "node",
     "noUnusedLocals": true,
@@ -14,7 +13,7 @@
     "target": "es2016"
   },
   "include": ["./src", "typings/*.d.ts"],
-  "exclude": ["node_modules/*"],
+  "exclude": ["node_modules/*", "dist"],
   "typedocOptions": {
     "inputFiles": ["./src"],
     "out": "doc",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1356,17 +1356,6 @@ babel-plugin-jest-hoist@^25.2.6:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-module-resolver@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.0.0.tgz#8f3a3d9d48287dc1d3b0d5595113adabd36a847f"
-  integrity sha512-3pdEq3PXALilSJ6dnC4wMWr0AZixHRM4utpdpBR9g5QG7B7JwWyukQv7a9hVxkbGFl+nQbrHDqqQOIBtTXTP/Q==
-  dependencies:
-    find-babel-config "^1.2.0"
-    glob "^7.1.6"
-    pkg-up "^3.1.0"
-    reselect "^4.0.0"
-    resolve "^1.13.1"
-
 babel-preset-current-node-syntax@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.2.tgz#fb4a4c51fe38ca60fede1dc74ab35eb843cb41d6"
@@ -2172,14 +2161,6 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-babel-config@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
-  integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
-  dependencies:
-    json5 "^0.5.1"
-    path-exists "^3.0.0"
-
 find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -2321,7 +2302,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -3261,11 +3242,6 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-  integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
-
 json5@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
@@ -3988,13 +3964,6 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pkg-up@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
-  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
-  dependencies:
-    find-up "^3.0.0"
-
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -4260,11 +4229,6 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
-reselect@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
-  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
-
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -4306,7 +4270,7 @@ resolve@^1.10.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.13.1, resolve@^1.15.1, resolve@^1.3.2:
+resolve@^1.15.1, resolve@^1.3.2:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==


### PR DESCRIPTION
Babel's module resolver was not interpreting paths correctly in consuming apps. This updates to remove the plugin and config, and use relative paths throughout. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.2-canary.20.352.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/cohesion@0.2.2-canary.20.352.0
  # or 
  yarn add @artsy/cohesion@0.2.2-canary.20.352.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
