### PR TITLE
feat: expose two more subjects for tappedInfoBubble

### DIFF
--- a/src/Helpers/Tap/TappedInfoBubble.ts
+++ b/src/Helpers/Tap/TappedInfoBubble.ts
@@ -10,7 +10,11 @@ export interface TappedInfoBubbleArgs {
   contextScreenOwnerType: ScreenOwnerType
   contextScreenOwnerId?: string
   contextScreenOwnerSlug?: string
-  subject: "auctionResults" | "demandIndex"
+  subject:
+    | "auctionResults"
+    | "demandIndex"
+    | "priceEstimate"
+    | "artistMarketStatistics"
 }
 
 export const tappedInfoBubble = ({

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -340,7 +340,11 @@ export interface TappedInfoBubble {
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id?: string
   context_screen_owner_slug?: string
-  subject: "auctionResults" | "demandIndex"
+  subject:
+    | "auctionResults"
+    | "demandIndex"
+    | "priceEstimate"
+    | "artistMarketStatistics"
 }
 
 /**


### PR DESCRIPTION
This PR adds two more subjects for `TappedInfoBubble`, which were unaccounted for: 

![image](https://user-images.githubusercontent.com/1627089/102300579-d62e7300-3f1a-11eb-96a7-6e655100ff0b.png)

Feel free to change the names @mikehrom, but for now I'm going to self-merge this to move forward.

