### PR TITLE
Add artistAuctionResults owner

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -148,8 +148,8 @@ export interface TappedAuctionGroup extends TappedEntityGroup {
  *  ```
  *  {
  *    action: "tappedAuctionResultGroup",
- *    context_module: "auctionResults",
- *    context_screen_owner_type: "artistInsights",
+ *    context_module: "artistAuctionResults",
+ *    context_screen_owner_type: "artistAuctionResults",
  *    context_screen_owner_id: "51aa03df8b3b8177260002ab",
  *    context_screen_owner_slug: "nicolas-party",
  *    destination_screen_owner_type: "auctionResult",

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -9,12 +9,11 @@ export enum OwnerType {
   articles = "articles",
   artist = "artist",
   artists = "artists",
-  artistInsights = "artistInsights",
+  artistAuctionResults = "artistAuctionResults",
   artistSeries = "artistSeries",
   artwork = "artwork",
   auctionResult = "auctionResult",
   auctions = "auctions",
-  gene = "gene",
   cityGuideGuide = "cityGuideGuide",
   cityGuideMap = "cityGuideMap",
   cityPicker = "cityPicker",
@@ -30,6 +29,7 @@ export enum OwnerType {
   fairArtworks = "fairArtworks",
   fairs = "fairs",
   galleries = "galleries",
+  gene = "gene",
   home = "home",
   inboxBids = "inboxBids",
   inboxConversation = "inboxConversation",
@@ -62,7 +62,7 @@ export type ScreenOwnerType =
   | OwnerType.article
   | OwnerType.articles
   | OwnerType.artist
-  | OwnerType.artistInsights
+  | OwnerType.artistAuctionResults
   | OwnerType.artistSeries
   | OwnerType.artwork
   | OwnerType.auctionResult
@@ -108,6 +108,7 @@ export type PageOwnerType =
   | OwnerType.articles
   | OwnerType.artist
   | OwnerType.artists
+  | OwnerType.artistAuctionResults
   | OwnerType.artistSeries
   | OwnerType.artwork
   | OwnerType.auctions


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR relates to [AS-1973].

### Description

We made the decision to keep web and app in sync with each other, so all views to the Auction Results (on web) or Insights (on app) tab will fire a screen view of type: artistAuctionResults, which should transform as "artist-auction-results". Changes to our pagetypes transforms will follow in subsequent fulcrum PRs, along with data migrations to use the new typings.

@MounirDhahri any existing instrumentation where the screen or page owner is "artistInsights" will need to be updated to "artistAuctionResults" - happy to pair on this when it can be prioritized!

### PR Checklist (tick all before merging)

- [x] If I've added a new file to the tree I've exported it from the common `index.ts`
- [x] I've added comments with examples for any new interfaces or helpers and ensured that they're in the docs 
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[AS-1973]: https://artsyproduct.atlassian.net/browse/AS-1973