### PR TITLE
[AS-3293] Adding new events for CMS tracking

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -645,6 +645,77 @@ export interface ClickedOnFramedMeasurementsDropdown {
 }
 
 /**
+ * A Partner clicks on one of the options (Accept collector's offer, Send a counteroffer, Decline collector's offer) 
+ * for offers on the orders page on CMS.
+ *
+ * This schema describes events sent to Segment from [[clickedOfferActions]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedOfferActions",
+ *    context_page_owner_type: "order",
+ *    context_page_owner_id: "60de173a47476c000fd5c4cc"
+ *    order_id: "60de173a47476c000fd5c4cc"
+ *    label: "Accept collector's offer"
+ *    artwork_id: "60de173a47476c000fd5c4cc"
+ *    flow: offer
+ *    partner_id: "60de173a47476c000fd5c4cc" 
+ *  }
+ * ```
+ */
+ export interface ClickedOfferActions {
+  action: ActionType.clickedOfferActions
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  order_id: string
+  label: string
+  artwork_id: string
+  flow: string
+  partner_id: string
+
+}
+
+/**
+ * A Partner clicks on one of the the CTAs on the orders page on the orders page on CMS.
+ * - Confirm order
+ * - Confirm shipping contact and confirm order
+ * - Accept offer
+ * - Confirm shipping contact and accept offer 
+ * - Decline offer
+ * - Send a counter offer
+ * - Confirm shipping contact and send counter offer
+ *
+ * This schema describes events sent to Segment from [[clickedOrderPage]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedOrderPage",
+ *    context_page_owner_type: "order",
+ *    context_page_owner_id: "60de173a47476c000fd5c4cc"
+ *    order_id: "60de173a47476c000fd5c4cc"
+ *    label: "Confirm order"
+ *    artwork_id: "60de173a47476c000fd5c4cc"
+ *    flow: buy
+ *    partner_id: "60de173a47476c000fd5c4cc" 
+ *  }
+ * ```
+ */
+ export interface ClickedOrderPage {
+  action: ActionType.clickedOrderPage
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  order_id: string
+  label: string
+  artwork_id: string
+  flow: string
+  partner_id: string  
+}
+
+/**
  *  User clicks on submit order on the orders review page.
  *
  *  This schema describes events sent to Segment from [[clickedOnSubmitOrder]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -61,6 +61,8 @@ import {
   ClickedSnooze,
   ClickedVerifyIdentity,
   ClickedViewingRoomCard,
+  ClickedOfferActions,
+  ClickedOrderPage,
 } from "./Click"
 import {
   ArtworkDetailsCompleted,
@@ -199,6 +201,8 @@ export type Event =
   | ClickedShowMore
   | ClickedVerifyIdentity
   | ClickedViewingRoomCard
+  | ClickedOfferActions
+  | ClickedOrderPage
   | CommercialFilterParamsChanged
   | ConfirmBid
   | ConfirmRegistrationPageview
@@ -507,6 +511,14 @@ export enum ActionType {
    * Corresponds to {@link ClickedViewingRoomCard}
    */
   clickedViewingRoomCard = "clickedViewingRoomCard",
+  /**
+   * Corresponds to {@link ClickedOfferActions}
+   */
+   clickedOfferActions = "clickedOfferActions",
+    /**
+   * Corresponds to {@link ClickedOrderPage}
+   */
+  clickedOrderPage = "clickedOrderPage",   
   /**
    * Corresponds to {@link CommercialFilterParamsChanged}
    */


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [AS-3293]

### Description

We want to add some tracking for CMS as described [here](https://www.notion.so/artsy/CMS-tracking-79b5ea1e3a21467ea5165fd376c2734d).

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common `index.ts`
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[AS-3293]: https://artsyproduct.atlassian.net/browse/AS-3293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