### PR TITLE
feat: add auth intent to create alert

### DIFF
--- a/src/Schema/Values/Intent.ts
+++ b/src/Schema/Values/Intent.ts
@@ -8,6 +8,7 @@ export enum Intent {
   bid = "bid",
   buyNow = "buyNow",
   consign = "consign",
+  createAlert = "createAlert",
   followArtist = "followArtist",
   followPartner = "followPartner",
   followGene = "followGene",
@@ -38,6 +39,7 @@ export type AuthIntent =
   | Intent.bid
   | Intent.buyNow
   | Intent.consign
+  | Intent.createAlert
   | Intent.followArtist
   | Intent.followGene
   | Intent.followPartner


### PR DESCRIPTION
The type of this PR is: **Feature**

Related Force comment: https://github.com/artsy/force/pull/9055#discussion_r769636380

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->
### Description

As we roll out the artwork alert ecosystem to web, we'll soon show "Create alert" buttons to unauthenticated users. To successfully create an alert, users will have to signup or login.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common `index.ts`
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)

cc/ @anastasiapyzhik 
