### PR TITLE
Shows Refresh Tracking

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -210,7 +210,7 @@ export interface ClickedEntityGroup {
 }
 
 /**
- * A user clicks a fair card on a show page
+ * A user clicks a fair card
  *
  * This schema describes events sent to Segment from [[ClickedFairCard]]
  *
@@ -304,7 +304,7 @@ export interface ClickedNavigationTab {
 }
 
 /**
- * A user clicks a partner card on a show page
+ * A user clicks a partner card
  *
  * This schema describes events sent to Segment from [[ClickedPartnerCard]]
  *
@@ -362,7 +362,7 @@ export interface ClickedShowMore {
 }
 
 /**
- * A user clicks a viewing room card on a show page
+ * A user clicks a viewing room card
  *
  * This schema describes events sent to Segment from [[ClickedViewingRoomCard]]
  *

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -210,6 +210,38 @@ export interface ClickedEntityGroup {
 }
 
 /**
+ * A user clicks a fair card on a show page
+ *
+ * This schema describes events sent to Segment from [[ClickedFairCard]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedFairCard",
+ *    context_module: "fairCard",
+ *    context_page_owner_type: "show",
+ *    context_page_owner_id: "5df7daac8225960007129b4f",
+ *    context_page_owner_slug: "mccormick-gallery-mccormick-gallery-at-palm-beach-modern-plus-contemporary-2020",
+ *    destination_page_owner_type: "fair",
+ *    destination_page_owner_id: "5df3e3fa485efe0012c37055",
+ *    destination_page_owner_slug: "palm-beach-modern-plus-contemporary-2020",
+ *    type: "thumbnail"
+ *  }
+ * ```
+ */
+export interface ClickedFairCard {
+  action: ActionType.clickedFairCard
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  context_page_owner_slug?: string
+  destination_page_owner_type: PageOwnerType
+  destination_page_owner_id: string
+  destination_page_owner_slug: string
+  type: "thumbnail"
+}
+
+/**
  * A user clicks on an artwork in the main artwork grid, which is the main product feed we can find on our core merchandising surfaces.
  * Currently, this event only fires on our new artwork grids on the following pages: Collect, Collection, Artist works-for-sale, and Search Results.
  * Note: This event is separate from [[clickedArtworkGroup]] because it is an important and frequent event. Separating it out will make it easier for analysts to access.
@@ -272,6 +304,38 @@ export interface ClickedNavigationTab {
 }
 
 /**
+ * A user clicks a partner card on a show page
+ *
+ * This schema describes events sent to Segment from [[ClickedPartnerCard]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedPartnerCard",
+ *    context_module: "partnerCard",
+ *    context_page_owner_type: "show",
+ *    context_page_owner_id: "5bb539507a931b299b243dd5",
+ *    context_page_owner_slug: "mccormick-gallery-vidvuds-zviedris-old-cities-and-ancient-walls",
+ *    destination_page_owner_type: "partner",
+ *    destination_page_owner_id: "4e2ed4c42ccd3c000100924f",
+ *    destination_page_owner_slug: "mccormick-gallery",
+ *    type: "thumbnail"
+ *  }
+ * ```
+ */
+export interface ClickedPartnerCard {
+  action: ActionType.clickedPartnerCard
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  context_page_owner_slug?: string
+  destination_page_owner_type: PageOwnerType
+  destination_page_owner_id: string
+  destination_page_owner_slug: string
+  type: "thumbnail"
+}
+
+/**
  * A user clicks a show more button on web.
  *
  * This schema describes events sent to Segment from [[clickedMainArtworkGrid]]
@@ -295,4 +359,36 @@ export interface ClickedShowMore {
   context_page_owner_id?: string
   context_page_owner_slug?: string
   subject: string
+}
+
+/**
+ * A user clicks a viewing room card on a show page
+ *
+ * This schema describes events sent to Segment from [[ClickedViewingRoomCard]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedViewingRoomCard",
+ *    context_module: "viewingRoomCard",
+ *    context_page_owner_type: "show",
+ *    context_page_owner_id: "541890237261692168870700",
+ *    context_page_owner_slug: "susan-eley-fine-art-susan-eley-fine-art-at-art-silicon-valley-slash-san-francisco",
+ *    destination_page_owner_type: "viewing-room",
+ *    destination_page_owner_id: "95f7dcfd-1996-45e1-9aab-979c38b2de59",
+ *    destination_page_owner_slug: "susan-eley-fine-art-counterbalance",
+ *    type: "thumbnail"
+ *  }
+ * ```
+ */
+export interface ClickedViewingRoomCard {
+  action: ActionType.clickedViewingRoomCard
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  context_page_owner_slug?: string
+  destination_page_owner_type: PageOwnerType
+  destination_page_owner_id: string
+  destination_page_owner_slug: string
+  type: "thumbnail"
 }

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -264,7 +264,7 @@ export interface TappedConsign {
 }
 
 /**
- * A user taps a fair card on a show screen
+ * A user taps a fair card
  *
  * This schema describes events sent to Segment from [[TappedFairCard]]
  *
@@ -454,7 +454,7 @@ export interface TappedNavigationTab {
 }
 
 /**
- * A user taps a partner card on a show screen
+ * A user taps a partner card
  *
  * This schema describes events sent to Segment from [[TappedPartnerCard]]
  *
@@ -486,7 +486,7 @@ export interface TappedPartnerCard {
 }
 
 /**
- * A user taps a viewing room card on a show screen
+ * A user taps a viewing room card
  *
  * This schema describes events sent to Segment from [[TappedViewingRoomCard]]
  *

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -264,6 +264,38 @@ export interface TappedConsign {
 }
 
 /**
+ * A user taps a fair card on a show screen
+ *
+ * This schema describes events sent to Segment from [[TappedFairCard]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedFairCard",
+ *    context_module: "fairCard",
+ *    context_screen_owner_type: "show",
+ *    context_screen_owner_id: "5df7daac8225960007129b4f",
+ *    context_screen_owner_slug: "mccormick-gallery-mccormick-gallery-at-palm-beach-modern-plus-contemporary-2020",
+ *    destination_screen_owner_type: "fair",
+ *    destination_screen_owner_id: "5df3e3fa485efe0012c37055",
+ *    destination_screen_owner_slug: "palm-beach-modern-plus-contemporary-2020",
+ *    type: "thumbnail"
+ *  }
+ * ```
+ */
+export interface TappedFairCard {
+  action: ActionType.tappedFairCard
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id?: string
+  context_screen_owner_slug?: string
+  destination_screen_owner_type: ScreenOwnerType
+  destination_screen_owner_id: string
+  destination_screen_owner_slug: string
+  type: "thumbnail"
+}
+
+/**
  * A user taps on an artwork in the main artwork grid, which is the main product feed we can find on our core merchandising surfaces.
  * Note: This event is separate from [[tappedArtworkGroup]] because it is an important and frequent event. Separating it out will make it easier for analysts to access.
  *
@@ -419,4 +451,68 @@ export interface TappedNavigationTab {
   context_screen_owner_id: string
   context_screen_owner_slug: string
   subject: "string"
+}
+
+/**
+ * A user taps a partner card on a show screen
+ *
+ * This schema describes events sent to Segment from [[TappedPartnerCard]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedPartnerCard",
+ *    context_module: "partnerCard",
+ *    context_screen_owner_type: "show",
+ *    context_screen_owner_id: "5bb539507a931b299b243dd5",
+ *    context_screen_owner_slug: "mccormick-gallery-vidvuds-zviedris-old-cities-and-ancient-walls",
+ *    destination_screen_owner_type: "partner",
+ *    destination_screen_owner_id: "4e2ed4c42ccd3c000100924f",
+ *    destination_screen_owner_slug: "mccormick-gallery",
+ *    type: "thumbnail"
+ *  }
+ * ```
+ */
+export interface TappedPartnerCard {
+  action: ActionType.tappedPartnerCard
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id?: string
+  context_screen_owner_slug?: string
+  destination_screen_owner_type: ScreenOwnerType
+  destination_screen_owner_id: string
+  destination_screen_owner_slug: string
+  type: "thumbnail"
+}
+
+/**
+ * A user taps a viewing room card on a show screen
+ *
+ * This schema describes events sent to Segment from [[TappedViewingRoomCard]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedViewingRoomCard",
+ *    context_module: "viewingRoomCard",
+ *    context_screen_owner_type: "show",
+ *    context_screen_owner_id: "541890237261692168870700",
+ *    context_screen_owner_slug: "susan-eley-fine-art-susan-eley-fine-art-at-art-silicon-valley-slash-san-francisco",
+ *    destination_screen_owner_type: "viewing-room",
+ *    destination_screen_owner_id: "95f7dcfd-1996-45e1-9aab-979c38b2de59",
+ *    destination_screen_owner_slug: "susan-eley-fine-art-counterbalance",
+ *    type: "thumbnail"
+ *  }
+ * ```
+ */
+export interface TappedViewingRoomCard {
+  action: ActionType.tappedViewingRoomCard
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id?: string
+  context_screen_owner_slug?: string
+  destination_screen_owner_type: ScreenOwnerType
+  destination_screen_owner_id: string
+  destination_screen_owner_slug: string
+  type: "thumbnail"
 }

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -11,10 +11,13 @@ import {
   ClickedArtworkGroup,
   ClickedAuctionGroup,
   ClickedCollectionGroup,
+  ClickedFairCard,
   ClickedFairGroup,
   ClickedMainArtworkGrid,
   ClickedNavigationTab,
+  ClickedPartnerCard,
   ClickedShowMore,
+  ClickedViewingRoomCard,
 } from "./Click"
 import {
   FocusedOnConversationMessageInput,
@@ -29,12 +32,15 @@ import {
   TappedCollectionGroup,
   TappedConsign,
   TappedExploreGroup,
+  TappedFairCard,
   TappedFairGroup,
   TappedMainArtworkGrid,
   TappedNavigationTab,
+  TappedPartnerCard,
   TappedPromoSpace,
   TappedShowMore,
   TappedTabBar,
+  TappedViewingRoomCard,
   TappedViewingRoomGroup,
 } from "./Tap"
 import { FollowEvents } from "./SavesAndFollows"
@@ -54,10 +60,13 @@ export type Event =
   | ClickedArtworkGroup
   | ClickedAuctionGroup
   | ClickedCollectionGroup
+  | ClickedFairCard
   | ClickedFairGroup
   | ClickedMainArtworkGrid
   | ClickedNavigationTab
+  | ClickedPartnerCard
   | ClickedShowMore
+  | ClickedViewingRoomCard
   | FocusedOnConversationMessageInput
   | FollowEvents
   | ResetYourPassword
@@ -70,13 +79,16 @@ export type Event =
   | TappedAuctionGroup
   | TappedCollectionGroup
   | TappedExploreGroup
+  | TappedFairCard
   | TappedFairGroup
   | TappedConsign
   | TappedNavigationTab
   | TappedMainArtworkGrid
+  | TappedPartnerCard
   | TappedPromoSpace
   | TappedShowMore
   | TappedTabBar
+  | TappedViewingRoomCard
   | TappedViewingRoomGroup
   | TimeOnPage
 
@@ -115,6 +127,10 @@ export enum ActionType {
    */
   clickedCollectionGroup = "clickedCollectionGroup",
   /**
+   * Corresponds to {@link ClickedFairCard}
+   */
+  clickedFairCard = "clickedFairCard",
+  /**
    * Corresponds to {@link ClickedFairGroup}
    */
   clickedFairGroup = "clickedFairGroup",
@@ -127,9 +143,17 @@ export enum ActionType {
    */
   clickedNavigationTab = "clickedNavigationTab",
   /**
+   * Corresponds to {@link ClickedPartnerCard}
+   */
+  clickedPartnerCard = "clickedPartnerCard",
+  /**
    * Corresponds to {@link ClickedShowMore}
    */
   clickedShowMore = "clickedShowMore",
+  /**
+   * Corresponds to {@link ClickedViewingRoomCard}
+   */
+  clickedViewingRoomCard = "clickedViewingRoomCard",
   /**
    * Corresponds to {@link CreatedAccount}
    */
@@ -203,9 +227,17 @@ export enum ActionType {
    */
   tappedConsign = "tappedConsign",
   /**
+   * Corresponds to {@link TappedFairCard}
+   */
+  tappedFairCard = "tappedFairCard",
+  /**
    * Corresponds to {@link TappedMainArtworkGrid}
    */
   tappedMainArtworkGrid = "tappedMainArtworkGrid",
+  /**
+   * Corresponds to {@link TappedPartnerCard}
+   */
+  tappedPartnerCard = "tappedPartnerCard",
   /**
    * Corresponds to {@link TappedPromoSpace}
    */
@@ -214,6 +246,10 @@ export enum ActionType {
    * Corresponds to {@link TappedTabBar}
    */
   tappedTabBar = "tappedTabBar",
+  /**
+   * Corresponds to {@link TappedViewingRoomCard}
+   */
+  tappedViewingRoomCard = "tappedViewingRoomCard",
   /**
    * Corresponds to {@link TappedViewingRoomGroup}
    */

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -62,6 +62,7 @@ export enum ContextModule {
   otherWorksFromPartnerRail = "otherWorksFromPartnerRail",
   otherWorksFromShowRail = "otherWorksFromShowRail",
   otherWorksInAuctionRail = "otherWorksInAuctionRail",
+  partnerCard = "partnerCard",
   partnerHeader = "partnerHeader",
   pastFairs = "pastFairs",
   popularArtistsRail = "popularArtistsRail",
@@ -87,6 +88,7 @@ export enum ContextModule {
   topWorksRail = "topWorksRail",
   trendingArtistsRail = "trendingArtistsRail",
   viewingRoom = "viewingRoom",
+  viewingRoomCard = "viewingRoomCard",
   worksByPopularArtistsRail = "worksByPopularArtistsRail",
   worksByArtistsYouFollowRail = "worksByArtistsYouFollowRail",
   worksForSaleRail = "worksForSaleRail",
@@ -131,6 +133,7 @@ export type AuthContextModule =
   | ContextModule.otherWorksFromPartnerRail
   | ContextModule.otherWorksFromShowRail
   | ContextModule.otherWorksInAuctionRail
+  | ContextModule.partnerCard
   | ContextModule.partnerHeader
   | ContextModule.pastFairs
   | ContextModule.popularArtistsRail
@@ -148,3 +151,4 @@ export type AuthContextModule =
   | ContextModule.worksByArtistsYouFollowRail
   | ContextModule.worksForSaleRail
   | ContextModule.viewingRoom
+  | ContextModule.viewingRoomCard

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -19,6 +19,7 @@ export enum ContextModule {
   artworkRecentlySoldGrid = "artworkRecentlySoldGrid",
   artworkSidebar = "artworkSidebar",
   artworksTab = "artworksTab",
+  associatedViewingRoom = "associatedViewingRoom",
   auctionSidebar = "auctionSidebar",
   auctionCard = "auctionCard",
   auctionRail = "auctionRail",
@@ -62,11 +63,12 @@ export enum ContextModule {
   otherWorksFromPartnerRail = "otherWorksFromPartnerRail",
   otherWorksFromShowRail = "otherWorksFromShowRail",
   otherWorksInAuctionRail = "otherWorksInAuctionRail",
-  partnerCard = "partnerCard",
   partnerHeader = "partnerHeader",
   pastFairs = "pastFairs",
   popularArtistsRail = "popularArtistsRail",
   popUpModal = "popUpModal",
+  presentingFair = "presentingFair",
+  presentingPartner = "presentingPartner",
   promoSpace = "promoSpace",
   recentlySavedRail = "recentlySavedRail",
   recentlyViewedRail = "recentlyViewedRail",
@@ -88,7 +90,6 @@ export enum ContextModule {
   topWorksRail = "topWorksRail",
   trendingArtistsRail = "trendingArtistsRail",
   viewingRoom = "viewingRoom",
-  viewingRoomCard = "viewingRoomCard",
   worksByPopularArtistsRail = "worksByPopularArtistsRail",
   worksByArtistsYouFollowRail = "worksByArtistsYouFollowRail",
   worksForSaleRail = "worksForSaleRail",
@@ -107,6 +108,7 @@ export type AuthContextModule =
   | ContextModule.artworkGrid
   | ContextModule.artworkImage
   | ContextModule.artworkSidebar
+  | ContextModule.associatedViewingRoom
   | ContextModule.auctionSidebar
   | ContextModule.auctionRail
   | ContextModule.auctionResults
@@ -133,11 +135,12 @@ export type AuthContextModule =
   | ContextModule.otherWorksFromPartnerRail
   | ContextModule.otherWorksFromShowRail
   | ContextModule.otherWorksInAuctionRail
-  | ContextModule.partnerCard
   | ContextModule.partnerHeader
   | ContextModule.pastFairs
   | ContextModule.popularArtistsRail
   | ContextModule.popUpModal
+  | ContextModule.presentingFair
+  | ContextModule.presentingPartner
   | ContextModule.recentlyViewedRail
   | ContextModule.recommendedArtistsRail
   | ContextModule.relatedArtistsRail
@@ -151,4 +154,3 @@ export type AuthContextModule =
   | ContextModule.worksByArtistsYouFollowRail
   | ContextModule.worksForSaleRail
   | ContextModule.viewingRoom
-  | ContextModule.viewingRoomCard


### PR DESCRIPTION
# What
Adding tracking for the shows refresh on Web and iOS.
Tracking spreadsheet: [link](https://docs.google.com/spreadsheets/d/1_VDAmRJz2K87FXDq7oh_tQSgwBv4syuZjaaR3sfetcI/edit?usp=sharing).

# Discussion:
- There are 3 events that are just clicks on either Viewing Room, Fair, Gallery card. I didn't create specific events for those - I left these as "tap" since it's just a tap on an isolated object. But happy to discuss.