### PR TITLE
Add context to auto jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ workflows:
       - auto/publish-canary:
           <<: *not_master
           <<: *deploy
+          context: npm-deploy
           requires:
             - yarn/jest
             - yarn/type-check
@@ -55,6 +56,7 @@ workflows:
       - auto/publish:
           <<: *only_master
           <<: *deploy
+          context: npm-deploy
           requires:
             - yarn/jest
             - yarn/type-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   yarn: artsy/yarn@5.1.3
-  auto: artsy/auto@1.3.2
+  auto: artsy/auto@dev:fba93e0215dd4f5182e0a772662d260c
   aws-s3: circleci/aws-s3@1.0.15
 
 jobs:


### PR DESCRIPTION
Auto jobs are failing due to node version complaints, added context to failing jobs to match Reaction's functional setup with node 12.