### PR TITLE
Use auth context for follow

### DIFF
--- a/src/Helpers/SavesAndFollows/Follow.ts
+++ b/src/Helpers/SavesAndFollows/Follow.ts
@@ -1,13 +1,13 @@
 import {
   ActionType,
-  ContextModule,
+  AuthContextModule,
   FollowedArtist,
   OwnerType,
   UnfollowedArtist,
 } from "../../Schema"
 
 export interface FollowedArtistArgs {
-  contextModule: ContextModule
+  contextModule: AuthContextModule
   contextOwnerId?: string
   contextOwnerSlug?: string
   contextOwnerType: OwnerType

--- a/src/Schema/Events/SavesAndFollows.ts
+++ b/src/Schema/Events/SavesAndFollows.ts
@@ -1,5 +1,5 @@
 import { ActionType } from "."
-import { ContextModule } from "../Values/ContextModule"
+import { AuthContextModule } from "../Values/ContextModule"
 import { OwnerType } from "../Values/OwnerType"
 
 /**
@@ -28,7 +28,7 @@ import { OwnerType } from "../Values/OwnerType"
  */
 export interface FollowedArtist {
   action: ActionType.followedArtist
-  context_module: ContextModule
+  context_module: AuthContextModule
   context_owner_type: OwnerType
   context_owner_id?: string
   context_owner_slug?: string

--- a/src/Schema/Events/SavesAndFollows.ts
+++ b/src/Schema/Events/SavesAndFollows.ts
@@ -58,7 +58,7 @@ export interface FollowedArtist {
  */
 export interface UnfollowedArtist {
   action: ActionType.unfollowedArtist
-  context_module: ContextModule
+  context_module: AuthContextModule
   context_owner_type: OwnerType
   context_owner_id?: string
   context_owner_slug?: string


### PR DESCRIPTION
Follow events require the same context as authentication, because it triggers an authentication modal for anonymous users. 
