### PR TITLE
Add tappedMainArtworkGrid helper

### DIFF
--- a/src/Helpers/Tap/TappedMainArtworkGrid.ts
+++ b/src/Helpers/Tap/TappedMainArtworkGrid.ts
@@ -1,0 +1,49 @@
+import {
+  ActionType,
+  ContextModule,
+  OwnerType,
+  ScreenOwnerType,
+  TappedMainArtworkGrid,
+} from "../../Schema"
+
+export interface TappedMainArtworkGridArgs {
+  contextPageOwnerType: ScreenOwnerType
+  contextPageOwnerId?: string
+  contextPageOwnerSlug?: string
+  destinationPageOwnerId: string
+  destinationPageOwnerSlug: string
+}
+
+/**
+ *  A user taps an artwork in the main artowrkGrid (iOS)
+ *
+ * @example
+ * ```
+ * tappedMainArtworkGrid({
+ *   contextPageOwnerType: OwnerType.artist,
+ *   contextPageOwnerId: "5359794d2a1e86c3741001f8",
+ *   contextPageOwnerSlug: "andy-warhol",
+ *   destinationPageOwnerId: "5359794d1a1e86c3740001f7",
+ *   destinationPageOwnerSlug: "andy-warhol-skull",
+ * })
+ * ```
+ */
+export const tappedMainArtworkGrid = ({
+  contextPageOwnerType,
+  contextPageOwnerId,
+  contextPageOwnerSlug,
+  destinationPageOwnerId,
+  destinationPageOwnerSlug,
+}: TappedMainArtworkGridArgs): TappedMainArtworkGrid => {
+  return {
+    action: ActionType.tappedMainArtworkGrid,
+    context_module: ContextModule.artworkGrid,
+    context_page_owner_id: contextPageOwnerId,
+    context_page_owner_slug: contextPageOwnerSlug,
+    context_page_owner_type: contextPageOwnerType,
+    destination_page_owner_id: destinationPageOwnerId,
+    destination_page_owner_slug: destinationPageOwnerSlug,
+    destination_page_owner_type: OwnerType.artwork,
+    type: "thumbnail",
+  }
+}

--- a/src/Helpers/Tap/TappedMainArtworkGrid.ts
+++ b/src/Helpers/Tap/TappedMainArtworkGrid.ts
@@ -7,11 +7,11 @@ import {
 } from "../../Schema"
 
 export interface TappedMainArtworkGridArgs {
-  contextPageOwnerType: ScreenOwnerType
-  contextPageOwnerId?: string
-  contextPageOwnerSlug?: string
-  destinationPageOwnerId: string
-  destinationPageOwnerSlug: string
+  contextScreenOwnerType: ScreenOwnerType
+  contextScreenOwnerId?: string
+  contextScreenOwnerSlug?: string
+  destinationScreenOwnerId: string
+  destinationScreenOwnerSlug: string
 }
 
 /**
@@ -20,30 +20,30 @@ export interface TappedMainArtworkGridArgs {
  * @example
  * ```
  * tappedMainArtworkGrid({
- *   contextPageOwnerType: OwnerType.artist,
- *   contextPageOwnerId: "5359794d2a1e86c3741001f8",
- *   contextPageOwnerSlug: "andy-warhol",
- *   destinationPageOwnerId: "5359794d1a1e86c3740001f7",
- *   destinationPageOwnerSlug: "andy-warhol-skull",
+ *   contextScreenOwnerType: OwnerType.artist,
+ *   contextScreenOwnerId: "5359794d2a1e86c3741001f8",
+ *   contextScreenOwnerSlug: "andy-warhol",
+ *   destinationScreenOwnerId: "5359794d1a1e86c3740001f7",
+ *   destinationScreenOwnerSlug: "andy-warhol-skull",
  * })
  * ```
  */
 export const tappedMainArtworkGrid = ({
-  contextPageOwnerType,
-  contextPageOwnerId,
-  contextPageOwnerSlug,
-  destinationPageOwnerId,
-  destinationPageOwnerSlug,
+  contextScreenOwnerType,
+  contextScreenOwnerId,
+  contextScreenOwnerSlug,
+  destinationScreenOwnerId,
+  destinationScreenOwnerSlug,
 }: TappedMainArtworkGridArgs): TappedMainArtworkGrid => {
   return {
     action: ActionType.tappedMainArtworkGrid,
     context_module: ContextModule.artworkGrid,
-    context_page_owner_id: contextPageOwnerId,
-    context_page_owner_slug: contextPageOwnerSlug,
-    context_page_owner_type: contextPageOwnerType,
-    destination_page_owner_id: destinationPageOwnerId,
-    destination_page_owner_slug: destinationPageOwnerSlug,
-    destination_page_owner_type: OwnerType.artwork,
+    context_screen_owner_id: contextScreenOwnerId,
+    context_screen_owner_slug: contextScreenOwnerSlug,
+    context_screen_owner_type: contextScreenOwnerType,
+    destination_screen_owner_id: destinationScreenOwnerId,
+    destination_screen_owner_slug: destinationScreenOwnerSlug,
+    destination_screen_owner_type: OwnerType.artwork,
     type: "thumbnail",
   }
 }

