### PR TITLE
FollowedGene / UnfollowedGene

### DIFF
--- a/src/Helpers/SavesAndFollows/Follow.ts
+++ b/src/Helpers/SavesAndFollows/Follow.ts
@@ -2,11 +2,13 @@ import {
   ActionType,
   AuthContextModule,
   FollowedArtist,
+  FollowedGene,
   OwnerType,
   UnfollowedArtist,
+  UnfollowedGene,
 } from "../../Schema"
 
-export interface FollowedArtistArgs {
+export interface FollowedArgs {
   contextModule: AuthContextModule
   contextOwnerId?: string
   contextOwnerSlug?: string
@@ -22,16 +24,16 @@ export interface FollowedArtistArgs {
  * ```
  * followedArtist({
  *   contextModule: ContextModule.artistSeriesRail
- *   contextOwnerType: OwnerType.artist,
  *   contextOwnerId: "5359794d2a1e86c3741001f8",
  *   contextOwnerSlug: "andy-warhol",
+ *   contextOwnerType: OwnerType.artist,
  *   ownerId: "5359794d1a1e86c3740001f7",
  *   ownerSlug: "sturtevant",
  * })
  * ```
  */
-export const followedArtist = (args: FollowedArtistArgs): FollowedArtist => {
-  return followArtist(args) as FollowedArtist
+export const followedArtist = (args: FollowedArgs): FollowedArtist => {
+  return follow(args, OwnerType.artist) as FollowedArtist
 }
 
 /**
@@ -41,21 +43,57 @@ export const followedArtist = (args: FollowedArtistArgs): FollowedArtist => {
  * ```
  * unfollowedArtist({
  *   contextModule: ContextModule.artistSeriesRail
- *   contextOwnerType: OwnerType.artist,
  *   contextOwnerId: "5359794d2a1e86c3741001f8",
  *   contextOwnerSlug: "andy-warhol",
+ *   contextOwnerType: OwnerType.artist,
  *   OwnerId: "5359794d1a1e86c3740001f7",
  *   OwnerSlug: "sturtevant",
  * })
  * ```
  */
-export const unfollowedArtist = (
-  args: FollowedArtistArgs,
-): UnfollowedArtist => {
-  return followArtist(args, true) as UnfollowedArtist
+export const unfollowedArtist = (args: FollowedArgs): UnfollowedArtist => {
+  return follow(args, OwnerType.artist, true) as UnfollowedArtist
 }
 
-const followArtist = (
+/**
+ *  A user follows a gene
+ *
+ * @example
+ * ```
+ * followedGene({
+ *   contextModule: ContextModule.intextTooltip,
+ *   contextOwnerId: "5359794d2a1e86c3741001f8",
+ *   contextOwnerSlug: "artsy-editorial-future-of-art",
+ *   contextOwnerType: OwnerType.article,
+ *   ownerId: "5359794d1a1e86c3740001f7",
+ *   ownerSlug: "surrealism",
+ * })
+ * ```
+ */
+export const followedGene = (args: FollowedArgs): FollowedGene => {
+  return follow(args, OwnerType.gene) as FollowedGene
+}
+
+/**
+ *  A user unfollows a gene
+ *
+ * @example
+ * ```
+ * unfollowedGene({
+ *   contextModule: ContextModule.intextTooltip,
+ *   contextOwnerId: "5359794d2a1e86c3741001f8",
+ *   contextOwnerSlug: "artsy-editorial-future-of-art",
+ *   contextOwnerType: OwnerType.article,
+ *   ownerId: "5359794d1a1e86c3740001f7",
+ *   ownerSlug: "surrealism",
+ * })
+ * ```
+ */
+export const unfollowedGene = (args: FollowedArgs): UnfollowedGene => {
+  return follow(args, OwnerType.gene, true) as UnfollowedGene
+}
+
+const follow = (
   {
     contextModule,
     contextOwnerId,
@@ -63,15 +101,24 @@ const followArtist = (
     contextOwnerType,
     ownerId,
     ownerSlug,
-  }: FollowedArtistArgs,
+  }: FollowedArgs,
+  ownerType: OwnerType.artist | OwnerType.gene,
   isUnfollow?: boolean,
-): UnfollowedArtist | FollowedArtist => {
+): UnfollowedArtist | FollowedArtist | FollowedGene | UnfollowedGene => {
   let action: ActionType
-  if (isUnfollow) {
-    action = ActionType.unfollowedArtist
-  } else {
-    action = ActionType.followedArtist
+
+  switch (ownerType) {
+    case OwnerType.artist: {
+      action = isUnfollow
+        ? ActionType.unfollowedArtist
+        : ActionType.followedArtist
+      break
+    }
+    case OwnerType.gene: {
+      action = isUnfollow ? ActionType.unfollowedGene : ActionType.followedGene
+    }
   }
+
   return {
     action,
     context_module: contextModule,
@@ -80,6 +127,6 @@ const followArtist = (
     context_owner_type: contextOwnerType,
     owner_id: ownerId,
     owner_slug: ownerSlug,
-    owner_type: OwnerType.artist,
+    owner_type: ownerType,
   }
 }

--- a/src/Helpers/SavesAndFollows/__tests__/Follow.test.ts
+++ b/src/Helpers/SavesAndFollows/__tests__/Follow.test.ts
@@ -1,8 +1,14 @@
 import { ContextModule, OwnerType } from "../../../Schema"
-import { FollowedArtistArgs, followedArtist, unfollowedArtist } from "../Follow"
+import {
+  FollowedArgs,
+  followedArtist,
+  followedGene,
+  unfollowedArtist,
+  unfollowedGene,
+} from "../Follow"
 
 describe("followedArtist", () => {
-  let args: FollowedArtistArgs
+  let args: FollowedArgs
   beforeEach(() => {
     args = {
       contextModule: ContextModule.popularArtistsRail,
@@ -48,7 +54,7 @@ describe("followedArtist", () => {
 })
 
 describe("unfollowedArtist", () => {
-  let args: FollowedArtistArgs
+  let args: FollowedArgs
   beforeEach(() => {
     args = {
       contextModule: ContextModule.popularArtistsRail,
@@ -89,6 +95,100 @@ describe("unfollowedArtist", () => {
       owner_id: "5359794d1a1e86c3740001f7",
       owner_slug: "andy-warhol",
       owner_type: "artist",
+    })
+  })
+})
+
+describe("followedGene", () => {
+  let args: FollowedArgs
+  beforeEach(() => {
+    args = {
+      contextModule: ContextModule.categoryRail,
+      contextOwnerType: OwnerType.home,
+      ownerId: "5359794d1a1e86c3740001f7",
+      ownerSlug: "surrealism",
+    }
+  })
+  it("Works with minimal args", () => {
+    const event = followedGene(args)
+
+    expect(event).toEqual({
+      action: "followedGene",
+      context_module: "categoryRail",
+      context_owner_id: undefined,
+      context_owner_slug: undefined,
+      context_owner_type: "home",
+      owner_id: "5359794d1a1e86c3740001f7",
+      owner_slug: "surrealism",
+      owner_type: "gene",
+    })
+  })
+
+  it("Works with all args", () => {
+    const event = followedGene({
+      ...args,
+      contextModule: ContextModule.intextTooltip,
+      contextOwnerId: "5359794d2a1e86c3741001f8",
+      contextOwnerSlug: "artsy-editorial-future-of-art",
+      contextOwnerType: OwnerType.article,
+    })
+
+    expect(event).toEqual({
+      action: "followedGene",
+      context_module: "intextTooltip",
+      context_owner_id: "5359794d2a1e86c3741001f8",
+      context_owner_slug: "artsy-editorial-future-of-art",
+      context_owner_type: "article",
+      owner_id: "5359794d1a1e86c3740001f7",
+      owner_slug: "surrealism",
+      owner_type: "gene",
+    })
+  })
+})
+
+describe("unfollowedGene", () => {
+  let args: FollowedArgs
+  beforeEach(() => {
+    args = {
+      contextModule: ContextModule.categoryRail,
+      contextOwnerType: OwnerType.home,
+      ownerId: "5359794d1a1e86c3740001f7",
+      ownerSlug: "surrealism",
+    }
+  })
+  it("Works with minimal args", () => {
+    const event = unfollowedGene(args)
+
+    expect(event).toEqual({
+      action: "unfollowedGene",
+      context_module: "categoryRail",
+      context_owner_id: undefined,
+      context_owner_slug: undefined,
+      context_owner_type: "home",
+      owner_id: "5359794d1a1e86c3740001f7",
+      owner_slug: "surrealism",
+      owner_type: "gene",
+    })
+  })
+
+  it("Works with all args", () => {
+    const event = unfollowedGene({
+      ...args,
+      contextModule: ContextModule.intextTooltip,
+      contextOwnerId: "5359794d2a1e86c3741001f8",
+      contextOwnerSlug: "artsy-editorial-future-of-art",
+      contextOwnerType: OwnerType.article,
+    })
+
+    expect(event).toEqual({
+      action: "unfollowedGene",
+      context_module: "intextTooltip",
+      context_owner_id: "5359794d2a1e86c3741001f8",
+      context_owner_slug: "artsy-editorial-future-of-art",
+      context_owner_type: "article",
+      owner_id: "5359794d1a1e86c3740001f7",
+      owner_slug: "surrealism",
+      owner_type: "gene",
     })
   })
 })

--- a/src/Schema/Events/SavesAndFollows.ts
+++ b/src/Schema/Events/SavesAndFollows.ts
@@ -7,6 +7,17 @@ import { OwnerType } from "../Values/OwnerType"
  * @packageDocumentation
  */
 
+export interface FollowedEntity {
+  // action: ActionType.followedArtist | ActionType.followedGene | ActionType.unfollowedArtist | ActionType.unfollowedGene
+  context_module: AuthContextModule
+  context_owner_type: OwnerType
+  context_owner_id?: string
+  context_owner_slug?: string
+  owner_type: OwnerType.artist | OwnerType.gene
+  owner_id: string
+  owner_slug: string
+}
+
 /**
  * A user has followed an artist.
  *
@@ -26,15 +37,31 @@ import { OwnerType } from "../Values/OwnerType"
  *  }
  * ```
  */
-export interface FollowedArtist {
+export interface FollowedArtist extends FollowedEntity {
   action: ActionType.followedArtist
-  context_module: AuthContextModule
-  context_owner_type: OwnerType
-  context_owner_id?: string
-  context_owner_slug?: string
-  owner_type: OwnerType.artist
-  owner_id: string
-  owner_slug: string
+}
+
+/**
+ * A user has followed a gene.
+ *
+ * This schema describes events sent to Segment from [[followedGene]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "followedGene",
+ *    context_module: "intextTooltip"
+ *    context_owner_type: "article"
+ *    context_owner_id: "5359794d1a1e86c3740001f7"
+ *    context_owner_slug: "artsy-editorial-future-of-art"
+ *    owner_type: "gene"
+ *    owner_id: "5359794d1a1e86c3740001f7"
+ *    owner_slug: "surrealism"
+ *  }
+ * ```
+ */
+export interface FollowedGene extends FollowedEntity {
+  action: ActionType.followedGene
 }
 
 /**
@@ -56,13 +83,29 @@ export interface FollowedArtist {
  *  }
  * ```
  */
-export interface UnfollowedArtist {
+export interface UnfollowedArtist extends FollowedEntity {
   action: ActionType.unfollowedArtist
-  context_module: AuthContextModule
-  context_owner_type: OwnerType
-  context_owner_id?: string
-  context_owner_slug?: string
-  owner_type: OwnerType.artist
-  owner_id: string
-  owner_slug: string
+}
+
+/**
+ * A user has unfollowed a gene.
+ *
+ * This schema describes events sent to Segment from [[unfollowedGene]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "unfollowedGene",
+ *    context_module: "intextTooltip"
+ *    context_owner_type: "article"
+ *    context_owner_id: "5359794d1a1e86c3740001f7"
+ *    context_owner_slug: "artsy-editorial-future-of-art"
+ *    owner_type: "gene"
+ *    owner_id: "5359794d1a1e86c3740001f7"
+ *    owner_slug: "surrealism"
+ *  }
+ * ```
+ */
+export interface UnfollowedGene extends FollowedEntity {
+  action: ActionType.unfollowedGene
 }

--- a/src/Schema/Events/SavesAndFollows.ts
+++ b/src/Schema/Events/SavesAndFollows.ts
@@ -8,14 +8,13 @@ import { OwnerType } from "../Values/OwnerType"
  */
 
 export interface FollowedEntity {
-  // action: ActionType.followedArtist | ActionType.followedGene | ActionType.unfollowedArtist | ActionType.unfollowedGene
   context_module: AuthContextModule
-  context_owner_type: OwnerType
   context_owner_id?: string
   context_owner_slug?: string
-  owner_type: OwnerType.artist | OwnerType.gene
+  context_owner_type: OwnerType
   owner_id: string
   owner_slug: string
+  owner_type: OwnerType.artist | OwnerType.gene
 }
 
 /**
@@ -28,12 +27,12 @@ export interface FollowedEntity {
  *  {
  *    action: "followedArtist",
  *    context_module: "featuredArtists"
- *    context_owner_type: "artistSeries"
  *    context_owner_id: "5359794d1a1e86c3740001f7"
  *    context_owner_slug: "alex-katz-departure"
- *    owner_type: "artist"
+ *    context_owner_type: "artistSeries"
  *    owner_id: "5359794d1a1e86c3740001f7"
  *    owner_slug: "alex-katz"
+ *    owner_type: "artist"
  *  }
  * ```
  */
@@ -51,12 +50,12 @@ export interface FollowedArtist extends FollowedEntity {
  *  {
  *    action: "followedGene",
  *    context_module: "intextTooltip"
- *    context_owner_type: "article"
  *    context_owner_id: "5359794d1a1e86c3740001f7"
  *    context_owner_slug: "artsy-editorial-future-of-art"
- *    owner_type: "gene"
+ *    context_owner_type: "article"
  *    owner_id: "5359794d1a1e86c3740001f7"
  *    owner_slug: "surrealism"
+ *    owner_type: "gene"
  *  }
  * ```
  */
@@ -74,12 +73,12 @@ export interface FollowedGene extends FollowedEntity {
  *  {
  *    action: "unfollowedArtist",
  *    context_module: "featuredArtists"
- *    context_owner_type: "artistSeries"
  *    context_owner_id: "5359794d1a1e86c3740001f7"
  *    context_owner_slug: "alex-katz-departure"
- *    owner_type: "artist"
+ *    context_owner_type: "artistSeries"
  *    owner_id: "5359794d1a1e86c3740001f7"
  *    owner_slug: "alex-katz"
+ *    owner_type: "artist"
  *  }
  * ```
  */
@@ -97,12 +96,12 @@ export interface UnfollowedArtist extends FollowedEntity {
  *  {
  *    action: "unfollowedGene",
  *    context_module: "intextTooltip"
- *    context_owner_type: "article"
  *    context_owner_id: "5359794d1a1e86c3740001f7"
  *    context_owner_slug: "artsy-editorial-future-of-art"
- *    owner_type: "gene"
+ *    context_owner_type: "article"
  *    owner_id: "5359794d1a1e86c3740001f7"
  *    owner_slug: "surrealism"
+ *    owner_type: "gene"
  *  }
  * ```
  */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -120,6 +120,10 @@ export enum ActionType {
    */
   followedArtist = "followedArtist",
   /**
+   * Corresponds to {@link FollowedGene}
+   */
+  followedGene = "followedGene",
+  /**
    * Corresponds to {@link ResetYourPassword}
    */
   resetYourPassword = "resetYourPassword",
@@ -187,4 +191,8 @@ export enum ActionType {
    * Corresponds to {@link UnfollowedArtist}
    */
   unfollowedArtist = "unfollowedArtist",
+  /**
+   * Corresponds to {@link UnfollowedArtist}
+   */
+  unfollowedGene = "unfollowedGene",
 }

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -18,6 +18,12 @@ import {
   SentConversationMessage,
 } from "./Conversations"
 import {
+  FollowedArtist,
+  FollowedGene,
+  UnfollowedArtist,
+  UnfollowedGene,
+} from "./SavesAndFollows"
+import {
   TappedArtistGroup,
   TappedArtistSeriesGroup,
   TappedArtworkGroup,
@@ -32,7 +38,6 @@ import {
   TappedViewingRoomGroup,
 } from "./Tap"
 import { TimeOnPage } from "./System"
-import { FollowedArtist, UnfollowedArtist } from "./SavesAndFollows"
 
 /**
  * Master list of valid schemas for analytics actions
@@ -51,6 +56,7 @@ export type Event =
   | ClickedMainArtworkGrid
   | FocusedOnConversationMessageInput
   | FollowedArtist
+  | FollowedGene
   | ResetYourPassword
   | SentConversationMessage
   | SuccessfullyLoggedIn
@@ -68,6 +74,7 @@ export type Event =
   | TappedViewingRoomGroup
   | TimeOnPage
   | UnfollowedArtist
+  | UnfollowedGene
 
 /**
  * The top-level actions an Event describes.


### PR DESCRIPTION
Ran into the need for a gene variant of the Follow/Unfollow action while attempting to convert article follow buttons to the new schema. 

- Adds `FollowedEntity` to schema, based on `FollowedArtist`
- Adds `FollowedGene` and `UnfollowedGene` to schema
- Adds helpers `followedGene` and `unfollowedGene`