### PR TITLE
[AS-1437] Artist series analytics tracking for iOS and web

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1,7 +1,7 @@
 import { ActionType } from "."
 import { ContextModule } from "../Values/ContextModule"
 import { EntityModuleType } from "../Values/EntityModuleType"
-import { PageOwnerType } from "../Values/OwnerType"
+import { OwnerType, PageOwnerType } from "../Values/OwnerType"
 
 /**
  * Schemas describing Click events
@@ -39,7 +39,7 @@ export interface ClickedArtistGroup extends ClickedEntityGroup {
 }
 
 /**
- * A user clicks a grouping of artist series on iOS. If the artist series was boosted by the curation team, then featured will be set to true.
+ * A user clicks a grouping of artist series on web. If the artist series was boosted by the curation team, then curation_boost will be set to true.
  *
  *  This schema describes events sent to Segment from [[clickedEntityGroup]]
  *
@@ -54,7 +54,7 @@ export interface ClickedArtistGroup extends ClickedEntityGroup {
  *    destination_page_owner_type: "artistSeries",
  *    destination_page_owner_id: "5359794d1a1e86c3740001f7",
  *    destination_page_owner_slug: "alex-katz-black-dress",
- *    featured: true,
+ *    curation_boost: true,
  *    horizontal_slide_position: 1,
  *    type: "thumbnail"
  *  }
@@ -62,6 +62,7 @@ export interface ClickedArtistGroup extends ClickedEntityGroup {
  */
 export interface ClickedArtistSeriesGroup extends ClickedEntityGroup {
   action: ActionType.clickedArtistSeriesGroup
+  destination_page_owner_type: OwnerType.artistSeries
 }
 
 /**

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -39,6 +39,32 @@ export interface ClickedArtistGroup extends ClickedEntityGroup {
 }
 
 /**
+ * A user clicks a grouping of artist series on iOS. If the artist series was boosted by the curation team, then featured will be set to true.
+ *
+ *  This schema describes events sent to Segment from [[clickedEntityGroup]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedArtistSeriesGroup",
+ *    context_module: "moreSeriesByThisArtist",
+ *    context_page_owner_type: "artistSeries",
+ *    context_page_owner_id: "5359794d1a1e86c3740001f7",
+ *    context_page_owner_slug: "alex-katz-departure",
+ *    destination_page_owner_type: "artistSeries",
+ *    destination_page_owner_id: "5359794d1a1e86c3740001f7",
+ *    destination_page_owner_slug: "alex-katz-black-dress",
+ *    featured: true,
+ *    horizontal_slide_position: 1,
+ *    type: "thumbnail"
+ *  }
+ * ```
+ */
+export interface ClickedArtistSeriesGroup extends ClickedEntityGroup {
+  action: ActionType.clickedArtistSeriesGroup
+}
+
+/**
  * A user clicks a grouping of artworks on web. This includes all artwork groupings (i.e. artwork rails), except the main artwork grid on our core merchandising surfaces.
  * For our main artwork grids, we use the event [[clickedMainArtworkGrid]].
  *
@@ -137,11 +163,12 @@ export interface ClickedFairGroup extends ClickedEntityGroup {
 export interface ClickedEntityGroup {
   action:
     | ActionType.clickedArtistGroup
-    | ActionType.clickedMainArtworkGrid
+    | ActionType.clickedArtistSeriesGroup
     | ActionType.clickedArtworkGroup
     | ActionType.clickedAuctionGroup
     | ActionType.clickedCollectionGroup
     | ActionType.clickedFairGroup
+    | ActionType.clickedMainArtworkGrid
   context_module: ContextModule
   context_page_owner_type: PageOwnerType
   context_page_owner_id?: string

--- a/src/Schema/Events/SavesAndFollows.ts
+++ b/src/Schema/Events/SavesAndFollows.ts
@@ -1,0 +1,38 @@
+import { ActionType } from "."
+import { ContextModule } from "../Values/ContextModule"
+import { ScreenOwnerType } from "../Values/OwnerType"
+
+/**
+ * Schemas describing save and follow events
+ * @packageDocumentation
+ */
+
+/**
+ * A user has followed an artist on iOS.
+ *
+ * This schema describes events sent to Segment from [[followedArtist]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "followedArtist",
+ *    context_module: "FeaturedArtists"
+ *    context_screen_owner_type: "artistSeries"
+ *    context_screen_owner_id: "5359794d1a1e86c3740001f7"
+ *    context_screen_owner_slug: "alex-katz-departure"
+ *    owner_type: "artist"
+ *    owner_id: "5359794d1a1e86c3740001f7"
+ *    owner_slug: "alex-katz"
+ *  }
+ * ```
+ */
+export interface FollowedArtist {
+  action: ActionType.followedArtist
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id?: string
+  context_screen_owner_slug?: string
+  owner_type: ScreenOwnerType
+  owner_id: string
+  owner_slug: string
+}

