### PR TITLE
no need for sort-keys

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
   root: true,
   rules: {
     "no-console": 1,
-    "sort-keys": 1,
     "sort-imports": 1,
     "spaced-comment": ["error", "always", { block: { balanced: true } }],
   },

--- a/src/Helpers/Click/ClickedMainArtworkGrid.ts
+++ b/src/Helpers/Click/ClickedMainArtworkGrid.ts
@@ -40,10 +40,10 @@ export const clickedMainArtworkGrid = ({
     context_module: ContextModule.artworkGrid,
     context_page_owner_id: contextPageOwnerId,
     context_page_owner_slug: contextPageOwnerSlug,
+    type: "thumbnail",
     context_page_owner_type: contextPageOwnerType,
     destination_page_owner_id: destinationPageOwnerId,
     destination_page_owner_slug: destinationPageOwnerSlug,
     destination_page_owner_type: OwnerType.artwork,
-    type: "thumbnail",
   }
 }

--- a/src/Helpers/Click/__tests__/ClickedMainArtworkGrid.test.ts
+++ b/src/Helpers/Click/__tests__/ClickedMainArtworkGrid.test.ts
@@ -22,10 +22,10 @@ describe("clickedEntityGroup", () => {
       context_page_owner_id: undefined,
       context_page_owner_slug: undefined,
       context_page_owner_type: "home",
+      type: "thumbnail",
       destination_page_owner_id: "5359794d1a1e86c3740001f7",
       destination_page_owner_slug: "andy-warhol-flower",
       destination_page_owner_type: "artwork",
-      type: "thumbnail",
     })
   })
 
@@ -43,10 +43,10 @@ describe("clickedEntityGroup", () => {
       context_page_owner_id: "5359794d1a1e86c3740001f6",
       context_page_owner_slug: "andy-warhol",
       context_page_owner_type: "artist",
+      type: "thumbnail",
       destination_page_owner_id: "5359794d1a1e86c3740001f7",
       destination_page_owner_slug: "andy-warhol-flower",
       destination_page_owner_type: "artwork",
-      type: "thumbnail",
     })
   })
 })

