### PR TITLE
feat(CX-2146): add promptForReview event

### DIFF
--- a/src/Schema/Events/PromptForReview.ts
+++ b/src/Schema/Events/PromptForReview.ts
@@ -28,5 +28,5 @@ export interface PromptForReview {
   context_owner_type: OwnerType
   context_owner_id?: string
   context_owner_slug?: string
-  subject: "ios" | "android"
+  platform: "ios" | "android"
 }

--- a/src/Schema/Events/PromptForReview.ts
+++ b/src/Schema/Events/PromptForReview.ts
@@ -1,0 +1,32 @@
+import { ContextModule } from "../Values/ContextModule"
+import { OwnerType } from "../Values/OwnerType"
+import { ActionType } from "."
+
+/**
+ * Schema describing 'Prompt for review' events (iOS and Android only)
+ * @packageDocumentation
+ */
+
+/**
+ * A user gets prompted for 'Review our app'
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "promptForReview",
+ *    context_module: "artistHeader",
+ *    context_owner_type: "artist",
+ *    context_owner_id: "5f99e0ba4c24bc000d02b8d7",
+ *    context_owner_slug: "andy-warhol",
+ *    platform: "ios"
+ *  }
+ * ```
+ */
+export interface PromptForReview {
+  action: ActionType.promptForReview
+  context_module: ContextModule
+  context_owner_type: OwnerType
+  context_owner_id?: string
+  context_owner_slug?: string
+  subject: "ios" | "android"
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -65,6 +65,7 @@ import {
   TappedCollectedArtwork,
   TappedCollectedArtworkImages,
 } from "./MyCollection"
+import { PromptForReview } from "./PromptForReview"
 import { DeletedSavedSearch, EditedSavedSearch } from "./SavedSearch"
 import { FollowEvents } from "./SavesAndFollows"
 import {
@@ -170,6 +171,7 @@ export type Event =
   | FollowEvents
   | OnboardingUserInputData
   | PriceDatabaseFilterParamsChanged
+  | PromptForReview
   | ResetYourPassword
   | SaleScreenLoadComplete
   | Screen
@@ -459,6 +461,10 @@ export enum ActionType {
    * Corresponds to {@link PriceDatabaseFilterParamsChanged}
    */
   priceDatabaseFilterParamsChanged = "priceDatabaseFilterParamsChanged",
+  /**
+   * Corresponds to {@link PromptForReview}
+   */
+  promptForReview = "promptForReview",
   /**
    * Corresponds to {@link ResetYourPassword}
    */


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-2146]

### Description

This PR adds `promptForReview` event. This event refers to asking the users to give an app review on both android and iOS.


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common `index.ts`
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[CX-2146]: https://artsyproduct.atlassian.net/browse/CX-2146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