### PR TITLE
Add context module for YourActiveBids

### DIFF
--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -109,6 +109,7 @@ export enum ContextModule {
   worksByPopularArtistsRail = "worksByPopularArtistsRail",
   worksByArtistsYouFollowRail = "worksByArtistsYouFollowRail",
   worksForSaleRail = "worksForSaleRail",
+  yourActiveBids = "yourActiveBids",
 }
 
 /**


### PR DESCRIPTION
#minor adds a context module for the YourActiveBids rail that is visible on iOS home when the user is engaged in auctions