### PR TITLE
Saved Search 1.0 tracking

### DIFF
--- a/src/Schema/Events/Toggle.ts
+++ b/src/Schema/Events/Toggle.ts
@@ -59,7 +59,7 @@ export interface ToggledSavedSearch {
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id?: string
   context_screen_owner_slug?: string
-  modified: number
-  original: number
+  modified: boolean
+  original: boolean
   search_criteria_id: string
 }

--- a/src/Schema/Events/Toggle.ts
+++ b/src/Schema/Events/Toggle.ts
@@ -47,6 +47,7 @@ export interface ToggledNotification {
  *    action: "toggledSavedSearch",
  *    context_screen_owner_type: "artist",
  *    context_screen_owner_id: "58de681f275b2464fcdde097",
+ *    context_screen_owner_slug: "anthony-hunter",
  *    modified: 1,
  *    original: 0,
  *    saved_search_id: "58de681f275b2464fcdde097"
@@ -57,6 +58,7 @@ export interface ToggledSavedSearch {
   action: ActionType.toggledSavedSearch
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id?: string
+  context_screen_owner_slug?: string
   modified: number
   original: number
   saved_search_id: string

--- a/src/Schema/Events/Toggle.ts
+++ b/src/Schema/Events/Toggle.ts
@@ -48,8 +48,8 @@ export interface ToggledNotification {
  *    context_screen_owner_type: "artist",
  *    context_screen_owner_id: "58de681f275b2464fcdde097",
  *    context_screen_owner_slug: "anthony-hunter",
- *    modified: 1,
- *    original: 0,
+ *    modified: True,
+ *    original: False,
  *    search_criteria_id: "58de681f275b2464fcdde097"
  *  }
  * ```

--- a/src/Schema/Events/Toggle.ts
+++ b/src/Schema/Events/Toggle.ts
@@ -35,3 +35,29 @@ export interface ToggledNotification {
   original: number
   subject: PushNotificationType
 }
+
+/**
+ * A user toggles a saved search on/off on iOS
+ *
+ *  This schema describes events sent to Segment from [[toggledNotification]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "toggledSavedSearch",
+ *    context_screen_owner_type: "artist",
+ *    context_screen_owner_id: "58de681f275b2464fcdde097",
+ *    modified: 1,
+ *    original: 0,
+ *    saved_search_id: "58de681f275b2464fcdde097"
+ *  }
+ * ```
+ */
+export interface ToggledSavedSearch {
+  action: ActionType.toggledSavedSearch
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id?: string
+  modified: number
+  original: number
+  saved_search_id: string
+}

--- a/src/Schema/Events/Toggle.ts
+++ b/src/Schema/Events/Toggle.ts
@@ -50,7 +50,7 @@ export interface ToggledNotification {
  *    context_screen_owner_slug: "anthony-hunter",
  *    modified: 1,
  *    original: 0,
- *    saved_search_id: "58de681f275b2464fcdde097"
+ *    search_criteria_id: "58de681f275b2464fcdde097"
  *  }
  * ```
  */
@@ -61,5 +61,5 @@ export interface ToggledSavedSearch {
   context_screen_owner_slug?: string
   modified: number
   original: number
-  saved_search_id: string
+  search_criteria_id: string
 }

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -73,7 +73,7 @@ import {
   TappedViewingRoomCard,
   TappedViewingRoomGroup,
 } from "./Tap"
-import { ToggledNotification } from "./Toggle"
+import { ToggledNotification, ToggledSavedSearch } from "./Toggle"
 
 /**
  * Master list of valid schemas for analytics actions
@@ -147,6 +147,7 @@ export type Event =
   | TappedViewOffer
   | TimeOnPage
   | ToggledNotification
+  | ToggledSavedSearch
 
 /**
  * The top-level actions an Event describes.
@@ -447,6 +448,10 @@ export enum ActionType {
    * Corresponds to {@link ToggledNotification}
    */
   toggledNotification = "toggledNotification",
+  /**
+   * Corresponds to {@link ToggledSavedSearch}
+   */
+  toggledSavedSearch = "toggledSavedSearch",
   /**
    * Corresponds to {@link UnfollowedArtist}
    */


### PR DESCRIPTION
The type of this PR is: **New events**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3014](https://artsyproduct.atlassian.net/browse/FX-3014)

### Description

Saved Search 1.0 tracking!
There is 1 event to track: which is toggling on/off the Saved Search! This event depends on how we model Saved Search on the back end and if we are able to generate a "saved search id" - I started the convo with engineering.

@abhitip I would like to instrument the push notification we send for a saved search alert. Is there anything to be done here?

### PR Checklist (tick all before merging)



- [ ] If I've added a new file to the tree I've exported it from the common `index.ts`
- [ ] I've added comments with examples for any new interfaces or helpers and ensured that they're in the docs 
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