--- a/src/Helpers/Tap/TappedEntityGroup.ts
+++ b/src/Helpers/Tap/TappedEntityGroup.ts
@@ -48,12 +48,12 @@ export interface TappedEntityGroupArgs {
  * tappedEntityGroup({
  *   contextModule: ContextModule.trendingArtistsRail,
  *   contextScreenOwnerType: OwnerType.home,
+ *   type: "thumbnail"
  *   destinationScreenOwnerType: OwnerType.artist,
  *   destinationScreenOwnerId: "5359794d1a1e86c3740001f7",
  *   destinationScreenOwnerSlug: "andy-warhol",
  *   horizontalSlidePosition: 2,
  *   moduleHeight: "double",
- *   type: "thumbnail"
  * })
  * ```
  */
@@ -62,12 +62,12 @@ export const tappedEntityGroup = ({
   contextScreenOwnerType,
   contextScreenOwnerId,
   contextScreenOwnerSlug,
+  type,
   destinationScreenOwnerType,
   destinationScreenOwnerId,
   destinationScreenOwnerSlug,
   horizontalSlidePosition,
   moduleHeight,
-  type,
 }: TappedEntityGroupArgs):
   | TappedArtistGroup
   | TappedArtworkGroup
@@ -107,11 +107,11 @@ export const tappedEntityGroup = ({
     context_screen_owner_id: contextScreenOwnerId,
     context_screen_owner_slug: contextScreenOwnerSlug,
     context_screen_owner_type: contextScreenOwnerType,
+    type,
     destination_screen_owner_id: destinationScreenOwnerId,
     destination_screen_owner_slug: destinationScreenOwnerSlug,
     destination_screen_owner_type: destinationScreenOwnerType,
     horizontal_slide_position: horizontalSlidePosition,
     module_height: moduleHeight,
-    type,
   }
 }

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -26,11 +26,11 @@ import { PageOwnerType } from "../Values/OwnerType"
  *    action: "clickedArtistGroup",
  *    context_module: "trendingArtistsRail",
  *    context_page_owner_type: "home",
+ *    type: "thumbnail"
  *    destination_page_owner_type: "artist",
  *    destination_page_owner_id: "5359794d1a1e86c3740001f7",
  *    destination_page_owner_slug: "anthony-hunter",
  *    horizontal_slide_position: 1,
- *    type: "thumbnail"
  *  }
  * ```
  */
@@ -50,11 +50,11 @@ export interface ClickedArtistGroup extends ClickedEntityGroup {
  *    action: "clickedArtworkGroup",
  *    context_module: "newWorksByArtistsYouFollowRail",
  *    context_page_owner_type: "home",
+ *    type: "thumbnail"
  *    destination_page_owner_type: "artwork",
  *    destination_page_owner_id: "5e9a7a238483bf000e2c4c5e",
  *    destination_page_owner_slug: "romain-jacquet-lagreze-makeshift-garden-hong-kong",
  *    horizontal_slide_position: 1,
- *    type: "thumbnail"
  *  }
  * ```
  */
@@ -73,11 +73,11 @@ export interface ClickedArtworkGroup extends ClickedEntityGroup {
  *    action: "clickedAuctionGroup",
  *    context_module: "auctionsRail",
  *    context_page_owner_type: "home",
+ *    type: "thumbnail"
  *    destination_page_owner_type: "sale",
  *    destination_page_owner_id: "5e95b37a2fdcb20012a0e082",
  *    destination_page_owner_slug: "forum-auctions-colour-theory-4",
  *    horizontal_slide_position: 3,
- *    type: "thumbnail"
  *  }
  * ```
  */
@@ -96,10 +96,10 @@ export interface ClickedAuctionGroup extends ClickedEntityGroup {
  *    action: "clickedCollectionGroup",
  *    context_module: "collectionRail",
  *    context_page_owner_type: "home",
+ *    type: "thumbnail"
  *    destination_page_owner_type: "collection",
  *    destination_page_owner_slug: "limited-edition-prints-trending-artists",
  *    horizontal_slide_position: 2,
- *    type: "thumbnail"
  *  }
  * ```
  */
@@ -118,12 +118,12 @@ export interface ClickedCollectionGroup extends ClickedEntityGroup {
  *    action: "clickedFairGroup",
  *    context_module: "fairRail",
  *    context_page_owner_type: "home",
+ *    type: "thumbnail"
  *    destination_page_owner_type: "fair",
  *    destination_page_owner_id: "5e726bd22524980012caafb0",
  *    destination_page_owner_slug: "arteba-special-edition",
  *    horizontal_slide_position: 2,
  *    module_height: "double",
- *    type: "thumbnail"
  *  }
  * ```
  */
@@ -146,11 +146,11 @@ export interface ClickedEntityGroup {
   context_page_owner_type: PageOwnerType
   context_page_owner_id?: string
   context_page_owner_slug?: string
+  type: EntityModuleType
   destination_page_owner_type: PageOwnerType
   destination_page_owner_id?: string
   destination_page_owner_slug?: string
   horizontal_slide_position?: number
-  type: EntityModuleType
 }
 
 /**
@@ -168,10 +168,10 @@ export interface ClickedEntityGroup {
  *    context_page_owner_type: "artist",
  *    context_page_owner_id: "4d8b926a4eb68a1b2c0000ae",
  *    context_page_owner_slug: "damien-hirst",
+ *    type: "thumbnail"
  *    destination_page_owner_type: "artwork",
  *    destination_page_owner_id: "53188b0d8b3b8192bb0005ae",
  *    destination_page_owner_slug: "damien-hirst-anatomy-of-an-angel",
- *    type: "thumbnail"
  *  }
  * ```
  */
@@ -181,8 +181,8 @@ export interface ClickedMainArtworkGrid {
   context_page_owner_type: PageOwnerType
   context_page_owner_id?: string
   context_page_owner_slug?: string
+  type: "thumbnail"
   destination_page_owner_type: PageOwnerType
   destination_page_owner_id: string
   destination_page_owner_slug: string
-  type: "thumbnail"
 }

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -143,12 +143,12 @@ export interface TappedExploreGroup extends TappedEntityGroup {
  *    action: "tappedFairGroup",
  *    context_module: "fairRail",
  *    context_screen_owner_type: "home",
+ *    type: "thumbnail"
  *    destination_screen_owner_type: "fair",
  *    destination_screen_owner_id: "5e726bd22524980012caafb0",
  *    destination_screen_owner_slug: "arteba-special-edition",
  *    horizontal_slide_position: 2,
  *    module_height: "double",
- *    type: "thumbnail"
  *  }
  * ```
  */
@@ -174,12 +174,12 @@ export interface TappedEntityGroup {
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id?: string
   context_screen_owner_slug?: string
+  type: EntityModuleType
   destination_screen_owner_type: ScreenOwnerType
   destination_screen_owner_id?: string
   destination_screen_owner_slug?: string
   horizontal_slide_position?: number
   module_height?: EntityModuleHeight
-  type: EntityModuleType
 }
 
 export type EntityModuleHeight = "single" | "double"
@@ -223,10 +223,10 @@ export interface TappedConsign {
  *    context_screen_owner_type: "artist",
  *    context_screen_owner_id: "4d8b926a4eb68a1b2c0000ae",
  *    context_screen_owner_slug: "damien-hirst",
+ *    type: "thumbnail"
  *    destination_screen_owner_type: "artwork",
  *    destination_screen_owner_id: "53188b0d8b3b8192bb0005ae",
  *    destination_screen_owner_slug: "damien-hirst-anatomy-of-an-angel",
- *    type: "thumbnail"
  *  }
  * ```
  */
@@ -236,10 +236,10 @@ export interface TappedMainArtworkGrid {
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id?: string
   context_screen_owner_slug?: string
+  type: "thumbnail"
   destination_screen_owner_type: ScreenOwnerType
   destination_screen_owner_id: string
   destination_screen_owner_slug: string
-  type: "thumbnail"
 }
 
 /**
@@ -306,8 +306,8 @@ export interface TappedTabBar {
  *    action: "tappedViewingRoomGroup",
  *    context_module: "featuredViewingRoomsRail",
  *    context_screen_owner_type: "home",
- *    destination_screen_owner_type: "viewingRoomList",
  *    type: "header"
+ *    destination_screen_owner_type: "viewingRoomList",
  *  }
  * ```
  */


### PR DESCRIPTION
This rule causes keys to go alphabetically, which doesn't offer any benefit for us here.

It's much more useful to be able to group keys in a way that makes sense, like having the `type` right next to the `context_page`. `type` is what we click on the page we are now, so it makes sense to be close to there, rather than last in the list because it is named `type` and not like `owner_page_type_of_thing_i_clicked`.
