### PR TITLE
[PX-4111] - Adds new shipping flow events to Cohesion

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -494,7 +494,6 @@ export interface ClickedNavigationTab {
   context_page_owner_id: string
 }
 
-
 /**
  * A user clicks a partner card
  *

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -16,6 +16,29 @@ import { ActionType } from "."
  */
 
 /**
+ *  User clicks to add new shipping address when entering the orders
+ *  checkout flow.
+ *
+ *  This schema describes events sent to Segment from [[clickedAddNewShippingAddress]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedAddNewShippingAddress",
+ *    context_module: "OrdersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b"
+ *  }
+ * ```
+ */
+ export interface ClickedAddNewShippingAddress {
+  action: ActionType.clickedAddNewShippingAddress
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
+}
+
+/**
  * A fair partner with an upcoming booth clicks on Add Works from CMS Checklist To-Do fair item.
  *
  *  This schema describes events sent to Segment from [[clickedAddWorksToFair]]
@@ -188,6 +211,123 @@ export interface ClickedCollectionGroup extends ClickedEntityGroup {
 }
 
 /**
+ *  User clicks on Artsy's buyer protection link during their checkout flow.
+ *
+ *  This schema describes events sent to Segment from [[clickedBuyerProtection]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedBuyerProtection",
+ *    context_module: "OrdersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    destination_page_owner_type: "articles",
+ *    destination_page_owner_slug: "360048946973-How-does-Artsy-protect-me"
+ *  }
+ * ```
+ */
+ export interface ClickedBuyerProtection {
+  action: ActionType.clickedBuyerProtection
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
+  destination_page_owner_type: PageOwnerType
+  destination_page_owner_slug: string
+}
+
+/**
+ *  User clicks on Change Payment Method on the orders review page.
+ *
+ *  This schema describes events sent to Segment from [[clickedChangePaymentMethod]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedChangePaymentMethod",
+ *    context_module: "OrdersReview",
+ *    context_page_owner_type: "orders-review",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *  }
+ * ```
+ */
+ export interface ClickedChangePaymentMethod {
+  action: ActionType.clickedChangePaymentMethod
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
+}
+
+/**
+ *  User clicks on Change Shipping Address on the orders review page.
+ *
+ *  This schema describes events sent to Segment from [[clickedChangeShippingAddress]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedChangeShippingAddress",
+ *    context_module: "OrdersReview",
+ *    context_page_owner_type: "orders-review",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *  }
+ * ```
+ */
+ export interface ClickedChangeShippingAddress {
+  action: ActionType.clickedChangeShippingAddress
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
+}
+
+/**
+ *  User clicks on Change Shipping Method on the orders review page.
+ *
+ *  This schema describes events sent to Segment from [[clickedChangePaymentMethod]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedChangeShippingMethod",
+ *    context_module: "OrdersReview",
+ *    context_page_owner_type: "orders-review",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *  }
+ * ```
+ */
+ export interface ClickedChangeShippingMethod {
+  action: ActionType.clickedChangeShippingMethod
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
+}
+
+/**
+ *  User selects delivery option (Shipping or Pick Up) when entering the orders
+ *  checkout flow.
+ *
+ *  This schema describes events sent to Segment from [[clickedDeliveryMethod]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedDeliveryMethod",
+ *    context_module: "OrdersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    subject: Pick up
+ *  }
+ * ```
+ */
+ export interface ClickedDeliveryMethod {
+  action: ActionType.clickedDeliveryMethod
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
+  subject: string
+}
+
+/**
  * A user clicks a grouping of fairs on web
  *
  * This schema describes events sent to Segment from [[clickedEntityGroup]]
@@ -333,6 +473,29 @@ export interface ClickedNavigationTab {
 }
 
 /**
+ *  User clicks on submit order on the orders review page.
+ *
+ *  This schema describes events sent to Segment from [[clickedOnSubmitOrder]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedOnSubmitOrder",
+ *    context_module: "OrdersReview",
+ *    context_page_owner_type: "orders-review",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *  }
+ * ```
+ */
+ export interface ClickedOnSubmitOrder {
+  action: ActionType.clickedOnSubmitOrder
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
+}
+
+
+/**
  * A user clicks a partner card
  *
  * This schema describes events sent to Segment from [[ClickedPartnerCard]]
@@ -362,6 +525,53 @@ export interface ClickedPartnerCard {
   destination_page_owner_id: string
   destination_page_owner_slug: string
   type: "thumbnail"
+}
+
+/**
+ *  User selects existing shipping address when entering the orders
+ *  checkout flow.
+ *
+ *  This schema describes events sent to Segment from [[clickedShippingAddress]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedShippingAddress",
+ *    context_module: "OrdersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b"
+ *  }
+ * ```
+ */
+ export interface ClickedShippingAddress {
+  action: ActionType.clickedShippingAddress
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
+}
+
+/**
+ *  User chooses shipping option.
+ *
+ *  This schema describes events sent to Segment from [[clickedSelectShippingOption]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedSelectShippingOption",
+ *    context_module: "OrdersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    subject: "UPS Ground"
+ *  }
+ * ```
+ */
+ export interface ClickedSelectShippingOption {
+  action: ActionType.clickedSelectShippingOption
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
+  subject: string
 }
 
 /**

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -7,6 +7,7 @@ import {
   SuccessfullyLoggedIn,
 } from "./Authentication"
 import {
+  ClickedAddNewShippingAddress,
   ClickedAddWorksToFair,
   ClickedAppDownload,
   ClickedArticleGroup,
@@ -14,7 +15,12 @@ import {
   ClickedArtistSeriesGroup,
   ClickedArtworkGroup,
   ClickedAuctionGroup,
+  ClickedBuyerProtection,
+  ClickedChangePaymentMethod,
+  ClickedChangeShippingAddress,
+  ClickedChangeShippingMethod,
   ClickedCollectionGroup,
+  ClickedDeliveryMethod,
   ClickedEditArtwork,
   ClickedExpansionToggle,
   ClickedFairCard,
@@ -22,7 +28,10 @@ import {
   ClickedLoadMore,
   ClickedMainArtworkGrid,
   ClickedNavigationTab,
+  ClickedOnSubmitOrder,
   ClickedPartnerCard,
+  ClickedSelectShippingOption,
+  ClickedShippingAddress,
   ClickedShowMore,
   ClickedSnooze,
   ClickedVerifyIdentity,
@@ -86,6 +95,7 @@ export type Event =
   | AuctionResultsFilterParamsChanged
   | AuthImpression
   | CreatedAccount
+  | ClickedAddNewShippingAddress
   | ClickedAddWorksToFair
   | ClickedAppDownload
   | ClickedArticleGroup
@@ -93,7 +103,12 @@ export type Event =
   | ClickedArtistSeriesGroup
   | ClickedArtworkGroup
   | ClickedAuctionGroup
+  | ClickedBuyerProtection
+  | ClickedChangePaymentMethod
+  | ClickedChangeShippingAddress
+  | ClickedChangeShippingMethod
   | ClickedCollectionGroup
+  | ClickedDeliveryMethod
   | ClickedEditArtwork
   | ClickedExpansionToggle
   | ClickedFairCard
@@ -101,8 +116,11 @@ export type Event =
   | ClickedLoadMore
   | ClickedMainArtworkGrid
   | ClickedNavigationTab
+  | ClickedOnSubmitOrder
   | ClickedSnooze
   | ClickedPartnerCard
+  | ClickedSelectShippingOption
+  | ClickedShippingAddress
   | ClickedShowMore
   | ClickedVerifyIdentity
   | ClickedViewingRoomCard
@@ -171,6 +189,10 @@ export enum ActionType {
    */
   auctionResultsFilterParamsChanged = "auctionResultsFilterParamsChanged",
   /**
+   * Corresponds to {@link ClickedAddNewShippingAddress}
+   */
+  clickedAddNewShippingAddress = "clickedAddNewShippingAddress",
+  /**
    * Corresponds to {@link ClickedAddWorksToFair}
    */
   clickedAddWorksToFair = "clickedAddWorksToFair",
