### PR TITLE
Expose consign helpers

### DIFF
--- a/src/Events/index.ts
+++ b/src/Events/index.ts
@@ -1,5 +1,6 @@
 export * from "./Authentication/AuthImpression"
 export * from "./Authentication/CreatedAccount"
-export * from "./Authentication/SuccessfullyLoggedIn"
 export * from "./Authentication/ResetYourPassword"
+export * from "./Authentication/SuccessfullyLoggedIn"
+export * from "./Tap/TappedConsign"
 export * from "./Tap/TappedEntityGroup"


### PR DESCRIPTION
I might be missing something, so please forgive me if so!!

But when I went to use the `tappedConsign` and `TappedConsignArgs` in Eigen, I was getting errors about those things not existing in `@artsy/cohesion` so I think this is what's required to do that? LMK if there's a better way!