### PR TITLE
Remove track api call for `screen` 

### DIFF
--- a/src/Schema/Events/System.ts
+++ b/src/Schema/Events/System.ts
@@ -55,27 +55,3 @@ export interface SaleScreenLoadComplete {
   load_time_ms: number
   number_of_lots: number
 }
-
-/**
- * A user views a screen on iOS
- *
- * This schema describes events sent to Segment from [[screen]]
- *
- *  @example
- *  ```
- *  {
- *    action: "screen",
- *    context_screen_owner_type: "artist",
- *    context_screen_owner_id: "527ac4a0cd530e258d0000d0",
- *    context_screen_owner_slug: "ramiro-gomez",
- *    context_screen_referrer_type: "artwork"
- *  }
- * ```
- */
-export interface Screen {
-  action: ActionType.screen
-  context_screen_owner_type: ScreenOwnerType
-  context_screen_owner_id?: string
-  context_screen_owner_slug?: string
-  context_screen_referrer_type?: ScreenOwnerType
-}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -48,7 +48,7 @@ import {
 } from "./MyCollection"
 import { FollowEvents } from "./SavesAndFollows"
 import { Share } from "./Share"
-import { SaleScreenLoadComplete, Screen, TimeOnPage } from "./System"
+import { SaleScreenLoadComplete, TimeOnPage } from "./System"
 import {
   TappedArticleGroup,
   TappedArtistGroup,
@@ -114,7 +114,6 @@ export type Event =
   | OnboardingUserInputData
   | ResetYourPassword
   | SaleScreenLoadComplete
-  | Screen
   | SentConversationMessage
   | Share
   | SuccessfullyLoggedIn
@@ -303,10 +302,6 @@ export enum ActionType {
    * Corresponds to {@link SaleScreenLoadComplete}
    */
   saleScreenLoadComplete = "saleScreenLoadComplete",
-  /**
-   * Corresponds to {@link Screen}
-   */
-  screen = "screen",
   /**
    * Corresponds to {@link SearchedWithNoResults}
    */


### PR DESCRIPTION
The type of this PR is: **Bugfix, sorta**

This PR relates to [AS-2136]

### Description

I introduced a Track api call event named `screen` to the cohesion schema, but we really want a Screen api call.
<img width="542" alt="Screen Shot 2021-05-05 at 11 13 29 AM" src="https://user-images.githubusercontent.com/26879583/117189357-f6a87e00-ad92-11eb-92de-da53fbb07bd0.png">

The pattern we want is how the Artist screen appears in the screenshot above, but right now for a few flows (myCollection for example), we fire a Track with the name `screen`. The former appears in `eigen_production.screens` (desired), the latter is in `eigen_production.screen`. We use the former in our sessions rollups, not the latter.

Want to get this right for Android launch, so we're starting with the first step of removing the track we do not want to use, and then we'll add structure in cohesion to differentiate between Screen api calls and Track api calls. For now, the non-cohesion schema for screens is acceptable (and preferred!).


[AS-2136]: https://artsyproduct.atlassian.net/browse/AS-2136