### PR TITLE
Auction results filtering

### DIFF
--- a/src/Schema/Events/FilterAndSort.ts
+++ b/src/Schema/Events/FilterAndSort.ts
@@ -56,7 +56,7 @@ export interface AuctionResultsFilterParams {
 }
 
 /**
- * A user applies filters to a filterable/sortable artworks or auction results module
+ * A user applies filters to a filterable/sortable artwork grid
  *
  * This schema describes events sent to Segment from [[commercialFilterParamsChanged]]
  *
@@ -75,10 +75,41 @@ export interface AuctionResultsFilterParams {
  */
 export interface CommercialFilterParamsChanged {
   action: ActionType.commercialFilterParamsChanged
-  context_module: ContextModule.artworkGrid | ContextModule.auctionResults
+  context_module: ContextModule.artworkGrid
   context_owner_type: OwnerType
   context_owner_id?: string
   context_owner_slug?: string
-  current: CommercialFilterParams | AuctionResultsFilterParams
-  changed: CommercialFilterParams | AuctionResultsFilterParams
+  current: CommercialFilterParams
+  changed: CommercialFilterParams
+}
+
+/**
+ * A user applies filters to a filterable/sortable auction results module
+ *
+ * This schema describes events sent to Segment from [[auctionResultsFilterParamsChanged]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "auctionResultsFilterParamsChanged",
+ *    context_module: "artistAuctionResults",
+ *    context_owner_type: "artist",
+ *    context_owner_id: "510ade6c4926534fd80000e9",
+ *    context_owner_slug: "alex-da-corte",
+ *    changed: {createdAfterYear: 2014},
+ *    current: {createdAfterYear: 2008; sort: "DATE_DESC"}
+ *  }
+ * ```
+ */
+export interface AuctionResultsFilterParamsChanged {
+  action: ActionType.auctionResultsFilterParamsChanged
+  context_module:
+    | ContextModule.auctionResults
+    | ContextModule.artistAuctionResults
+  /** artistAuctionResults should be used for the Artist Insights feature (Auction results tab on web, Insights tab on app) */
+  context_owner_type: OwnerType
+  context_owner_id?: string
+  context_owner_slug?: string
+  current: AuctionResultsFilterParams
+  changed: AuctionResultsFilterParams
 }

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -33,7 +33,10 @@ import {
   TappedMakeOffer,
   TappedViewOffer,
 } from "./Conversations"
-import { CommercialFilterParamsChanged } from "./FilterAndSort"
+import {
+  AuctionResultsFilterParamsChanged,
+  CommercialFilterParamsChanged,
+} from "./FilterAndSort"
 import {
   AddCollectedArtwork,
   DeleteCollectedArtwork,
@@ -78,6 +81,7 @@ import { ToggledNotification } from "./Toggle"
 export type Event =
   | AddToCalendar
   | AddCollectedArtwork
+  | AuctionResultsFilterParamsChanged
   | AuthImpression
   | CreatedAccount
   | ClickedAppDownload
@@ -158,6 +162,10 @@ export enum ActionType {
    * Corresponds to {@link AddCollectedArtwork}
    */
   addCollectedArtwork = "addCollectedArtwork",
+  /**
+   * Corresponds to {@link AuctionResultsFilterParamsChanged}
+   */
+  auctionResultsFilterParamsChanged = "auctionResultsFilterParamsChanged",
   /**
    * Corresponds to {@link ClickedAppDownload}
    */

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -8,6 +8,7 @@ export enum ContextModule {
   aboutTheWork = "aboutTheWork",
   aboutThisAuction = "aboutThisAuction",
   articleArtist = "articleArtist",
+  artistAuctionResults = "artistAuctionResults",
   artistCard = "artistCard",
   artistHeader = "artistHeader",
   artistHighDemandGrid = "artistHighDemandGrid",


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [AS-1986].

### Description

Similar to `commercial_filter_params_changed`, this instruments `auction_results_filter_params_changed` in cohesion, for use on web and in the app. Commercial filtering is for artwork grids, auction results filtering is unique to auction results – either within the Artist Insights feature or within the upcoming auction results database. Context module and page/screen owner should be used to differentiate between environments in which auction results filtering is used.

**Note:** Today, `commercial_filter_params_changed` is used on the app for filtering within the Insights tab on the Artist screen. This will need to be re-implemented to use the new filter event: `auction_results_filter_params_changed`.

### PR Checklist (tick all before merging)

- [x] If I've added a new file to the tree I've exported it from the common `index.ts`
- [x] I've added comments with examples for any new interfaces or helpers and ensured that they're in the docs 
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[AS-1986]: https://artsyproduct.atlassian.net/browse/AS-1986