--- a/src/Helpers/Tap/__tests__/TappedMainArtworkGrid.test.ts
+++ b/src/Helpers/Tap/__tests__/TappedMainArtworkGrid.test.ts
@@ -1,0 +1,52 @@
+import {
+  TappedMainArtworkGridArgs,
+  tappedMainArtworkGrid,
+} from "../TappedMainArtworkGrid"
+import { OwnerType } from "../../../Schema"
+
+describe("clickedEntityGroup", () => {
+  let args: TappedMainArtworkGridArgs
+  beforeEach(() => {
+    args = {
+      contextPageOwnerType: OwnerType.home,
+      destinationPageOwnerId: "5359794d1a1e86c3740001f7",
+      destinationPageOwnerSlug: "andy-warhol-flower",
+    }
+  })
+  it("Works with minimal args", () => {
+    const event = tappedMainArtworkGrid(args)
+
+    expect(event).toEqual({
+      action: "tappedMainArtworkGrid",
+      context_module: "artworkGrid",
+      context_page_owner_id: undefined,
+      context_page_owner_slug: undefined,
+      context_page_owner_type: "home",
+      destination_page_owner_id: "5359794d1a1e86c3740001f7",
+      destination_page_owner_slug: "andy-warhol-flower",
+      destination_page_owner_type: "artwork",
+      type: "thumbnail",
+    })
+  })
+
+  it("Works with all args", () => {
+    const event = tappedMainArtworkGrid({
+      ...args,
+      contextPageOwnerId: "5359794d1a1e86c3740001f6",
+      contextPageOwnerSlug: "andy-warhol",
+      contextPageOwnerType: OwnerType.artist,
+    })
+
+    expect(event).toEqual({
+      action: "tappedMainArtworkGrid",
+      context_module: "artworkGrid",
+      context_page_owner_id: "5359794d1a1e86c3740001f6",
+      context_page_owner_slug: "andy-warhol",
+      context_page_owner_type: "artist",
+      destination_page_owner_id: "5359794d1a1e86c3740001f7",
+      destination_page_owner_slug: "andy-warhol-flower",
+      destination_page_owner_type: "artwork",
+      type: "thumbnail",
+    })
+  })
+})

