### PR TITLE
bugfix: Prevent tests from appearing in docs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "inputFiles": ["./src"],
     "out": "doc",
     "mode": "module",
-    "exclude": ["src/**/index.ts", "src/**/__tests__/*.ts"],
+    "exclude": ["src/**/index.ts", "src/**/__tests__/**/*.ts"],
     "excludeNotExported": true,
     "excludeExternals": true,
     "readme": "README.md"


### PR DESCRIPTION
Updates `typedoc`'s `exclude` settings, which did not allow for subdirectories within `__tests__` directories, and was errantly  including test files in documentation. 

Fixes:
<img width="1792" alt="Screen Shot 2020-09-28 at 1 19 57 PM" src="https://user-images.githubusercontent.com/1497424/94465196-86e36c80-018d-11eb-9786-3e243de8e095.png">
