### PR TITLE
Event for failed artist search in the consignments flow

### DIFF
--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -87,3 +87,25 @@ export interface SearchedWithNoResults {
   destination_owner_type?: PageOwnerType
   query: string
 }
+
+/**
+ * A user searches for an artist in the consignment submission flow but receives an error and cannot search
+ *
+ * This schema describes events sent to Segment from [[consignmentArtistFailed]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "consignmentArtistFailed",
+ *    context_module: "consignSubmissionFlow",
+ *    context_owner_type: "consign",
+ *    query: "artist we are not accepting submissions for"
+ *  }
+ * ```
+ */
+export interface ConsignmentArtistFailed {
+  action: ActionType.consignmentArtistFailed
+  context_module: ContextModule.consignSubmissionFlow
+  context_owner_type: OwnerType.consign
+  query: string
+}

--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -93,7 +93,7 @@ export interface SearchedWithNoResults {
  *
  * This schema describes events sent to Segment from [[searchedPriceDatabase]]
  *
- *  *  @example
+ *  @example
  *  ```
  *  {
  *    action: "searchedPriceDatabase",

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -61,6 +61,7 @@ import {
   TappedCollectedArtworkImages,
 } from "./MyCollection"
 import { FollowEvents } from "./SavesAndFollows"
+import { ConsignmentArtistFailed } from "./Search"
 import { Share } from "./Share"
 import { SaleScreenLoadComplete, Screen, TimeOnPage } from "./System"
 import {
@@ -135,6 +136,7 @@ export type Event =
   | ClickedVerifyIdentity
   | ClickedViewingRoomCard
   | CommercialFilterParamsChanged
+  | ConsignmentArtistFailed
   | DeleteCollectedArtwork
   | EditCollectedArtwork
   | FocusedOnConversationMessageInput
@@ -340,6 +342,10 @@ export enum ActionType {
    * Corresponds to {@link CommercialFilterParamsChanged}
    */
   commercialFilterParamsChanged = "commercialFilterParamsChanged",
+  /**
+   * Corresponds to {@link ConsignmentArtistFailed}
+   */
+  consignmentArtistFailed = "consignmentArtistFailed",
   /**
    * Corresponds to {@link CreatedAccount}
    */


### PR DESCRIPTION
Consignments business team wants to know who users are attempting to submit artworks for outside of our P1/P2 list; this event will provide a way to query for those search bar inputs. Example of where this happens on web:

<img width="960" alt="Screen Shot 2021-08-10 at 2 22 26 PM" src="https://user-images.githubusercontent.com/26879583/128936912-e992f038-ca87-45f2-bb02-94575850000a.png">

