### PR TITLE
refactor(filter params): replace nested properties with a JSON string

### DIFF
--- a/src/Helpers/FilterAndSort/CommercialFilterParamsChanged.ts
+++ b/src/Helpers/FilterAndSort/CommercialFilterParamsChanged.ts
@@ -1,14 +1,13 @@
 import {
   ActionType,
-  CommercialFilterParams,
   CommercialFilterParamsChanged,
   ContextModule,
   OwnerType,
 } from "../../Schema"
 
 export interface CommercialFilterParamsChangedArgs {
-  current: CommercialFilterParams
-  changed: CommercialFilterParams
+  current: string
+  changed: string
   contextOwnerId?: string
   contextOwnerSlug?: string
   contextOwnerType: OwnerType
@@ -23,8 +22,8 @@ export interface CommercialFilterParamsChangedArgs {
  *   context_owner_type: OwnerType.artist,
  *   context_owner_id: "58ba65b1275b24421f80a102",
  *   context_owner_slug: "tugo-cheng",
- *   changed: {acquireable: 1, priceRange: "1000-5000"},
- *   current: {acquireable: 0, priceRange: "*-*"}
+ *   changed: '{"acquireable": 1, "priceRange": "1000-5000"}',
+ *   current: '{"acquireable": 0, "priceRange": "*-*"}'
  * })
  * ```
  */

--- a/src/Helpers/FilterAndSort/__tests__/CommercialFilterParamsChanged.ts
+++ b/src/Helpers/FilterAndSort/__tests__/CommercialFilterParamsChanged.ts
@@ -4,27 +4,21 @@ import { commercialFilterParamsChanged } from "../CommercialFilterParamsChanged"
 describe("commercialFilterParamsChanged", () => {
   it("returns expected event properties", () => {
     const event = commercialFilterParamsChanged({
-      changed: { acquireable: true, priceRange: "1000-5000" },
+      changed: '{"acquireable":true,"priceRange":"1000-5000"}',
       contextOwnerId: "58ba65b1275b24421f80a102",
       contextOwnerSlug: "tugo-cheng",
       contextOwnerType: OwnerType.artist,
-      current: { acquireable: false, priceRange: "*-*" },
+      current: '{"acquireable":false,"priceRange":"*-*"}',
     })
 
     expect(event).toEqual({
       action: "commercialFilterParamsChanged",
-      changed: {
-        acquireable: true,
-        priceRange: "1000-5000",
-      },
+      changed: '{"acquireable":true,"priceRange":"1000-5000"}',
       context_module: "artworkGrid",
       context_owner_id: "58ba65b1275b24421f80a102",
       context_owner_slug: "tugo-cheng",
       context_owner_type: "artist",
-      current: {
-        acquireable: false,
-        priceRange: "*-*",
-      },
+      current: '{"acquireable":false,"priceRange":"*-*"}',
     })
   })
 })

--- a/src/Helpers/Tap/TappedTabBar.ts
+++ b/src/Helpers/Tap/TappedTabBar.ts
@@ -30,7 +30,7 @@ export interface TappedTabBarArgs {
 export const tappedTabBar = ({
   badge,
   tab,
-  contextScreenOwnerType
+  contextScreenOwnerType,
 }: TappedTabBarArgs): TappedTabBar => {
   return {
     action: ActionType.tappedTabBar,

--- a/src/Schema/Events/FilterAndSort.ts
+++ b/src/Schema/Events/FilterAndSort.ts
@@ -3,59 +3,6 @@ import { OwnerType } from "../Values/OwnerType"
 import { ActionType } from "."
 
 /**
- * Master list of filter params available in web and iOS, specific to the artwork grid
- *
- * Intended action by a user that triggered an event
- * @packageDocumentation
- */
-export interface CommercialFilterParams {
-  acquireable?: boolean
-  artist_id?: string
-  artistIDs?: string[]
-  atAuction?: boolean
-  color?: string
-  /**
-   * FIXME: this and other Range filters may be string[]
-   */
-  dimensionRange?: string
-  estimateRange?: string
-  forSale?: boolean
-  height?: string
-  includeArtworksByFollowedArtists?: boolean
-  inquireableOnly?: boolean
-  keyword?: string
-  majorPeriods?: string[]
-  medium?: string
-  offerable?: boolean
-  page?: number
-  partnerID?: string
-  priceRange?: string
-  sizes?: string[]
-  sort?: string
-  term?: string
-  width?: string
-}
-
-/**
- * Master list of filter params available in web and iOS, specific to auction results
- *
- * Intended action by a user that triggered an event
- * @packageDocumentation
- */
-export interface AuctionResultsFilterParams {
-  allowEmptyCreatedDates?: boolean
-  categories?: string[]
-  createdAfterYear?: string
-  createdBeforeYear?: string
-  earliestCreatedYear?: string
-  latestCreatedYear?: string
-  organizations?: string[]
-  pageAndCursor?: string[]
-  sizes?: string[]
-  sort?: string
-}
-
-/**
  * A user applies filters to a filterable/sortable artwork grid
  *
  * This schema describes events sent to Segment from [[commercialFilterParamsChanged]]
@@ -68,8 +15,8 @@ export interface AuctionResultsFilterParams {
  *    context_owner_type: "artist",
  *    context_owner_id: "58ba65b1275b24421f80a102",
  *    context_owner_slug: "tugo-cheng",
- *    changed: {acquireable = 1; priceRange = "1000-5000";},
- *    current: {acquireable = 0; priceRange = "*-*";}
+ *    changed: '{"acquireable": 1, "priceRange": "1000-5000"}',
+ *    current: '{"acquireable": 0, "priceRange": "*-*"}'
  *  }
  * ```
  */
