### PR TITLE
Don't require module height for entity group

### DIFF
--- a/src/Events/Tap/TappedEntityGroup.ts
+++ b/src/Events/Tap/TappedEntityGroup.ts
@@ -34,7 +34,7 @@ export interface TappedEntityGroupArgs {
   destinationScreenOwnerId?: string
   destinationScreenOwnerSlug?: string
   horizontalSlidePosition?: number
-  moduleHeight: EntityModuleHeight
+  moduleHeight?: EntityModuleHeight
   type: EntityModuleType
 }
 


### PR DESCRIPTION
Per some conversation over on this one: https://github.com/artsy/eigen/pull/3350#discussion_r429335663 this PR marks the module height bit as optional so that I can leave it off over there.