### PR TITLE
Adds timeOnPage

### DIFF
--- a/src/Schema/Event.ts
+++ b/src/Schema/Event.ts
@@ -13,6 +13,7 @@ import {
   TappedExploreGroup,
   TappedFairGroup,
 } from "./Events/Tap"
+import { TimeOnPage } from "./Events/System"
 
 /**
  * The top-level actions an Event describes.
@@ -64,6 +65,10 @@ export enum ActionType {
    * Corresponds to {@link TappedConsign}
    */
   tappedConsign = "tappedConsign",
+  /**
+   * Corresponds to {@link TimeOnPage}
+   */
+  timeOnPage = "timeOnPage",
 }
 
 /**
@@ -83,3 +88,4 @@ export type Event =
   | TappedExploreGroup
   | TappedFairGroup
   | TappedConsign
+  | TimeOnPage

--- a/src/Schema/Events/System.ts
+++ b/src/Schema/Events/System.ts
@@ -1,0 +1,29 @@
+import { ActionType } from "../Event"
+import { PageOwnerType } from "../OwnerType"
+
+/**
+ * Schemas describing system events
+ * @packageDocumentation
+ */
+
+/**
+ * A user has been on a page for 15 seconds.
+ *
+ * This schema describes events sent to Segment from [[timeOnPage]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "timeOnPage",
+ *    category: "15 seconds",
+ *    context_page_owner_type: "home"
+ *  }
+ * ```
+ */
+export interface TimeOnPage {
+  action: ActionType.timeOnPage
+  category: "15 seconds"
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  context_page_owner_slug?: string
+}


### PR DESCRIPTION
As a part of the Segment audit, we decided to remove `timeOnPage` events for 30 seconds, 1 min, and 3 mins. We are also using this as an opportunity to move `timeOnPage` into cohesion.

The current `time_on_page` event has two properties - `category` for the time and `message` for the page path. I decided to get rid of `message` in favor of the `context_page_owner_[x]` properties. Lmk what you think!