### PR TITLE
Adds clickedMainArtworkGrid

### DIFF
--- a/src/Schema/ContextModule.ts
+++ b/src/Schema/ContextModule.ts
@@ -11,7 +11,7 @@ export enum ContextModule {
   artistRecentlySold = "artistRecentlySold",
   artistsTab = "artistsTab",
   artistsToFollowRail = "artistsToFollowRail",
-  artworkGrid = "artworkGrid",
+  mainArtworkGrid = "mainArtworkGrid",
   artworkImage = "artworkImage",
   artworkRecentlySoldGrid = "artworkRecentlySoldGrid",
   artworkSidebar = "artworkSidebar",

--- a/src/Schema/ContextModule.ts
+++ b/src/Schema/ContextModule.ts
@@ -11,7 +11,7 @@ export enum ContextModule {
   artistRecentlySold = "artistRecentlySold",
   artistsTab = "artistsTab",
   artistsToFollowRail = "artistsToFollowRail",
-  mainArtworkGrid = "mainArtworkGrid",
+  artworkGrid = "artworkGrid",
   artworkImage = "artworkImage",
   artworkRecentlySoldGrid = "artworkRecentlySoldGrid",
   artworkSidebar = "artworkSidebar",

--- a/src/Schema/Event.ts
+++ b/src/Schema/Event.ts
@@ -52,6 +52,10 @@ export enum ActionType {
    */
   clickedFairGroup = "clickedFairGroup",
   /**
+   * Corresponds to {@link ClickedArtworkGrid}
+   */
+  clickedArtworkGrid = "clickedArtworkGrid",
+  /**
    * Corresponds to {@link CreatedAccount}
    */
   createdAccount = "createdAccount",

--- a/src/Schema/Event.ts
+++ b/src/Schema/Event.ts
@@ -52,9 +52,9 @@ export enum ActionType {
    */
   clickedFairGroup = "clickedFairGroup",
   /**
-   * Corresponds to {@link ClickedArtworkGrid}
+   * Corresponds to {@link ClickedMainArtworkGrid}
    */
-  clickedArtworkGrid = "clickedArtworkGrid",
+  clickedArtworkGrid = "clickedMainArtworkGrid",
   /**
    * Corresponds to {@link CreatedAccount}
    */

--- a/src/Schema/Event.ts
+++ b/src/Schema/Event.ts
@@ -54,7 +54,7 @@ export enum ActionType {
   /**
    * Corresponds to {@link ClickedMainArtworkGrid}
    */
-  clickedArtworkGrid = "clickedMainArtworkGrid",
+  clickedMainArtworkGrid = "clickedMainArtworkGrid",
   /**
    * Corresponds to {@link CreatedAccount}
    */

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -61,8 +61,8 @@ export interface ClickedArtistGroup extends ClickedEntityGroup {
  *  }
  * ```
  */
-export interface ClickedArtworkGrid extends ClickedEntityGroup {
-  action: ActionType.clickedArtworkGrid
+export interface ClickedMainArtworkGrid extends ClickedEntityGroup {
+  action: ActionType.clickedMainArtworkGrid
 }
 
 /**
@@ -164,7 +164,7 @@ export interface ClickedFairGroup extends ClickedEntityGroup {
 export interface ClickedEntityGroup {
   action:
     | ActionType.clickedArtistGroup
-    | ActionType.clickedArtworkGrid
+    | ActionType.clickedMainArtworkGrid
     | ActionType.clickedArtworkGroup
     | ActionType.clickedAuctionGroup
     | ActionType.clickedCollectionGroup

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -39,17 +39,18 @@ export interface ClickedArtistGroup extends ClickedEntityGroup {
 }
 
 /**
- * A user clicks on an artwork in an artwork grid.
+ * A user clicks on an artwork in the main artwork grid, which is the main product feed we can find on our core merchandising surfaces.
+ * Currently, this event only fires on our new artwork grids on the following pages: Collect, Collection, Artist works-for-sale, and Search Results.
  * Note: This event is separate from [[clickedArtworkGroup]] because it is an important and frequent event.
  * Separating it out will make it easier for analysts to access.
  *
- * This schema describes events sent to Segment from [[clickedArtworkGrid]]
+ * This schema describes events sent to Segment from [[clickedMainArtworkGrid]]
  *
  *  @example
  *  ```
  *  {
- *    action: "clickedArtworkGrid",
- *    context_module: "artworkGrid",
+ *    action: "clickedMainArtworkGrid",
+ *    context_module: "mainArtworkGrid",
  *    context_page_owner_type: "artist",
  *    context_page_owner_id: "4d8b926a4eb68a1b2c0000ae",
  *    context_page_owner_slug: "damien-hirst",
@@ -65,7 +66,8 @@ export interface ClickedArtworkGrid extends ClickedEntityGroup {
 }
 
 /**
- * A user clicks a grouping of artworks on web
+ * A user clicks a grouping of artworks on web. This includes all artwork groupings (i.e. artwork rails), except the main artwork grid on our core merchandising surfaces.
+ * For our main artwork grids, we use the event [[clickedMainArtworkGrid]].
  *
  * This schema describes events sent to Segment from [[clickedArtworkGroup]]
  *

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -39,6 +39,32 @@ export interface ClickedArtistGroup extends ClickedEntityGroup {
 }
 
 /**
+ * A user clicks on an artwork in an artwork grid.
+ * Note: This event is separate from [[clickedArtworkGroup]] because it is an important and frequent event.
+ * Separating it out will make it easier for analysts to access.
+ *
+ * This schema describes events sent to Segment from [[clickedArtworkGrid]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedArtworkGrid",
+ *    context_module: "artworkGrid",
+ *    context_page_owner_type: "artist",
+ *    context_page_owner_id: "4d8b926a4eb68a1b2c0000ae",
+ *    context_page_owner_slug: "damien-hirst",
+ *    destination_page_owner_type: "artwork",
+ *    destination_page_owner_id: "53188b0d8b3b8192bb0005ae",
+ *    destination_page_owner_slug: "damien-hirst-anatomy-of-an-angel",
+ *    type: "thumbnail"
+ *  }
+ * ```
+ */
+export interface ClickedArtworkGrid extends ClickedEntityGroup {
+  action: ActionType.clickedArtworkGrid
+}
+
+/**
  * A user clicks a grouping of artworks on web
  *
  * This schema describes events sent to Segment from [[clickedArtworkGroup]]
@@ -136,6 +162,7 @@ export interface ClickedFairGroup extends ClickedEntityGroup {
 export interface ClickedEntityGroup {
   action:
     | ActionType.clickedArtistGroup
+    | ActionType.clickedArtworkGrid
     | ActionType.clickedArtworkGroup
     | ActionType.clickedAuctionGroup
     | ActionType.clickedCollectionGroup


### PR DESCRIPTION
This adds `clickedMainArtworkGrid`. I added a comment in the code, but I decided to create another event for the artwork grid (instead of using clickedArtworkGroup) because I think it's important and frequent enough that it'll make it easier to access if it's in its own table. Lmk what you think!