--- a/src/Schema/Events/SavesAndFollows.ts
+++ b/src/Schema/Events/SavesAndFollows.ts
@@ -17,9 +17,9 @@ import { OwnerType, PageOwnerType } from "../Values/OwnerType"
  *  {
  *    action: "followedArtist",
  *    context_module: "featuredArtists"
- *    context_page_owner_type: "artistSeries"
- *    context_page_owner_id: "5359794d1a1e86c3740001f7"
- *    context_page_owner_slug: "alex-katz-departure"
+ *    context_owner_type: "artistSeries"
+ *    context_owner_id: "5359794d1a1e86c3740001f7"
+ *    context_owner_slug: "alex-katz-departure"
  *    owner_type: "artist"
  *    owner_id: "5359794d1a1e86c3740001f7"
  *    owner_slug: "alex-katz"
@@ -29,9 +29,9 @@ import { OwnerType, PageOwnerType } from "../Values/OwnerType"
 export interface FollowedArtist {
   action: ActionType.followedArtist
   context_module: ContextModule
-  context_page_owner_type: PageOwnerType
-  context_page_owner_id?: string
-  context_page_owner_slug?: string
+  context_owner_type: PageOwnerType
+  context_owner_id?: string
+  context_owner_slug?: string
   owner_type: OwnerType.artist
   owner_id: string
   owner_slug: string
@@ -47,9 +47,9 @@ export interface FollowedArtist {
  *  {
  *    action: "unfollowedArtist",
  *    context_module: "featuredArtists"
- *    context_page_owner_type: "artistSeries"
- *    context_page_owner_id: "5359794d1a1e86c3740001f7"
- *    context_page_owner_slug: "alex-katz-departure"
+ *    context_owner_type: "artistSeries"
+ *    context_owner_id: "5359794d1a1e86c3740001f7"
+ *    context_owner_slug: "alex-katz-departure"
  *    owner_type: "artist"
  *    owner_id: "5359794d1a1e86c3740001f7"
  *    owner_slug: "alex-katz"
@@ -59,9 +59,9 @@ export interface FollowedArtist {
 export interface UnfollowedArtist {
   action: ActionType.unfollowedArtist
   context_module: ContextModule
-  context_page_owner_type: PageOwnerType
-  context_page_owner_id?: string
-  context_page_owner_slug?: string
+  context_owner_type: PageOwnerType
+  context_owner_id?: string
+  context_owner_slug?: string
   owner_type: OwnerType.artist
   owner_id: string
   owner_slug: string

--- a/src/Schema/Events/SavesAndFollows.ts
+++ b/src/Schema/Events/SavesAndFollows.ts
@@ -1,9 +1,9 @@
 import { ActionType } from "."
 import { ContextModule } from "../Values/ContextModule"
-import { OwnerType, PageOwnerType } from "../Values/OwnerType"
+import { OwnerType } from "../Values/OwnerType"
 
 /**
- * Schemas describing save and follow events
+ * Schemas describing save and follow events for all systems
  * @packageDocumentation
  */
 
@@ -29,7 +29,7 @@ import { OwnerType, PageOwnerType } from "../Values/OwnerType"
 export interface FollowedArtist {
   action: ActionType.followedArtist
   context_module: ContextModule
-  context_owner_type: PageOwnerType
+  context_owner_type: OwnerType
   context_owner_id?: string
   context_owner_slug?: string
   owner_type: OwnerType.artist
@@ -59,7 +59,7 @@ export interface FollowedArtist {
 export interface UnfollowedArtist {
   action: ActionType.unfollowedArtist
   context_module: ContextModule
-  context_owner_type: PageOwnerType
+  context_owner_type: OwnerType
   context_owner_id?: string
   context_owner_slug?: string
   owner_type: OwnerType.artist

--- a/src/Schema/Events/SavesAndFollows.ts
+++ b/src/Schema/Events/SavesAndFollows.ts
@@ -1,6 +1,6 @@
 import { ActionType } from "."
 import { ContextModule } from "../Values/ContextModule"
-import { ScreenOwnerType } from "../Values/OwnerType"
+import { OwnerType, PageOwnerType } from "../Values/OwnerType"
 
 /**
  * Schemas describing save and follow events
@@ -8,7 +8,7 @@ import { ScreenOwnerType } from "../Values/OwnerType"
  */
 
 /**
- * A user has followed an artist on iOS.
+ * A user has followed an artist.
  *
  * This schema describes events sent to Segment from [[followedArtist]]
  *
@@ -17,9 +17,9 @@ import { ScreenOwnerType } from "../Values/OwnerType"
  *  {
  *    action: "followedArtist",
  *    context_module: "featuredArtists"
- *    context_screen_owner_type: "artistSeries"
- *    context_screen_owner_id: "5359794d1a1e86c3740001f7"
- *    context_screen_owner_slug: "alex-katz-departure"
+ *    context_page_owner_type: "artistSeries"
+ *    context_page_owner_id: "5359794d1a1e86c3740001f7"
+ *    context_page_owner_slug: "alex-katz-departure"
  *    owner_type: "artist"
  *    owner_id: "5359794d1a1e86c3740001f7"
  *    owner_slug: "alex-katz"
@@ -29,16 +29,16 @@ import { ScreenOwnerType } from "../Values/OwnerType"
 export interface FollowedArtist {
   action: ActionType.followedArtist
   context_module: ContextModule
-  context_screen_owner_type: ScreenOwnerType
-  context_screen_owner_id?: string
-  context_screen_owner_slug?: string
-  owner_type: ScreenOwnerType
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  context_page_owner_slug?: string
+  owner_type: OwnerType.artist
   owner_id: string
   owner_slug: string
 }
 
 /**
- * A user has unfollowed an artist on iOS.
+ * A user has unfollowed an artist.
  *
  * This schema describes events sent to Segment from [[unfollowedArtist]]
  *
@@ -47,9 +47,9 @@ export interface FollowedArtist {
  *  {
  *    action: "unfollowedArtist",
  *    context_module: "featuredArtists"
- *    context_screen_owner_type: "artistSeries"
- *    context_screen_owner_id: "5359794d1a1e86c3740001f7"
- *    context_screen_owner_slug: "alex-katz-departure"
+ *    context_page_owner_type: "artistSeries"
+ *    context_page_owner_id: "5359794d1a1e86c3740001f7"
+ *    context_page_owner_slug: "alex-katz-departure"
  *    owner_type: "artist"
  *    owner_id: "5359794d1a1e86c3740001f7"
  *    owner_slug: "alex-katz"
@@ -59,10 +59,10 @@ export interface FollowedArtist {
 export interface UnfollowedArtist {
   action: ActionType.unfollowedArtist
   context_module: ContextModule
-  context_screen_owner_type: ScreenOwnerType
-  context_screen_owner_id?: string
-  context_screen_owner_slug?: string
-  owner_type: ScreenOwnerType
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  context_page_owner_slug?: string
+  owner_type: OwnerType.artist
   owner_id: string
   owner_slug: string
 }

--- a/src/Schema/Events/SavesAndFollows.ts
+++ b/src/Schema/Events/SavesAndFollows.ts
@@ -16,7 +16,7 @@ import { ScreenOwnerType } from "../Values/OwnerType"
  *  ```
  *  {
  *    action: "followedArtist",
- *    context_module: "FeaturedArtists"
+ *    context_module: "featuredArtists"
  *    context_screen_owner_type: "artistSeries"
  *    context_screen_owner_id: "5359794d1a1e86c3740001f7"
  *    context_screen_owner_slug: "alex-katz-departure"
@@ -28,6 +28,36 @@ import { ScreenOwnerType } from "../Values/OwnerType"
  */
 export interface FollowedArtist {
   action: ActionType.followedArtist
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id?: string
+  context_screen_owner_slug?: string
+  owner_type: ScreenOwnerType
+  owner_id: string
+  owner_slug: string
+}
+
+/**
+ * A user has unfollowed an artist on iOS.
+ *
+ * This schema describes events sent to Segment from [[unfollowedArtist]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "unfollowedArtist",
+ *    context_module: "featuredArtists"
+ *    context_screen_owner_type: "artistSeries"
+ *    context_screen_owner_id: "5359794d1a1e86c3740001f7"
+ *    context_screen_owner_slug: "alex-katz-departure"
+ *    owner_type: "artist"
+ *    owner_id: "5359794d1a1e86c3740001f7"
+ *    owner_slug: "alex-katz"
+ *  }
+ * ```
+ */
+export interface UnfollowedArtist {
+  action: ActionType.unfollowedArtist
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id?: string

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -56,6 +56,7 @@ export interface TappedArtistGroup extends TappedEntityGroup {
  *    destination_screen_owner_type: "artistSeries",
  *    destination_screen_owner_id: "5359794d1a1e86c3740001f7",
  *    destination_screen_owner_slug: "alex-katz-black-dress",
+ *    featured: true,
  *    horizontal_slide_position: 1,
  *    type: "thumbnail"
  *  }
@@ -79,7 +80,6 @@ export interface TappedArtistSeriesGroup extends TappedEntityGroup {
  *    destination_screen_owner_type: "artwork",
  *    destination_screen_owner_id: "5e9a7a238483bf000e2c4c5e",
  *    destination_screen_owner_slug: "romain-jacquet-lagreze-makeshift-garden-hong-kong",
- *    featured: true,
  *    horizontal_slide_position: 1,
  *    module_height: "single",
  *    type: "thumbnail"

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -79,6 +79,7 @@ export interface TappedArtistSeriesGroup extends TappedEntityGroup {
  *    destination_screen_owner_type: "artwork",
  *    destination_screen_owner_id: "5e9a7a238483bf000e2c4c5e",
  *    destination_screen_owner_slug: "romain-jacquet-lagreze-makeshift-garden-hong-kong",
+ *    featured: true,
  *    horizontal_slide_position: 1,
  *    module_height: "single",
  *    type: "thumbnail"
@@ -203,6 +204,7 @@ export interface TappedEntityGroup {
   destination_screen_owner_type: ScreenOwnerType
   destination_screen_owner_id?: string
   destination_screen_owner_slug?: string
+  featured?: boolean
   horizontal_slide_position?: number
   module_height?: EntityModuleHeight
   type: EntityModuleType

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -1,7 +1,7 @@
 import { ActionType } from "."
 import { ContextModule } from "../Values/ContextModule"
 import { EntityModuleType } from "../Values/EntityModuleType"
-import { ScreenOwnerType } from "../Values/OwnerType"
+import { OwnerType, ScreenOwnerType } from "../Values/OwnerType"
 import { Tab } from "../Values/Tab"
 
 /**
@@ -41,7 +41,7 @@ export interface TappedArtistGroup extends TappedEntityGroup {
 }
 
 /**
- * A user taps a grouping of artist series on iOS
+ * A user taps a grouping of artist series on iOS. If the artist series was boosted by the curation team, then curation_boost will be set to true.
  *
  *  This schema describes events sent to Segment from [[tappedEntityGroup]]
  *
@@ -56,7 +56,7 @@ export interface TappedArtistGroup extends TappedEntityGroup {
  *    destination_screen_owner_type: "artistSeries",
  *    destination_screen_owner_id: "5359794d1a1e86c3740001f7",
  *    destination_screen_owner_slug: "alex-katz-black-dress",
- *    featured: true,
+ *    curation_boost: true,
  *    horizontal_slide_position: 1,
  *    type: "thumbnail"
  *  }
@@ -64,6 +64,7 @@ export interface TappedArtistGroup extends TappedEntityGroup {
  */
 export interface TappedArtistSeriesGroup extends TappedEntityGroup {
   action: ActionType.tappedArtistSeriesGroup
+  destination_screen_owner_type: OwnerType.artistSeries
 }
 
 /**
@@ -204,7 +205,7 @@ export interface TappedEntityGroup {
   destination_screen_owner_type: ScreenOwnerType
   destination_screen_owner_id?: string
   destination_screen_owner_slug?: string
-  featured?: boolean
+  curation_boost?: boolean
   horizontal_slide_position?: number
   module_height?: EntityModuleHeight
   type: EntityModuleType

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -41,6 +41,31 @@ export interface TappedArtistGroup extends TappedEntityGroup {
 }
 
 /**
+ * A user taps a grouping of artist series on iOS
+ *
+ *  This schema describes events sent to Segment from [[tappedEntityGroup]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedArtistSeriesGroup",
+ *    context_module: "moreSeriesByThisArtist",
+ *    context_screen_owner_type: "artistSeries",
+ *    context_screen_owner_id: "5359794d1a1e86c3740001f7",
+ *    context_screen_owner_slug: "alex-katz-departure",
+ *    destination_screen_owner_type: "artistSeries",
+ *    destination_screen_owner_id: "5359794d1a1e86c3740001f7",
+ *    destination_screen_owner_slug: "alex-katz-black-dress",
+ *    horizontal_slide_position: 1,
+ *    type: "thumbnail"
+ *  }
+ * ```
+ */
+export interface TappedArtistSeriesGroup extends TappedEntityGroup {
+  action: ActionType.tappedArtistSeriesGroup
+}
+
+/**
  * A user taps a grouping of artworks on iOS
  *
  * This schema describes events sent to Segment from [[tappedEntityGroup]]
@@ -164,6 +189,7 @@ export interface TappedFairGroup extends TappedEntityGroup {
 export interface TappedEntityGroup {
   action:
     | ActionType.tappedArtistGroup
+    | ActionType.tappedArtistSeriesGroup
     | ActionType.tappedArtworkGroup
     | ActionType.tappedAuctionGroup
     | ActionType.tappedCollectionGroup

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -82,6 +82,10 @@ export enum ActionType {
    */
   clickedArtistGroup = "clickedArtistGroup",
   /**
+   * Corresponds to {@link ClickedArtistSeriesGroup}
+   */
+  clickedArtistSeriesGroup = "clickedArtistSeriesGroup",
+  /**
    * Corresponds to {@link ClickedArtworkGroup}
    */
   clickedArtworkGroup = "clickedArtworkGroup",

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -6,6 +6,7 @@ import {
 } from "./Authentication"
 import {
   ClickedArtistGroup,
+  ClickedArtistSeriesGroup,
   ClickedArtworkGroup,
   ClickedAuctionGroup,
   ClickedCollectionGroup,
@@ -42,6 +43,7 @@ export type Event =
   | AuthImpression
   | CreatedAccount
   | ClickedArtistGroup
+  | ClickedArtistSeriesGroup
   | ClickedArtworkGroup
   | ClickedAuctionGroup
   | ClickedCollectionGroup

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -31,7 +31,7 @@ import {
   TappedViewingRoomGroup,
 } from "./Tap"
 import { TimeOnPage } from "./System"
-import { FollowedArtist } from "./SavesAndFollows"
+import { FollowedArtist, UnfollowedArtist } from "./SavesAndFollows"
 
 /**
  * Master list of valid schemas for analytics actions
@@ -65,6 +65,7 @@ export type Event =
   | TappedTabBar
   | TappedViewingRoomGroup
   | TimeOnPage
+  | UnfollowedArtist
 
 /**
  * The top-level actions an Event describes.
@@ -176,4 +177,8 @@ export enum ActionType {
    * Corresponds to {@link TimeOnPage}
    */
   timeOnPage = "timeOnPage",
+  /**
+   * Corresponds to {@link UnfollowedArtist}
+   */
+  unfollowedArtist = "unfollowedArtist",
 }

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -18,6 +18,7 @@ import {
 } from "./Conversations"
 import {
   TappedArtistGroup,
+  TappedArtistSeriesGroup,
   TappedArtworkGroup,
   TappedAuctionGroup,
   TappedCollectionGroup,
@@ -50,6 +51,7 @@ export type Event =
   | SentConversationMessage
   | SuccessfullyLoggedIn
   | TappedArtistGroup
+  | TappedArtistSeriesGroup
   | TappedArtworkGroup
   | TappedAuctionGroup
   | TappedCollectionGroup
@@ -120,6 +122,10 @@ export enum ActionType {
    * Corresponds to {@link TappedArtistGroup}
    */
   tappedArtistGroup = "tappedArtistGroup",
+  /**
+   * Corresponds to {@link TappedArtistSeriesGroup}
+   */
+  tappedArtistSeriesGroup = "tappedArtistSeriesGroup",
   /**
    * Corresponds to {@link TappedArtworkGroup}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -31,6 +31,7 @@ import {
   TappedViewingRoomGroup,
 } from "./Tap"
 import { TimeOnPage } from "./System"
+import { FollowedArtist } from "./SavesAndFollows"
 
 /**
  * Master list of valid schemas for analytics actions
@@ -47,6 +48,7 @@ export type Event =
   | ClickedFairGroup
   | ClickedMainArtworkGrid
   | FocusedOnConversationMessageInput
+  | FollowedArtist
   | ResetYourPassword
   | SentConversationMessage
   | SuccessfullyLoggedIn
@@ -106,6 +108,10 @@ export enum ActionType {
    * Corresponds to {@link FocusedOnConversationMessageInput}
    */
   focusedOnConversationMessageInput = "focusedOnConversationMessageInput",
+  /**
+   * Corresponds to {@link FollowedArtist}
+   */
+  followedArtist = "followedArtist",
   /**
    * Corresponds to {@link ResetYourPassword}
    */

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -45,6 +45,7 @@ export enum ContextModule {
   liveAuctionsRail = "liveAuctionsRail",
   mainCarousel = "mainCarousel",
   minimalCTABanner = "minimalCTABanner",
+  moreSeriesByThisArtist = "moreSeriesByThisArtist",
   newWorksByArtistsYouFollowRail = "newWorksByArtistsYouFollowRail",
   newWorksByGalleriesYouFollowRail = "newWorksByGalleriesYouFollowRail",
   otherWorksByArtistRail = "otherWorksByArtistRail",

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -45,6 +45,7 @@ export enum ContextModule {
   liveAuctionsRail = "liveAuctionsRail",
   mainCarousel = "mainCarousel",
   minimalCTABanner = "minimalCTABanner",
+  moreFromThisSeries = "moreFromThisSeries",
   moreSeriesByThisArtist = "moreSeriesByThisArtist",
   newWorksByArtistsYouFollowRail = "newWorksByArtistsYouFollowRail",
   newWorksByGalleriesYouFollowRail = "newWorksByGalleriesYouFollowRail",

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -10,6 +10,7 @@ export enum ContextModule {
   artistHeader = "artistHeader",
   artistHighDemandGrid = "artistHighDemandGrid",
   artistRecentlySold = "artistRecentlySold",
+  artistSeriesRail = "artistSeriesRail",
   artistsTab = "artistsTab",
   artistsToFollowRail = "artistsToFollowRail",
   artworkGrid = "artworkGrid",

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -34,6 +34,7 @@ export enum ContextModule {
   fairsHeader = "fairsHeader",
   fairRail = "fairRail",
   fairCard = "fairCard",
+  featuredArtists = "featuredArtists",
   featuredArtistsRail = "featuredArtistsRail",
   featuredCollection = "featuredCollection",
   featuredViewingRoomsRail = "featuredViewingRoomsRail",

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -70,6 +70,7 @@ export type ScreenOwnerType =
 export type PageOwnerType =
   | OwnerType.artist
   | OwnerType.artists
+  | OwnerType.artistSeries
   | OwnerType.artwork
   | OwnerType.auctions
   | OwnerType.collect

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -5,6 +5,7 @@
  */
 export enum OwnerType {
   artist = "artist",
+  artistSeries = "artistSeries",
   artists = "artists",
   artwork = "artwork",
   auctions = "auctions",
@@ -38,6 +39,7 @@ export enum OwnerType {
  */
 export type ScreenOwnerType =
   | OwnerType.artist
+  | OwnerType.artistSeries
   | OwnerType.artwork
   | OwnerType.auctions
   | OwnerType.gene


### PR DESCRIPTION
This adds three new events for iOS in cohesion: tappedArtistSeriesGroup, followedArtist, and unfollowedArtist. You can find the events I'd like to track for artist series in iOS [here](https://docs.google.com/spreadsheets/d/1_VDAmRJz2K87FXDq7oh_tQSgwBv4syuZjaaR3sfetcI/edit#gid=1858087022).

Note that adding followedArtist and unfollowedArtist to cohesion means we are moving follow events out of the `success` schema.