@@ -199,9 +221,29 @@ export enum ActionType {
    */
   clickedAuctionGroup = "clickedAuctionGroup",
   /**
+   * Corresponds to {@link ClickedBuyerProtection}
+   */
+  clickedBuyerProtection = "clickedBuyerProtection",
+  /**
+   * Corresponds to {@link ClickedChangeShippingAddress}
+   */
+  clickedChangeShippingAddress = "clickedChangeShippingAddress",
+  /**
+   * Corresponds to {@link ClickedChangeShippingMethod}
+   */
+  clickedChangeShippingMethod = "clickedChangeShippingMethod",
+  /**
+   * Corresponds to {@link ClickedChangePaymentMethod}
+   */
+  clickedChangePaymentMethod = "clickedChangePaymentMethod",
+  /**
    * Corresponds to {@link ClickedCollectionGroup}
    */
   clickedCollectionGroup = "clickedCollectionGroup",
+  /**
+   * Corresponds to {@link ClickedDeliveryMethod}
+   */
+  clickedDeliveryMethod = "clickedDeliveryMethod",
   /**
    * Corresponds to {@link ClickedEditArtwork}
    */
@@ -232,6 +274,10 @@ export enum ActionType {
    */
   clickedNavigationTab = "clickedNavigationTab",
   /**
+   * Corresponds to {@link ClickedOnSubmitOrder}
+   */
+  clickedOnSubmitOrder = "clickedOnSubmitOrder",
+  /**
    * Corresponds to {@link ClickedSnooze}
    */
   clickedSnooze = "clickedSnooze",
@@ -239,6 +285,14 @@ export enum ActionType {
    * Corresponds to {@link ClickedPartnerCard}
    */
   clickedPartnerCard = "clickedPartnerCard",
+  /**
+   * Corresponds to {@link ClickedSelecthippingOption}
+   */
+  clickedSelectShippingOption = "clickedSelectShippingOption",
+  /**
+   * Corresponds to {@link ClickedShippingAddress}
+   */
+  clickedShippingAddress = "clickedShippingAddress",
   /**
    * Corresponds to {@link ClickedShowMore}
    */

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -75,6 +75,8 @@ export enum ContextModule {
   marketInsights = "marketInsights",
   newWorksByArtistsYouFollowRail = "newWorksByArtistsYouFollowRail",
   newWorksByGalleriesYouFollowRail = "newWorksByGalleriesYouFollowRail",
+  ordersShipping = "ordersShipping",
+  ordersReview = "ordersReview",
   onboardingArtists = "onboardingArtists",
   onboardingBudget = "onboardingBudget",
   onboardingGenes = "onboardingGenes",


### PR DESCRIPTION
1. I have added new events to being able to track users' interactions with the new shipping flow for **web**; designs are [here](https://www.figma.com/file/J5bIQj4a0l7wYAHnhbVGTp/%5BCollector%5D-Checkout-Shipping?node-id=1761%3A0);
2. Added two new context_module: OrdersShipping and OrdersReview to distinguish between orders-shipping and orders-review pagetypes. 
