### PR TITLE
[NX-3133] Adding impulse id to buy now tap

### DIFF
--- a/src/Schema/Events/Conversations.ts
+++ b/src/Schema/Events/Conversations.ts
@@ -123,3 +123,8 @@ export interface TappedConfirmArtwork {
   context_module: OwnerType.conversationMakeOfferConfirmArtwork
   context_owner_type: OwnerType.conversation
 }
+
+export interface TappedBuyNowConfirmArtwork {
+  context_module: OwnerType.conversationBuyNowConfirmArtwork
+  context_owner_type: OwnerType.conversation
+}

--- a/src/Schema/Events/Conversations.ts
+++ b/src/Schema/Events/Conversations.ts
@@ -120,11 +120,6 @@ export interface TappedViewOffer {
 }
 
 export interface TappedConfirmArtwork {
-  context_module: OwnerType.conversationMakeOfferConfirmArtwork
-  context_owner_type: OwnerType.conversation
-}
-
-export interface TappedBuyNowConfirmArtwork {
-  context_module: OwnerType.conversationBuyNowConfirmArtwork
+  context_module: string
   context_owner_type: OwnerType.conversation
 }

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -743,6 +743,7 @@ export interface TappedBid {
  *    context_owner_type: "Artwork",
  *    context_owner_slug: "radna-segal-pearl",
  *    context_owner_id: "6164889300d643000db86504",
+ *    impulse_conversation_id: "198"
  *  }
  * ```
  */
@@ -752,6 +753,7 @@ export interface TappedBuyNow {
   context_owner_type: ScreenOwnerType
   context_owner_id: string
   context_owner_slug: string
+  impulse_conversation_id: string
 }
 
 /**

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -753,7 +753,7 @@ export interface TappedBuyNow {
   context_owner_type: ScreenOwnerType
   context_owner_id: string
   context_owner_slug: string
-  impulse_conversation_id: string
+  impulse_conversation_id?: string
 }
 
 /**

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -166,6 +166,7 @@ export enum ContextModule {
   worksByPopularArtistsRail = "worksByPopularArtistsRail",
   worksForSaleRail = "worksForSaleRail",
   yourActiveBids = "yourActiveBids",
+  conversationConfirmArtwork = "conversationConfirmArtwork"
 }
 
 /**

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -166,7 +166,8 @@ export enum ContextModule {
   worksByPopularArtistsRail = "worksByPopularArtistsRail",
   worksForSaleRail = "worksForSaleRail",
   yourActiveBids = "yourActiveBids",
-  conversationConfirmArtwork = "conversationConfirmArtwork"
+  conversationMakeOfferConfirmArtwork = "conversationMakeOfferConfirmArtwork",
+  conversationBuyNowConfirmArtwork = "conversationBuyNowConfirmArtwork"
 }
 
 /**

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -28,6 +28,7 @@ export enum OwnerType {
   consign = "consign",
   conversation = "conversation",
   conversationMakeOfferConfirmArtwork = "conversationMakeOfferConfirmArtwork",
+  conversationBuyNowConfirmArtwork = "conversationBuyNowConfirmArtwork",
   explore = "explore",
   fair = "fair",
   fairArtworks = "fairArtworks",
@@ -99,6 +100,7 @@ export type ScreenOwnerType =
   | OwnerType.consign
   | OwnerType.conversation
   | OwnerType.conversationMakeOfferConfirmArtwork
+  | OwnerType.conversationBuyNowConfirmArtwork
   | OwnerType.explore
   | OwnerType.fair
   | OwnerType.fairArtworks

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -28,7 +28,6 @@ export enum OwnerType {
   consign = "consign",
   conversation = "conversation",
   conversationMakeOfferConfirmArtwork = "conversationMakeOfferConfirmArtwork",
-  conversationBuyNowConfirmArtwork = "conversationBuyNowConfirmArtwork",
   explore = "explore",
   fair = "fair",
   fairArtworks = "fairArtworks",
@@ -100,7 +99,6 @@ export type ScreenOwnerType =
   | OwnerType.consign
   | OwnerType.conversation
   | OwnerType.conversationMakeOfferConfirmArtwork
-  | OwnerType.conversationBuyNowConfirmArtwork
   | OwnerType.explore
   | OwnerType.fair
   | OwnerType.fairArtworks


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CO-]

### Description

- Adding `impulse id` to the tapped buy now event, so that we can track when the click happens in the conversation.
- Adding event to track when user selects edition set in the conversation (same thing we are doing for MOI)

[Ticket](https://artsyproduct.atlassian.net/browse/NX-3133)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common `index.ts`
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
