### PR TITLE
[AS-2774] Creating new event for the new offer submission flow

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -530,13 +530,13 @@ export interface ClickedNavigationTab {
  *  ```
  *  {
  *    action: "clickedOfferOption",
- *    flow: Make Offer
+ *    flow: "Make Offer",
  *    context_page_owner_type: "orders-offer",
- *    context_page_owner_id: "dd0cbbb5-300b-4c49-92a1-fed55b077fa9"
- *    order_id: "407dd09f-4afd-4aad-a6cc-1d6704dc2b11"
- *    offer: [20% below the list price, 15% below the list price, 10% below the list price, low-end of range, midpoint of the range, top-end of the range, different amount]
- *    amount: 2000
- *    currency: USD
+ *    context_page_owner_id: "dd0cbbb5-300b-4c49-92a1-fed55b077fa9",
+ *    order_id: "407dd09f-4afd-4aad-a6cc-1d6704dc2b11",
+ *    offer: "20% below the list price",
+ *    amount: 2000,
+ *    currency: "USD"
  *  }
  * ```
  */

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -530,17 +530,26 @@ export interface ClickedNavigationTab {
  *  ```
  *  {
  *    action: "clickedOfferOption",
- *    context_module: "OrdersOffer",
+ *    flow: Make Offer
  *    context_page_owner_type: "orders-offer",
  *    context_page_owner_id: "dd0cbbb5-300b-4c49-92a1-fed55b077fa9"
+ *    order_id: "407dd09f-4afd-4aad-a6cc-1d6704dc2b11"
+ *    offer: [20% below the list price, 15% below the list price, 10% below the list price, low-end of range, midpoint of the range, top-end of the range, different amount]
+ *    amount: 2000
+ *    currency: USD
  *  }
  * ```
  */
  export interface ClickedOfferOption {
   action: ActionType.clickedOfferOption
-  context_module: ContextModule
+  flow: string
   context_page_owner_type: string
   context_page_owner_id: string
+  order_id: string
+  offer: string
+  amount: number
+  currency: string
+
 }
 
 /**

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -14,7 +14,6 @@ import { ActionType } from "."
  *  Events are separated by entity type
  *
  */
-
 /**
  *  User clicks to add new shipping address when entering the orders
  *  checkout flow.
@@ -520,6 +519,28 @@ export interface ClickedNavigationTab {
   context_page_owner_slug?: string
   destination_path: string
   subject: string
+}
+
+/**
+ *  User clicks in one of the price options on the offer page
+ *
+ *  This schema describes events sent to Segment from [[clickedOfferOption]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedOfferOption",
+ *    context_module: "OrdersOffer",
+ *    context_page_owner_type: "orders-offer",
+ *    context_page_owner_id: "dd0cbbb5-300b-4c49-92a1-fed55b077fa9"
+ *  }
+ * ```
+ */
+ export interface ClickedOfferOption {
+  action: ActionType.clickedOfferOption
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
 }
 
 /**

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -30,6 +30,7 @@ import {
   ClickedLoadMore,
   ClickedMainArtworkGrid,
   ClickedNavigationTab,
+  ClickedOfferOption,
   ClickedOnArtworkShippingUnitsDropdown,
   ClickedOnArtworkShippingWeight,
   ClickedOnFramedMeasurements,
@@ -144,6 +145,7 @@ export type Event =
   | ClickedLoadMore
   | ClickedMainArtworkGrid
   | ClickedNavigationTab
+  | ClickedOfferOption
   | ClickedOnArtworkShippingWeight
   | ClickedOnArtworkShippingUnitsDropdown
   | ClickedOnFramedMeasurements
@@ -336,6 +338,10 @@ export enum ActionType {
   /**
    * Corresponds to {@link ClickedOnArtworkShippingUnitsDropdown}
    */
+   clickedOfferOption = "clickedOfferOption",
+   /**
+    * Corresponds to {@link ClickedOfferOption}
+    */
   clickedOnArtworkShippingUnitsDropdown = "clickedOnArtworkShippingUnitsDropdown",
   /**
    * Corresponds to {@link ClickedOnArtworkShippingWeight}


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CO-]

### Description
The offer submission flow has been changing and we need to track some of the new features.
We need to create a new event to track in which offer option users are clicking (lower, mid, high, different amount).

All the details can be found [here](https://www.notion.so/artsy/Analytics-for-new-offer-submission-page-c242c0115fa74753afc00728c9e85689).

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common `index.ts`
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
