### PR TITLE
Makes context page properties optional in timeOnPage

### DIFF
--- a/src/Helpers/System/TimeOnPage.ts
+++ b/src/Helpers/System/TimeOnPage.ts
@@ -3,7 +3,7 @@ import { ActionType, PageOwnerType, TimeOnPage } from "../../Schema"
 export interface TimeOnPageArgs {
   contextPageOwnerId?: string
   contextPageOwnerSlug?: string
-  contextPageOwnerType: PageOwnerType
+  contextPageOwnerType?: PageOwnerType
 }
 
 /**

--- a/src/Schema/Events/System.ts
+++ b/src/Schema/Events/System.ts
@@ -23,7 +23,7 @@ import { PageOwnerType } from "../Values/OwnerType"
 export interface TimeOnPage {
   action: ActionType.timeOnPage
   category: "15 seconds"
-  context_page_owner_type: PageOwnerType
+  context_page_owner_type?: PageOwnerType
   context_page_owner_id?: string
   context_page_owner_slug?: string
 }


### PR DESCRIPTION
We have to make the context page properties optional due to the same issue we had [here](https://github.com/artsy/eigen/pull/3517).

We do not need to add a `path` property because `context_page_path` is already provided as a common field from Segment.