@@ -79,8 +26,8 @@ export interface CommercialFilterParamsChanged {
   context_owner_type: OwnerType
   context_owner_id?: string
   context_owner_slug?: string
-  current: CommercialFilterParams
-  changed: CommercialFilterParams
+  current: string
+  changed: string
 }
 
 /**
@@ -96,8 +43,8 @@ export interface CommercialFilterParamsChanged {
  *    context_owner_type: "artist",
  *    context_owner_id: "510ade6c4926534fd80000e9",
  *    context_owner_slug: "alex-da-corte",
- *    changed: {createdAfterYear: 2014},
- *    current: {createdAfterYear: 2008; sort: "DATE_DESC"}
+ *    changed: '{"createdAfterYear": 2014}',
+ *    current: '{"createdAfterYear": 2008, "sort": "DATE_DESC"}'
  *  }
  * ```
  */
@@ -110,6 +57,6 @@ export interface AuctionResultsFilterParamsChanged {
   context_owner_type: OwnerType
   context_owner_id?: string
   context_owner_slug?: string
-  current: AuctionResultsFilterParams
-  changed: AuctionResultsFilterParams
+  current: string
+  changed: string
 }


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2850]

### Description

Changes the shape of the generated `CommercialFilterParamsChanged` event so that it doesn't result in automatic creation of a zillion columns in Redshift. 

~We simply take some of the nested properties and replace them with a flat JSON string.~

Take 2! We expect Cohesion clients (currently that means only non-auction grids in Force) to send `current` and `changed` as JSON instead of as nested params. These will be forwarded unchanged to Segment/Redshift.

Basically this —

![Screen Shot 2021-04-29 at 5 56 53 PM](https://user-images.githubusercontent.com/140521/116623639-8cb45280-a914-11eb-9f3a-1235947a2496.png)

~The public interface of the helper `commercialFilterParamsChanged` remains unchanged. Since this requires no change from upstream consumers (Force, Eigen) I am leaving this as a minor change re: semantic versioning, rather than a major/breaking change.~ 

This is now a breaking change for Force, so I'm inclined to bump the major version number.

It will also create breaking changes downstream, as @louislecluse as I have discussed.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common `index.ts`
- [x] I've added comments with examples for any new interfaces or helpers and ensured that they're in the docs 
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[FX-2850]: https://artsyproduct.atlassian.net/browse/FX-2850