### PR TITLE
Add new events and contexts for auction results on iOS

### DIFF
--- a/src/Schema/Events/FilterAndSort.ts
+++ b/src/Schema/Events/FilterAndSort.ts
@@ -37,7 +37,26 @@ export interface CommercialFilterParams {
 }
 
 /**
- * A user applies filters to a filterable/sortable module
+ * Master list of filter params available in web and iOS, specific to auction results
+ *
+ * Intended action by a user that triggered an event
+ * @packageDocumentation
+ */
+export interface AuctionResultsFilterParams {
+  allowEmptyCreatedDates?: boolean
+  categories?: string[]
+  createdAfterYear?: string
+  createdBeforeYear?: string
+  earliestCreatedYear?: string
+  latestCreatedYear?: string
+  organizations?: string[]
+  pageAndCursor?: string[]
+  sizes?: string[]
+  sort?: string
+}
+
+/**
+ * A user applies filters to a filterable/sortable artworks module
  *
  * This schema describes events sent to Segment from [[CommercialFilterParamsChanged]]
  *
@@ -62,4 +81,32 @@ export interface CommercialFilterParamsChanged {
   context_owner_slug?: string
   current: CommercialFilterParams
   changed: CommercialFilterParams
+}
+
+/**
+ * A user applies filters to a filterable/sortable auction results module
+ *
+ * This schema describes events sent to Segment from [[AuctionResultsFilterParamsChanged]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "auctionResultsFilterParamsChanged",
+ *    context_module: "auctionResults",
+ *    context_owner_type: "artist",
+ *    context_owner_id: "51aa03df8b3b8177260002ab",
+ *    context_owner_slug: "nicolas-party",
+ *    changed: {createdAfterYear: 2016},
+ *    current: {createdAfterYear: 2013}
+ *  }
+ * ```
+ */
+export interface AuctionResultsFilterParamsChanged {
+  action: ActionType.auctionResultsFilterParamsChanged
+  context_module: ContextModule.auctionResults
+  context_owner_type: OwnerType
+  context_owner_id?: string
+  context_owner_slug?: string
+  current: AuctionResultsFilterParams
+  changed: AuctionResultsFilterParams
 }

--- a/src/Schema/Events/FilterAndSort.ts
+++ b/src/Schema/Events/FilterAndSort.ts
@@ -56,7 +56,7 @@ export interface AuctionResultsFilterParams {
 }
 
 /**
- * A user applies filters to a filterable/sortable artworks module
+ * A user applies filters to a filterable/sortable artworks or auction results module
  *
  * This schema describes events sent to Segment from [[CommercialFilterParamsChanged]]
  *
@@ -75,38 +75,10 @@ export interface AuctionResultsFilterParams {
  */
 export interface CommercialFilterParamsChanged {
   action: ActionType.commercialFilterParamsChanged
-  context_module: ContextModule.artworkGrid
+  context_module: ContextModule.artworkGrid | ContextModule.auctionResults
   context_owner_type: OwnerType
   context_owner_id?: string
   context_owner_slug?: string
-  current: CommercialFilterParams
-  changed: CommercialFilterParams
-}
-
-/**
- * A user applies filters to a filterable/sortable auction results module
- *
- * This schema describes events sent to Segment from [[AuctionResultsFilterParamsChanged]]
- *
- *  @example
- *  ```
- *  {
- *    action: "auctionResultsFilterParamsChanged",
- *    context_module: "auctionResults",
- *    context_owner_type: "artist",
- *    context_owner_id: "51aa03df8b3b8177260002ab",
- *    context_owner_slug: "nicolas-party",
- *    changed: {createdAfterYear: 2016},
- *    current: {createdAfterYear: 2013}
- *  }
- * ```
- */
-export interface AuctionResultsFilterParamsChanged {
-  action: ActionType.auctionResultsFilterParamsChanged
-  context_module: ContextModule.auctionResults
-  context_owner_type: OwnerType
-  context_owner_id?: string
-  context_owner_slug?: string
-  current: AuctionResultsFilterParams
-  changed: AuctionResultsFilterParams
+  current: CommercialFilterParams | AuctionResultsFilterParams
+  changed: CommercialFilterParams | AuctionResultsFilterParams
 }

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -140,6 +140,29 @@ export interface TappedAuctionGroup extends TappedEntityGroup {
 }
 
 /**
+ * A user taps a grouping of auction results on iOS
+ *
+ * This schema describes events sent to Segment from [[tappedEntityGroup]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedAuctionResultGroup",
+ *    context_module: "auctionResults",
+ *    context_screen_owner_type: "artistInsights",
+ *    context_screen_owner_id: "51aa03df8b3b8177260002ab",
+ *    context_screen_owner_slug: "nicolas-party",
+ *    destination_screen_owner_type: "auctionResult",
+ *    destination_screen_owner_id: "6398282",
+ *    type: "thumbnail"
+ *  }
+ * ```
+ */
+export interface TappedAuctionResultGroup extends TappedEntityGroup {
+  action: ActionType.tappedAuctionResultGroup
+}
+
+/**
  * A user taps a grouping of collections on iOS
  *
  * This schema describes events sent to Segment from [[tappedEntityGroup]]
@@ -219,6 +242,7 @@ export interface TappedEntityGroup {
     | ActionType.tappedArtistSeriesGroup
     | ActionType.tappedArtworkGroup
     | ActionType.tappedAuctionGroup
+    | ActionType.tappedAuctionResultGroup
     | ActionType.tappedCollectionGroup
     | ActionType.tappedExploreGroup
     | ActionType.tappedFairGroup

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -26,7 +26,10 @@ import {
   FocusedOnConversationMessageInput,
   SentConversationMessage,
 } from "./Conversations"
-import { CommercialFilterParamsChanged } from "./FilterAndSort"
+import {
+  AuctionResultsFilterParamsChanged,
+  CommercialFilterParamsChanged,
+} from "./FilterAndSort"
 import { FollowEvents } from "./SavesAndFollows"
 import { SaleScreenLoadComplete, TimeOnPage } from "./System"
 import {
@@ -35,6 +38,7 @@ import {
   TappedArtistSeriesGroup,
   TappedArtworkGroup,
   TappedAuctionGroup,
+  TappedAuctionResultGroup,
   TappedCollectionGroup,
   TappedConsign,
   TappedExploreGroup,
@@ -58,6 +62,7 @@ import { ToggledNotification } from "./Toggle"
  */
 export type Event =
   | AddToCalendar
