### PR TITLE
Chore: Change babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,9 @@
 {
   "presets": [
-    ["@babel/preset-env", { "targets": { "node": "current" } }],
+    [
+      "@babel/preset-env",
+      { "targets": "defaults", "useBuiltIns": "usage", "corejs": 3 }
+    ],
     "@babel/preset-typescript"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "typedoc": "0.17.7",
     "typescript": "4.2.3"
   },
-  "dependencies": {},
+  "dependencies": {
+    "core-js": "3"
+  },
   "jest": {
     "transform": {
       ".ts": "babel-jest"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,6 +1926,11 @@ core-js-compat@^3.6.2:
     browserslist "^4.8.5"
     semver "7.0.0"
 
+core-js@3:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.0.tgz#9a020547c8b6879f929306949e31496bbe2ae9b3"
+  integrity sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
The type of this PR is: Bugfix

### Description

Slack context: https://artsy.slack.com/archives/CP9P4KR35/p1617223446228800

After adding Cohesion to Volt, we started having problems because one of Cohesion's exported JS files, ClickedShowMore.js, included a spread operator (`...`) and Volt wasn't able to easily transpile that feature.

We noticed that Cohesion was targeting `node` and figured we should update to target browsers instead, since it is consumed by web apps.

This PR updates the .babelrc targets to use Babel's `preset-env` default targets. We also added `corejs` as a dep since that's best practice according to [Babel docs](https://babeljs.io/docs/en/babel-preset-env). Thanks to @damassi for helping!

Here's a before/after for the offending file after compilation:

Before:
![Screen Shot 2021-04-01 at 11 38 18 AM](https://user-images.githubusercontent.com/5361806/113319389-5c5ea180-92df-11eb-9ab0-f2d799e7294f.png)

After:
![Screen Shot 2021-04-01 at 11 37 39 AM](https://user-images.githubusercontent.com/5361806/113319420-6385af80-92df-11eb-91d1-99cca4e8ad8a.png)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common `index.ts`
- [x] I've added comments with examples for any new interfaces or helpers and ensured that they're in the docs 
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
