### PR TITLE
Track sale_screen_load_complete

### DIFF
--- a/src/Schema/Events/System.ts
+++ b/src/Schema/Events/System.ts
@@ -1,6 +1,5 @@
 import { ActionType } from "."
-import { PageOwnerType } from "../Values/OwnerType"
-import { ScreenOwnerType } from "../Values/OwnerType"
+import { PageOwnerType, ScreenOwnerType } from "../Values/OwnerType"
 
 /**
  * Schemas describing system events

--- a/src/Schema/Events/System.ts
+++ b/src/Schema/Events/System.ts
@@ -27,3 +27,31 @@ export interface TimeOnPage {
   context_page_owner_id?: string
   context_page_owner_slug?: string
 }
+
+/**
+ * A user loads a sale screen on the iOS app.
+ *
+ * This schema describes events sent to Segment from [[saleScreenLoadComplete]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "saleScreenLoadComplete",
+ *    context_page_owner_type: "auction",
+ *    context_page_owner_id: "5f841d4044f91e000fd0acc4",
+ *    context_page_owner_slug: "finarte-modern-and-contemporary-art-8",
+ *    jump_to_lai_interface: true,
+ *    load_time_ms: 2000,
+ *    number_of_lots: 276
+ *  }
+ * ```
+ */
+export interface SaleScreenLoadComplete {
+  action: ActionType.saleScreenLoadComplete
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  context_page_owner_slug?: string
+  jump_to_lai_interface: boolean
+  load_time_ms: number
+  number_of_lots: number
+}

--- a/src/Schema/Events/System.ts
+++ b/src/Schema/Events/System.ts
@@ -1,5 +1,6 @@
 import { ActionType } from "."
 import { PageOwnerType } from "../Values/OwnerType"
+import { ScreenOwnerType } from "../Values/OwnerType"
 
 /**
  * Schemas describing system events
@@ -37,9 +38,9 @@ export interface TimeOnPage {
  *  ```
  *  {
  *    action: "saleScreenLoadComplete",
- *    context_page_owner_type: "auction",
- *    context_page_owner_id: "5f841d4044f91e000fd0acc4",
- *    context_page_owner_slug: "finarte-modern-and-contemporary-art-8",
+ *    context_screen_owner_type: "auction",
+ *    context_screen_owner_id: "5f841d4044f91e000fd0acc4",
+ *    context_screen_owner_slug: "finarte-modern-and-contemporary-art-8",
  *    jump_to_lai_interface: true,
  *    load_time_ms: 2000,
  *    number_of_lots: 276
@@ -48,9 +49,9 @@ export interface TimeOnPage {
  */
 export interface SaleScreenLoadComplete {
   action: ActionType.saleScreenLoadComplete
-  context_page_owner_type: PageOwnerType
-  context_page_owner_id?: string
-  context_page_owner_slug?: string
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id?: string
+  context_screen_owner_slug?: string
   jump_to_lai_interface: boolean
   load_time_ms: number
   number_of_lots: number

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -44,7 +44,7 @@ import {
   TappedViewingRoomGroup,
 } from "./Tap"
 import { FollowEvents } from "./SavesAndFollows"
-import { TimeOnPage } from "./System"
+import { SaleScreenLoadComplete, TimeOnPage } from "./System"
 
 /**
  * Master list of valid schemas for analytics actions
@@ -70,6 +70,7 @@ export type Event =
   | FocusedOnConversationMessageInput
   | FollowEvents
   | ResetYourPassword
+  | SaleScreenLoadComplete
   | SentConversationMessage
   | SuccessfullyLoggedIn
   | TappedArticleGroup
@@ -182,6 +183,10 @@ export enum ActionType {
    * Corresponds to {@link ResetYourPassword}
    */
   resetYourPassword = "resetYourPassword",
+  /**
+   * Corresponds to {@link SaleScreenLoadComplete}
+   */
+  saleScreenLoadComplete = "saleScreenLoadComplete",
   /**
    * Corresponds to {@link SuccessfullyLoggedIn}
    */


### PR DESCRIPTION
[tagged @brainbicycle because we've worked on cohesion event implementation before, and we'll need to do tests/helpers]

- tracks an event for when the sale home screen loads on iOS