### PR TITLE
feat: adds schema for article events

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1083,3 +1083,94 @@ export interface ClickedCreateAlert {
   context_page_owner_id?: string
   context_page_owner_slug?: string
 }
+
+/**
+ * A user clicks the external news source of an article
+ *
+ * This schema describes events sent to Segment from [[clickedExternalNewsSource]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedExternalNewsSource",
+ *    context_page_owner_type: "article",
+ *    context_page_owner_id: "62389c0a0b01c80022eb82a1",
+ *    context_page_owner_slug: "artsy-editorial-making-generative-art-changed-understanding",
+ *  }
+ * ```
+ */
+export interface ClickedExternalNewsSource {
+  action: ActionType.clickedExternalNewsSource
+  context_owner_id: string
+  context_owner_slug: string
+  context_owner_type: PageOwnerType
+  destination_path: string
+}
+
+/**
+ * A user clicks on the sponsor of an article
+ *
+ * This schema describes events sent to Segment from [[clickedSponsorLink]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedSponsorLink",
+ *    context_page_owner_type: "article",
+ *    context_page_owner_id: "62389c0a0b01c80022eb82a1",
+ *    context_page_owner_slug: "artsy-editorial-making-generative-art-changed-understanding",
+ *    destination_path: "https://www.bmw.com/",
+ *  }
+ * ```
+ */
+export interface ClickedSponsorLink {
+  action: ActionType.clickedSponsorLink
+  context_owner_id: string
+  context_owner_slug: string
+  context_owner_type: PageOwnerType
+  destination_path: string
+}
+
+/**
+ * A user clicks to share an article
+ *
+ * This schema describes events sent to Segment from [[clickedArticleShare]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedArticleShare",
+ *    context_page_owner_type: "article",
+ *    context_page_owner_id: "62389c0a0b01c80022eb82a1",
+ *    context_page_owner_slug: "artsy-editorial-making-generative-art-changed-understanding",
+ *  }
+ * ```
+ */
+export interface ClickedArticleShare {
+  action: ActionType.clickedArticleShare
+  context_owner_id: string
+  context_owner_slug: string
+  context_owner_type: PageOwnerType
+}
+
+/**
+ * A user clicks to play a video
+ *
+ * This schema describes events sent to Segment from [[clickedPlayVideo]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedPlayVideo",
+ *    context_page_owner_type: "article",
+ *    context_page_owner_id: "62389c0a0b01c80022eb82a1",
+ *    context_page_owner_slug: "artsy-editorial-making-generative-art-changed-understanding",
+ *  }
+ * ```
+ */
+export interface ClickedPlayVideo {
+  action: ActionType.clickedPlayVideo
+  context_owner_id: string
+  context_owner_slug: string
+  context_owner_type: PageOwnerType
+}

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -717,7 +717,7 @@ export interface ClickedPartnerCard {
  *  }
  * ```
  */
- export interface ClickedPaymentMethod {
+export interface ClickedPaymentMethod {
   action: ActionType.clickedPaymentMethod
   flow: string
   context_page_owner_type: string
@@ -744,15 +744,13 @@ export interface ClickedPartnerCard {
  *  }
  * ```
  */
