### PR TITLE
fix: rename context_screen param to contextScreen for tappedMainArtworkGrid

### DIFF
--- a/src/DeprecatedHelpers/Tap/TappedMainArtworkGrid.ts
+++ b/src/DeprecatedHelpers/Tap/TappedMainArtworkGrid.ts
@@ -7,7 +7,7 @@ import {
 } from "../../Schema"
 
 export interface TappedMainArtworkGridArgs {
-  context_screen?: string
+  contextScreen?: string
   contextScreenOwnerType: ScreenOwnerType
   contextScreenOwnerId?: string
   contextScreenOwnerSlug?: string
@@ -33,7 +33,7 @@ export interface TappedMainArtworkGridArgs {
  * ```
  */
 export const tappedMainArtworkGrid = ({
-  context_screen,
+  contextScreen,
   contextScreenOwnerType,
   contextScreenOwnerId,
   contextScreenOwnerSlug,
@@ -46,7 +46,7 @@ export const tappedMainArtworkGrid = ({
   return {
     action: ActionType.tappedMainArtworkGrid,
     context_module: ContextModule.artworkGrid,
-    context_screen,
+    context_screen: contextScreen,
     context_screen_owner_id: contextScreenOwnerId,
     context_screen_owner_slug: contextScreenOwnerSlug,
     context_screen_owner_type: contextScreenOwnerType,

--- a/src/DeprecatedHelpers/Tap/__tests__/TappedMainArtworkGrid.test.ts
+++ b/src/DeprecatedHelpers/Tap/__tests__/TappedMainArtworkGrid.test.ts
@@ -32,10 +32,10 @@ describe("clickedEntityGroup", () => {
   it("Works with all args", () => {
     const event = tappedMainArtworkGrid({
       ...args,
+      contextScreen: "ArtistArtworks",
       contextScreenOwnerId: "5359794d1a1e86c3740001f6",
       contextScreenOwnerSlug: "andy-warhol",
       contextScreenOwnerType: OwnerType.artist,
-      context_screen: "ArtistArtworks",
       position: 4,
       sort: "-decayed_merch",
     })


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

### Description
Rename `context_screen` param to `contextScreen` for `tappedMainArtworkGrid`

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common `index.ts`
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