+  | AuctionResultsFilterParamsChanged
   | AuthImpression
   | CreatedAccount
   | ClickedAppDownload
@@ -87,6 +92,7 @@ export type Event =
   | TappedArtistSeriesGroup
   | TappedArtworkGroup
   | TappedAuctionGroup
+  | TappedAuctionResultGroup
   | TappedCollectionGroup
   | TappedExploreGroup
   | TappedFairCard
@@ -117,6 +123,10 @@ export enum ActionType {
    * Corresponds to {@link AddToCalendar}
    */
   addToCalendar = "addToCalendar",
+  /**
+   * Corresponds to {@link AuctionResultsFilterParamsChanged}
+   */
+  auctionResultsFilterParamsChanged = "auctionResultsFilterParamsChanged",
   /**
    * Corresponds to {@link ClickedAppDownload}
    */
@@ -253,6 +263,10 @@ export enum ActionType {
    * Corresponds to {@link TappedAuctionGroup}
    */
   tappedAuctionGroup = "tappedAuctionGroup",
+  /**
+   * Corresponds to {@link TappedAuctionResultGroup}
+   */
+  tappedAuctionResultGroup = "tappedAuctionResultGroup",
   /**
    * Corresponds to {@link TappedCollectionGroup}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -26,10 +26,7 @@ import {
   FocusedOnConversationMessageInput,
   SentConversationMessage,
 } from "./Conversations"
-import {
-  AuctionResultsFilterParamsChanged,
-  CommercialFilterParamsChanged,
-} from "./FilterAndSort"
+import { CommercialFilterParamsChanged } from "./FilterAndSort"
 import { FollowEvents } from "./SavesAndFollows"
 import { SaleScreenLoadComplete, TimeOnPage } from "./System"
 import {
@@ -62,7 +59,6 @@ import { ToggledNotification } from "./Toggle"
  */
 export type Event =
   | AddToCalendar
-  | AuctionResultsFilterParamsChanged
   | AuthImpression
   | CreatedAccount
   | ClickedAppDownload
@@ -123,10 +119,6 @@ export enum ActionType {
    * Corresponds to {@link AddToCalendar}
    */
   addToCalendar = "addToCalendar",
-  /**
-   * Corresponds to {@link AuctionResultsFilterParamsChanged}
-   */
-  auctionResultsFilterParamsChanged = "auctionResultsFilterParamsChanged",
   /**
    * Corresponds to {@link ClickedAppDownload}
    */

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -9,8 +9,10 @@ export enum OwnerType {
   articles = "articles",
   artist = "artist",
   artists = "artists",
+  artistInsights = "artistInsights",
   artistSeries = "artistSeries",
   artwork = "artwork",
+  auctionResult = "auctionResult",
   auctions = "auctions",
   gene = "gene",
   cityGuideGuide = "cityGuideGuide",
@@ -52,8 +54,10 @@ export type ScreenOwnerType =
   | OwnerType.article
   | OwnerType.articles
   | OwnerType.artist
+  | OwnerType.artistInsights
   | OwnerType.artistSeries
   | OwnerType.artwork
+  | OwnerType.auctionResult
   | OwnerType.auctions
   | OwnerType.gene
   | OwnerType.cityGuideGuide


### PR DESCRIPTION
Introducing: event tracking schema for the bulk of native auction results features headed to iOS. Information bubble taps are not included here; I'll follow up with those later as they are not critical or a blocker. 