### PR TITLE
Add tapped_register_to_bid event

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -358,6 +358,30 @@ export interface TappedPromoSpace {
 }
 
 /**
+ * A user taps "Register to bid" on an iOS sale (auction) page
+ *
+ * This schema describes events sent to Segment from [[tappedRegisterToBid]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedRegisterToBid",
+ *    context_module: "auctionHome",
+ *    context_screen_owner_type: "sale",
+ *    context_screen_owner_id: "5f8085e733d847000e3af175",
+ *    context_screen_owner_slug: "forum-auctions-only-banksy-1"
+ *  }
+ * ```
+ */
+export interface TappedRegisterToBid {
+  action: ActionType.tappedRegisterToBid
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id: string
+  context_screen_owner_slug?: string
+}
+
+/**
  * A user taps an icon on the tab bar
  *
  * This schema describes events sent to Segment from [[tappedTabBar]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -248,6 +248,10 @@ export enum ActionType {
    */
   tappedPromoSpace = "tappedPromoSpace",
   /**
+   * Corresponds to {@link TappedRegisterToBid}
+   */
+  tappedRegisterToBid = "tappedRegisterToBid",
+  /**
    * Corresponds to {@link TappedTabBar}
    */
   tappedTabBar = "tappedTabBar",

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -22,6 +22,7 @@ export enum ContextModule {
   associatedViewingRoom = "associatedViewingRoom",
   auctionSidebar = "auctionSidebar",
   auctionCard = "auctionCard",
+  auctionHome = "auctionHome",
   auctionRail = "auctionRail",
   auctionResults = "auctionResults",
   auctionsInfo = "auctionsInfo",
@@ -111,6 +112,7 @@ export type AuthContextModule =
   | ContextModule.associatedViewingRoom
   | ContextModule.auctionSidebar
   | ContextModule.auctionRail
+  | ContextModule.auctionHome
   | ContextModule.auctionResults
   | ContextModule.auctionsInfo
   | ContextModule.bannerPopUp


### PR DESCRIPTION
Adding this event, which will be helpful to track on the new sale pages we're releasing on iOS. I believe until now we've been using an older schema. Everything else critical on the sale page should be captured within `TappedArtworkGroup` with contexts. 