### PR TITLE
Add additional screen destinations, add category screen

### DIFF
--- a/src/Events/Tap/TappedEntityGroup.ts
+++ b/src/Events/Tap/TappedEntityGroup.ts
@@ -20,6 +20,10 @@ export type TappedEntityDestinationType =
   | OwnerType.explore
   | OwnerType.fair
   | OwnerType.sale
+  | OwnerType.auctions
+  | OwnerType.savesAndFollows
+  | OwnerType.category
+  | OwnerType.worksForYou
 
 export interface TappedEntityGroupArgs {
   contextModule: ContextModule
@@ -77,6 +81,9 @@ export const tappedEntityGroup = ({
       action = ActionType.tappedArtistGroup
       break
     case OwnerType.artwork:
+    case OwnerType.category:
+    case OwnerType.worksForYou:
+    case OwnerType.savesAndFollows:
       action = ActionType.tappedArtworkGroup
       break
     case OwnerType.collection:
@@ -89,6 +96,7 @@ export const tappedEntityGroup = ({
       action = ActionType.tappedFairGroup
       break
     case OwnerType.sale:
+    case OwnerType.auctions:
       action = ActionType.tappedAuctionGroup
       break
   }

--- a/src/Events/Tap/TappedEntityGroup.ts
+++ b/src/Events/Tap/TappedEntityGroup.ts
@@ -22,7 +22,7 @@ export type TappedEntityDestinationType =
   | OwnerType.sale
   | OwnerType.auctions
   | OwnerType.savesAndFollows
-  | OwnerType.category
+  | OwnerType.gene
   | OwnerType.worksForYou
 
 export interface TappedEntityGroupArgs {
@@ -81,7 +81,7 @@ export const tappedEntityGroup = ({
       action = ActionType.tappedArtistGroup
       break
     case OwnerType.artwork:
-    case OwnerType.category:
+    case OwnerType.gene:
     case OwnerType.worksForYou:
     case OwnerType.savesAndFollows:
       action = ActionType.tappedArtworkGroup

--- a/src/Events/Tap/__tests__/TappedEntityGroup.test.ts
+++ b/src/Events/Tap/__tests__/TappedEntityGroup.test.ts
@@ -76,12 +76,12 @@ describe("tappedEntityGroup", () => {
 
     expect(worksForYouEvent.action).toEqual("tappedArtworkGroup")
 
-    const categoryEvent = tappedEntityGroup({
+    const geneEvent = tappedEntityGroup({
       ...args,
-      destinationScreenOwnerType: OwnerType.category,
+      destinationScreenOwnerType: OwnerType.gene,
     })
 
-    expect(categoryEvent.action).toEqual("tappedArtworkGroup")
+    expect(geneEvent.action).toEqual("tappedArtworkGroup")
 
     const savesAndFollowsEvent = tappedEntityGroup({
       ...args,

--- a/src/Events/Tap/__tests__/TappedEntityGroup.test.ts
+++ b/src/Events/Tap/__tests__/TappedEntityGroup.test.ts
@@ -63,19 +63,46 @@ describe("tappedEntityGroup", () => {
   })
 
   it("Constructs TappedArtworkGroup events", () => {
-    const event = tappedEntityGroup({
+    const singleArtworkEvent = tappedEntityGroup({
       ...args,
       destinationScreenOwnerType: OwnerType.artwork,
     })
-    expect(event.action).toEqual("tappedArtworkGroup")
+    expect(singleArtworkEvent.action).toEqual("tappedArtworkGroup")
+
+    const worksForYouEvent = tappedEntityGroup({
+      ...args,
+      destinationScreenOwnerType: OwnerType.worksForYou,
+    })
+
+    expect(worksForYouEvent.action).toEqual("tappedArtworkGroup")
+
+    const categoryEvent = tappedEntityGroup({
+      ...args,
+      destinationScreenOwnerType: OwnerType.category,
+    })
+
+    expect(categoryEvent.action).toEqual("tappedArtworkGroup")
+
+    const savesAndFollowsEvent = tappedEntityGroup({
+      ...args,
+      destinationScreenOwnerType: OwnerType.savesAndFollows,
+    })
+
+    expect(savesAndFollowsEvent.action).toEqual("tappedArtworkGroup")
   })
 
   it("Constructs TappedAuctionGroup events", () => {
-    const event = tappedEntityGroup({
+    const singleAuctionEvent = tappedEntityGroup({
       ...args,
       destinationScreenOwnerType: OwnerType.sale,
     })
-    expect(event.action).toEqual("tappedAuctionGroup")
+    expect(singleAuctionEvent.action).toEqual("tappedAuctionGroup")
+
+    const auctionOverviewEvent = tappedEntityGroup({
+      ...args,
+      destinationScreenOwnerType: OwnerType.auctions,
+    })
+    expect(auctionOverviewEvent.action).toEqual("tappedAuctionGroup")
   })
 
   it("Constructs TappedCollectionGroup events", () => {

--- a/src/Schema/OwnerType.ts
+++ b/src/Schema/OwnerType.ts
@@ -6,7 +6,7 @@ export enum OwnerType {
   artist = "artist",
   artwork = "artwork",
   auctions = "auctions",
-  category = "category",
+  gene = "gene",
   cityGuideGuide = "cityGuideGuide",
   cityGuideMap = "cityGuideMap",
   cityPicker = "cityPicker",
@@ -31,7 +31,7 @@ export type ScreenOwnerType =
   | OwnerType.artist
   | OwnerType.artwork
   | OwnerType.auctions
-  | OwnerType.category
+  | OwnerType.gene
   | OwnerType.cityGuideGuide
   | OwnerType.cityGuideMap
   | OwnerType.cityPicker

--- a/src/Schema/OwnerType.ts
+++ b/src/Schema/OwnerType.ts
@@ -6,6 +6,7 @@ export enum OwnerType {
   artist = "artist",
   artwork = "artwork",
   auctions = "auctions",
+  category = "category",
   cityGuideGuide = "cityGuideGuide",
   cityGuideMap = "cityGuideMap",
   cityPicker = "cityPicker",
@@ -30,6 +31,7 @@ export type ScreenOwnerType =
   | OwnerType.artist
   | OwnerType.artwork
   | OwnerType.auctions
+  | OwnerType.category
   | OwnerType.cityGuideGuide
   | OwnerType.cityGuideMap
   | OwnerType.cityPicker


### PR DESCRIPTION
This adds a few screens that are valid destinations for the home rails as well as `OwnerType.category` for category/gene home rails. 

**category**: landed on by tapping header of category/gene module e.g. "Photography"
**auctions:** landed on by tapping header of auctions rail, overview screen of all running auctions
**savesAndFollows:** landed on by tapping header of recently saved rail
**worksForYou:** landed on by tapping header of recommend works rail
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.3-canary.36.691.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/cohesion@1.0.3-canary.36.691.0
  # or 
  yarn add @artsy/cohesion@1.0.3-canary.36.691.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