- export interface ClickedPaymentDetails {
+export interface ClickedPaymentDetails {
   action: ActionType.clickedPaymentDetails
   flow: string
   context_page_owner_type: string
   order_id: string
   subject: string
 }
-
-
 
 /**
  *  User selects existing shipping address when entering the orders
@@ -1173,4 +1171,30 @@ export interface ClickedPlayVideo {
   context_owner_id: string
   context_owner_slug: string
   context_owner_type: PageOwnerType
+}
+
+/**
+ * A user an entity within a tooltip. `type` will be an artist, gene, or partner.
+ *
+ * This schema describes events sent to Segment from [[clickedTooltip]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedTooltip",
+ *    context_page_owner_type: "artist",
+ *    context_page_owner_id: "4d8b926a4eb68a1b2c0000ae",
+ *    context_page_owner_slug: "damien-hirst",
+ *    destination_path: "/artist/damien-hirst",
+ *    type: "artist",
+ *  }
+ * ```
+ */
+export interface ClickedTooltip {
+  action: ActionType.clickedTooltip
+  context_owner_id: string
+  context_owner_slug: string
+  context_owner_type: PageOwnerType
+  destination_path: string
+  type: string
 }

--- a/src/Schema/Events/Impression.ts
+++ b/src/Schema/Events/Impression.ts
@@ -1,0 +1,11 @@
+import { ContextModule } from "../Values/ContextModule"
+import { OwnerType } from "../Values/OwnerType"
+import { ActionType } from "."
+
+export interface Impression {
+  action: ActionType.impression
+  context_module: ContextModule
+  context_owner_id: string
+  context_owner_slug: string
+  context_owner_type: OwnerType
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -325,6 +325,10 @@ export enum ActionType {
    */
   clickedArticleGroup = "clickedArticleGroup",
   /**
+   * Corresponds to {@link ClickedArticleShare}
+   */
+  clickedArticleShare = "clickedArticleShare",
+  /**
    * Corresponds to {@link ClickedArtistGroup}
    */
   clickedArtistGroup = "clickedArtistGroup",
@@ -380,6 +384,10 @@ export enum ActionType {
    * Corresponds to {@link ClickedExpansionToggle}
    */
   clickedExpansionToggle = "clickedExpansionToggle",
+  /**
+   * Corresponds to {@link ClickedExternalNewsSource}
+   */
+  clickedExternalNewsSource = "clickedExternalNewsSource",
   /**
    * Corresponds to {@link ClickedFairCard}
    */
@@ -438,6 +446,10 @@ export enum ActionType {
    */
   clickedPartnerCard = "clickedPartnerCard",
   /**
+   * Corresponds to {@link ClickedPlayVideo}
+   */
+  clickedPlayVideo = "clickedPlayVideo",
+  /**
    * Corresponds to {@link ClickedPromoSpace}
    */
    clickedPaymentMethod = "clickedPaymentMethod",
@@ -469,6 +481,10 @@ export enum ActionType {
    * Corresponds to {@link ClickedShowMore}
    */
   clickedShowMore = "clickedShowMore",
+  /**
+   * Corresponds to {@link ClickedSponsorLink}
+   */
+  clickedSponsorLink = "clickedSponsorLink",
   /**
    * Corresponds to {@link ClickedVerifyIdentiity}
    */
@@ -557,6 +573,10 @@ export enum ActionType {
    * Corresponds to {@link FollowedPartner}
    */
   followedPartner = "followedPartner",
+  /**
+   * Corresponds to {@link Impression}
+   */
+  impression = "impression",
   /**
    * Corresponds to {@link MaxBidSelected}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -50,8 +50,8 @@ import {
   ClickedOnFramedMeasurementsDropdown,
   ClickedOnSubmitOrder,
   ClickedPartnerCard,
-  ClickedPaymentMethod,
   ClickedPaymentDetails,
+  ClickedPaymentMethod,
   ClickedPromoSpace,
   ClickedSelectShippingOption,
   ClickedShippingAddress,
@@ -452,14 +452,14 @@ export enum ActionType {
   /**
    * Corresponds to {@link ClickedPromoSpace}
    */
-   clickedPaymentMethod = "clickedPaymentMethod",
-   /**
-    * Corresponds to {@link ClickedPaymentMethod}
-    */
-    clickedPaymentDetails = "clickedPaymentDetails",
-    /**
-     * Corresponds to {@link ClickedPaymentDetails}
-     */
+  clickedPaymentMethod = "clickedPaymentMethod",
+  /**
+   * Corresponds to {@link ClickedPaymentMethod}
+   */
+  clickedPaymentDetails = "clickedPaymentDetails",
+  /**
+   * Corresponds to {@link ClickedPaymentDetails}
+   */
   clickedPromoSpace = "clickedPromoSpace",
   /**
    * Corresponds to {@link ClickedRegisterToBid}
@@ -485,6 +485,10 @@ export enum ActionType {
    * Corresponds to {@link ClickedSponsorLink}
    */
   clickedSponsorLink = "clickedSponsorLink",
+  /**
+   * Corresponds to {@link ClickedTooltip}
+   */
+  clickedTooltip = "clickedTooltip",
   /**
    * Corresponds to {@link ClickedVerifyIdentiity}
    */

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -7,6 +7,7 @@
 export enum ContextModule {
   aboutTheWork = "aboutTheWork",
   aboutThisAuction = "aboutThisAuction",
+  adServer = "adServer",
   articleArtist = "articleArtist",
   articleRail = "articleRail",
   articles = "articles",


### PR DESCRIPTION
The type of this PR is: **Feature**

### Description

Analytics schema to support https://github.com/artsy/force/pull/9629

I need to add events for the entity tooltips; which currently look like

```
      action: "Click",
      flow: "tooltip",
      type: "artist stub",
      context_module: "intext tooltip",
      destination_path: artist.href,
```

And are on artists, genes, and partners