### PR TITLE
chore: add label and remove type from ClickedEditArtwork

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -33,7 +33,7 @@ import { ActionType } from "."
  *  }
  * ```
  */
- export interface ClickedAddWorksToFair {
+export interface ClickedAddWorksToFair {
   action: ActionType.clickedAddWorksToFair
   context_module: ContextModule
   context_page_owner_type: PageOwnerType
@@ -463,6 +463,7 @@ export interface ClickedAppDownload {
  *    destination_page_owner_id: "5808b9a0cd530e658500008a",
  *    destination_page_owner_slug: "maddalena-ambrosio-untitled"
  *    destination_path: "/artworks/maddalena-ambrosio-untitled/edit"
+ *    label: "Add images"
  *  }
  * ```
  */
@@ -474,7 +475,7 @@ export interface ClickedEditArtwork {
   destination_page_owner_id: string
   destination_page_owner_slug: string
   destination_path: string
-  type: "page"
+  label: string
 }
 
 /**

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -170,10 +170,10 @@ export enum ActionType {
    * Corresponds to {@link AuctionResultsFilterParamsChanged}
    */
   auctionResultsFilterParamsChanged = "auctionResultsFilterParamsChanged",
-   /**
+  /**
    * Corresponds to {@link ClickedAddWorksToFair}
    */
-    clickedAddWorksToFair = "clickedAddWorksToFair",
+  clickedAddWorksToFair = "clickedAddWorksToFair",
   /**
    * Corresponds to {@link ClickedAppDownload}
    */


### PR DESCRIPTION
The type of this PR is: enhancement

Paired with @brendamanganelli on reviewing checklist tracking, and we decided to add a `label` property to `ClickedEditArtwork` so that we could tell if the user clicked on a button to take them to the images flow or the price edit flow. We also removed `type` because it was unnecessary.

### Description

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common `index.ts`
- [x] I've added comments with examples for any new interfaces or helpers and ensured that they're in the docs 
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
