### PR TITLE
Adds Fair Items Event to CMS Checklist

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -16,6 +16,33 @@ import { ActionType } from "."
  */
 
 /**
+ * A fair partner with an upcoming booth clicks on Add Works from CMS Checklist To-Do fair item.
+ *
+ *  This schema describes events sent to Segment from [[clickedAddWorksToFair]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedAddWorksToFair",
+ *    context_module: "toDoList",
+ *    context_page_owner_type: "home",
+ *    destination_page_owner_type: "partner_shows",
+ *    destination_page_owner_id: "603f847842d0c10007a960a8",
+ *    destination_page_owner_slug: "xavier-hufkens-xavier-hufkens-at-art-brussels-2021",
+ *    destination_path: "partner_shows/xavier-hufkens-xavier-hufkens-at-art-brussels-2021/artworks#show-add-artworks-modal"
+ *  }
+ * ```
+ */
+ export interface ClickedAddWorksToFair {
+  action: ActionType.clickedAddWorksToFair
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  destination_page_owner_type: PageOwnerType
+  destination_page_owner_id: string
+  destination_page_owner_slug: string
+  destination_path: string
+}
+/**
  * A user clicks a grouping of articles on web
  *
  *  This schema describes events sent to Segment from [[clickedEntityGroup]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -7,6 +7,7 @@ import {
   SuccessfullyLoggedIn,
 } from "./Authentication"
 import {
+  ClickedAddWorksToFair,
   ClickedAppDownload,
   ClickedArticleGroup,
   ClickedArtistGroup,
@@ -85,6 +86,7 @@ export type Event =
   | AuctionResultsFilterParamsChanged
   | AuthImpression
   | CreatedAccount
+  | ClickedAddWorksToFair
   | ClickedAppDownload
   | ClickedArticleGroup
   | ClickedArtistGroup
@@ -168,6 +170,10 @@ export enum ActionType {
    * Corresponds to {@link AuctionResultsFilterParamsChanged}
    */
   auctionResultsFilterParamsChanged = "auctionResultsFilterParamsChanged",
+   /**
+   * Corresponds to {@link ClickedAddWorksToFair}
+   */
+    clickedAddWorksToFair = "clickedAddWorksToFair",
   /**
    * Corresponds to {@link ClickedAppDownload}
    */

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -38,6 +38,7 @@ export enum OwnerType {
   myCollectionArtwork = "myCollectionArtwork",
   onboarding = "onboarding",
   partner = "partner",
+  partnerShowsArtworks = "partnerShowsArtworks",
   profile = "profile",
   sale = "sale",
   saleInformation = "saleInformation",
@@ -122,6 +123,7 @@ export type PageOwnerType =
   | OwnerType.home
   | OwnerType.onboarding
   | OwnerType.partner
+  | OwnerType.partnerShowsArtworks
   | OwnerType.profile
   | OwnerType.sale
   | OwnerType.search


### PR DESCRIPTION
The event ClickedAddWorksToFair would fire when a partner with an upcoming booth clicks on Add Works button from CMS Checklist fair item. For reference, the flow is [here](https://www.figma.com/file/x19uDFCmGCfl2fbo9MKier/Untitled?node-id=0%3A1). Since this is really specific, I thought of adding an ad-hoc page owner type for the destination page. 

- Added ClickedAddWorksToFair event;
- Added new partnerShowsArtworks owner type 
