### PR TITLE
Adding clickedSubmitAnArtwork to cohesion

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1083,3 +1083,27 @@ export interface ClickedCreateAlert {
   context_page_owner_id?: string
   context_page_owner_slug?: string
 }
+
+/**
+ * A user clicks on "Submit an artwork" on the Sell with Artsy landing page
+ *
+ * This schema describes events sent to Segment from [[ClickedSubmitAnArtwork]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "ClickedSubmitAnArtwork",
+ *    context_module: "Header",
+ *    context_page_owner_type: "consign",
+ *    destination_path: "/consign/submission/artwork-details",
+ *    subject: "Submit an Artwork"
+ *  }
+ * ```
+ */
+ export interface ClickedSubmitAnArtwork {
+  action: ActionType.ClickedSubmitAnArtwork
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  destination_path: string
+  subject: string
+}

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1101,7 +1101,7 @@ export interface ClickedCreateAlert {
  * ```
  */
  export interface ClickedSubmitAnArtwork {
-  action: ActionType.ClickedSubmitAnArtwork
+  action: ActionType.clickedSubmitAnArtwork
   context_module: ContextModule
   context_page_owner_type: PageOwnerType
   destination_path: string

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -57,6 +57,7 @@ import {
   ClickedShowGroup,
   ClickedShowMore,
   ClickedSnooze,
+  ClickedSubmitAnArtwork,
   ClickedVerifyIdentity,
   ClickedViewingRoomCard,
 } from "./Click"
@@ -191,6 +192,7 @@ export type Event =
   | ClickedShippingAddress
   | ClickedShowGroup
   | ClickedShowMore
+  | ClickedSubmitAnArtwork
   | ClickedVerifyIdentity
   | ClickedViewingRoomCard
   | CommercialFilterParamsChanged
@@ -466,7 +468,11 @@ export enum ActionType {
   /**
    * Corresponds to {@link ClickedVerifyIdentiity}
    */
-  clickedVerifyIdentity = "clickedVerifyIdentity",
+   clickedSubmitAnArtwork = "clickedSubmitAnArtwork",
+   /**
+    * Corresponds to {@link ClickedSubmitAnArtwork}
+    */
+   clickedVerifyIdentity = "clickedVerifyIdentity",
   /**
    * Corresponds to {@link ClickedViewingRoomCard}
    */


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CO-]

### Description

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common `index.ts`
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)

Context: this PR aims at adding the new event “Submit an Artwork” button on the Sell with Artsy landing page. Clicking on the button takes the user to the editing of the artwork details. 
We were not tracking the equivalent event on the Sell with Artsy landing page.  
@abhitip do you think that `context_page_owner_type: consign`makes sense? We also have Consignments schema, but this one is a Click event. 
cc @kiryl-zubarau 