### PR TITLE
Add optional properties for TappedNavigationTab

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -529,7 +529,7 @@ export interface TappedShowMore {
 /**
  * A user taps a navigation tab on iOS
  *
- * This schema describes events sent to Segment from [[tappedView]]
+ * This schema describes events sent to Segment from [[tappedNavigationTab]]
  *
  *  @example
  *  ```
@@ -548,7 +548,7 @@ export interface TappedNavigationTab {
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id?: string
   context_screen_owner_slug?: string
-  subject: "string"
+  subject?: string
 }
 
 /**

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -546,8 +546,8 @@ export interface TappedNavigationTab {
   action: ActionType.tappedNavigationTab
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
-  context_screen_owner_id: string
-  context_screen_owner_slug: string
+  context_screen_owner_id?: string
+  context_screen_owner_slug?: string
   subject: "string"
 }
 


### PR DESCRIPTION
Some implementations of `tappedNavigationTab` will involve context screens without ids or slugs (example: navigating from inboxBids to inboxInquiries or vice versa)