### PR TITLE
(GRO-834) add trove rail to context modules

### DIFF
--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -155,6 +155,7 @@ export enum ContextModule {
   topWorksRail = "topWorksRail",
   trendingArtistsRail = "trendingArtistsRail",
   trendingLots = "trendingLots",
+  troveArtworksRail = "troveArtworksRail",
   upcomingAuctions = "upcomingAuctions",
   uploadPhotos = "uploadPhotos",
   viewingRoom = "viewingRoom",


### PR DESCRIPTION
The type of this PR is: feat

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [GRO-834]

Adding a new context module in order to implement a `clickedArtworkGroup` on a Trove artwork rail on the artsy homepage. 

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common `index.ts`
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[GRO-834]: https://artsyproduct.atlassian.net/browse/GRO-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