--- a/src/Helpers/Tap/__tests__/TappedMainArtworkGrid.test.ts
+++ b/src/Helpers/Tap/__tests__/TappedMainArtworkGrid.test.ts
@@ -8,9 +8,9 @@ describe("clickedEntityGroup", () => {
   let args: TappedMainArtworkGridArgs
   beforeEach(() => {
     args = {
-      contextPageOwnerType: OwnerType.home,
-      destinationPageOwnerId: "5359794d1a1e86c3740001f7",
-      destinationPageOwnerSlug: "andy-warhol-flower",
+      contextScreenOwnerType: OwnerType.home,
+      destinationScreenOwnerId: "5359794d1a1e86c3740001f7",
+      destinationScreenOwnerSlug: "andy-warhol-flower",
     }
   })
   it("Works with minimal args", () => {
@@ -19,12 +19,12 @@ describe("clickedEntityGroup", () => {
     expect(event).toEqual({
       action: "tappedMainArtworkGrid",
       context_module: "artworkGrid",
-      context_page_owner_id: undefined,
-      context_page_owner_slug: undefined,
-      context_page_owner_type: "home",
-      destination_page_owner_id: "5359794d1a1e86c3740001f7",
-      destination_page_owner_slug: "andy-warhol-flower",
-      destination_page_owner_type: "artwork",
+      context_screen_owner_id: undefined,
+      context_screen_owner_slug: undefined,
+      context_screen_owner_type: "home",
+      destination_screen_owner_id: "5359794d1a1e86c3740001f7",
+      destination_screen_owner_slug: "andy-warhol-flower",
+      destination_screen_owner_type: "artwork",
       type: "thumbnail",
     })
   })
@@ -32,20 +32,20 @@ describe("clickedEntityGroup", () => {
   it("Works with all args", () => {
     const event = tappedMainArtworkGrid({
       ...args,
-      contextPageOwnerId: "5359794d1a1e86c3740001f6",
-      contextPageOwnerSlug: "andy-warhol",
-      contextPageOwnerType: OwnerType.artist,
+      contextScreenOwnerId: "5359794d1a1e86c3740001f6",
+      contextScreenOwnerSlug: "andy-warhol",
+      contextScreenOwnerType: OwnerType.artist,
     })
 
     expect(event).toEqual({
       action: "tappedMainArtworkGrid",
       context_module: "artworkGrid",
-      context_page_owner_id: "5359794d1a1e86c3740001f6",
-      context_page_owner_slug: "andy-warhol",
-      context_page_owner_type: "artist",
-      destination_page_owner_id: "5359794d1a1e86c3740001f7",
-      destination_page_owner_slug: "andy-warhol-flower",
-      destination_page_owner_type: "artwork",
+      context_screen_owner_id: "5359794d1a1e86c3740001f6",
+      context_screen_owner_slug: "andy-warhol",
+      context_screen_owner_type: "artist",
+      destination_screen_owner_id: "5359794d1a1e86c3740001f7",
+      destination_screen_owner_slug: "andy-warhol-flower",
+      destination_screen_owner_type: "artwork",
       type: "thumbnail",
     })
   })

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -220,12 +220,12 @@ export interface TappedConsign {
  *  {
  *    action: "tappedMainArtworkGrid",
  *    context_module: "artworkGrid",
- *    context_page_owner_type: "artist",
- *    context_page_owner_id: "4d8b926a4eb68a1b2c0000ae",
- *    context_page_owner_slug: "damien-hirst",
- *    destination_page_owner_type: "artwork",
- *    destination_page_owner_id: "53188b0d8b3b8192bb0005ae",
- *    destination_page_owner_slug: "damien-hirst-anatomy-of-an-angel",
+ *    context_screen_owner_type: "artist",
+ *    context_screen_owner_id: "4d8b926a4eb68a1b2c0000ae",
+ *    context_screen_owner_slug: "damien-hirst",
+ *    destination_screen_owner_type: "artwork",
+ *    destination_screen_owner_id: "53188b0d8b3b8192bb0005ae",
+ *    destination_screen_owner_slug: "damien-hirst-anatomy-of-an-angel",
  *    type: "thumbnail"
  *  }
  * ```
@@ -233,12 +233,12 @@ export interface TappedConsign {
 export interface TappedMainArtworkGrid {
   action: ActionType.tappedMainArtworkGrid
   context_module: ContextModule
-  context_page_owner_type: ScreenOwnerType
-  context_page_owner_id?: string
-  context_page_owner_slug?: string
-  destination_page_owner_type: ScreenOwnerType
-  destination_page_owner_id: string
-  destination_page_owner_slug: string
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id?: string
+  context_screen_owner_slug?: string
+  destination_screen_owner_type: ScreenOwnerType
+  destination_screen_owner_id: string
+  destination_screen_owner_slug: string
   type: "thumbnail"
 }
 


### PR DESCRIPTION
Adds helper `tappedMainArtworkGrid` & test.

I've updated the schema to use `screen` over `page` in column name, which matches all existing iOS `OwnerType`s. 
