### PR TITLE
chore(deprecated-schema): Move deprecated schema from force

### DIFF
--- a/src/DeprecatedSchema/DeprecatedAuctionInfo.ts
+++ b/src/DeprecatedSchema/DeprecatedAuctionInfo.ts
@@ -1,0 +1,37 @@
+export interface AuctionInfo {
+  /**
+   * database id of a Bidder record (instance of user registered for an auction)
+   */
+  bidder_id: string
+
+  /**
+   * database id of a Bidder Position record
+   *
+   * Bidder position is the term used in Gravity to track the intent of a Bidder
+   * to bid on a lot. Typically this is a "max bid" (they could win at a lower value),
+   * but occasionally it is a fixed bid amount.
+   */
+  bidder_position_id: string
+
+  /**
+   * List of reasons why there's a failure event
+   *
+   *  Used by the auction registration flow.
+   */
+  error_messages: string[]
+
+  /**
+   * The amount of max bid the user selected in cents. For example, if the user
+   * selected $5,000.00, it will be reported as 500000.
+   *
+   *  Used by the auction confirm bid flow.
+   */
+  selected_max_bid_minor: string
+
+  /**
+   * Internal ID of the SaleArtwork.
+   *
+   *  Used by the request condition report flow.
+   */
+  sale_artwork_id: string
+}

--- a/src/DeprecatedSchema/DeprecatedContextModule.ts
+++ b/src/DeprecatedSchema/DeprecatedContextModule.ts
@@ -1,0 +1,10 @@
+import { ContextModule as _ContextModule } from "./DeprecatedValues"
+
+export interface ContextModule {
+  /**
+   * A conceptual module on the page. While this may be a React component name,
+   * it does not need to be, as long as given the name it should be clear what
+   * part of the page is being referred to.
+   */
+  context_module: _ContextModule
+}

--- a/src/DeprecatedSchema/DeprecatedContextPage.ts
+++ b/src/DeprecatedSchema/DeprecatedContextPage.ts
@@ -1,0 +1,24 @@
+import { OwnerType, PageName } from "./DeprecatedValues"
+
+/**
+ * The current page.
+ */
+export interface ContextPage {
+  context_page: PageName
+
+  /**
+   * The type of the entity that this page represents.
+   */
+  context_page_owner_type?: OwnerType
+
+  /**
+   * The database ID of the owner. E.g. in the case of an entity that comes out
+   * of Gravity this should be its Mongo ID.
+   */
+  context_page_owner_id?: string
+
+  /**
+   * The slug of the entity, if it has one.
+   */
+  context_page_owner_slug?: string
+}

--- a/src/DeprecatedSchema/DeprecatedFlow.ts
+++ b/src/DeprecatedSchema/DeprecatedFlow.ts
@@ -1,0 +1,8 @@
+import { Flow as _Flow } from "./DeprecatedValues"
+
+export interface Flow {
+  /**
+   * TODO: Descriptor
+   */
+  flow: _Flow
+}

--- a/src/DeprecatedSchema/DeprecatedInteraction.ts
+++ b/src/DeprecatedSchema/DeprecatedInteraction.ts
@@ -1,0 +1,54 @@
+import { ActionName, ActionType } from "./DeprecatedValues"
+
+/**
+ * An interaction event is one that is triggered by a user in _some_ way. This
+ * could be either an active action, such as a click, or a passive action, such
+ * as hovering over a UI element.
+ *
+ * Some actions lead to results, such as following an artist, in which case the
+ * action name is used to tie the interaction and result events together.
+ */
+export interface Interaction {
+  /**
+   * The type of interaction that this event represents. E.g. `Click`.
+   *
+   * NOTE: In the old Force schema, this was the event’s name.
+   */
+  action_type: ActionType
+
+  /**
+   * In case the interaction will lead to a result, this should be the action
+   * name that will be used to associate the interaction to the result.
+   */
+  action_name?: ActionName
+
+  /**
+   * A description of the UI element that describes it inside the page/module.
+   * This is e.g. the label of the UI element.
+   */
+  subject?: string
+
+  /**
+   * In case of a link, the location that it points to.
+   *
+   * NOTE: This is old Force schema.
+   */
+  destination_path?: string
+
+  /*
+   * Flow
+   */
+  flow?: string
+}
+
+export interface AuthenticationInteraction extends Interaction {
+  /*
+   * The action taken that prompted user to signup or login.
+   */
+  intent?: string
+
+  /*
+   *  The type of action that triggered the modal (eg: click, timed)
+   */
+  trigger?: string
+}

--- a/src/DeprecatedSchema/DeprecatedLabel.ts
+++ b/src/DeprecatedSchema/DeprecatedLabel.ts
@@ -1,0 +1,13 @@
+import { Label as _Label } from "./DeprecatedValues"
+
+export interface Label {
+  /**
+   * The label of element being iteracted with
+   */
+  label: _Label
+
+  /**
+   * The notification count as seen in the NavBar
+   */
+  new_notification_count: string | number
+}

--- a/src/DeprecatedSchema/DeprecatedResult.ts
+++ b/src/DeprecatedSchema/DeprecatedResult.ts
@@ -1,0 +1,52 @@
+import { ActionName, OwnerType } from "./DeprecatedValues"
+
+/**
+ * The base interface for either a successful or failure event.
+ */
+interface Result {
+  /**
+   * The action name that will be used to tie this back to an interaction.
+   */
+  action_name: ActionName
+
+  /**
+   * The type of the entity that owns this result.
+   */
+  owner_type: OwnerType
+
+  /**
+   * The database ID of the entity. E.g. in the case of an entity that comes out
+   * of Gravity this should be its Mongo ID.
+   */
+  owner_id: string
+
+  /**
+   * The slug of the entity, if it has one.
+   */
+  owner_slug?: string
+}
+
+/**
+ * A successful result.
+ */
+export interface Success extends Result {
+  /**
+   * Used to identify the event as a success one.
+   */
+  result: "Success"
+}
+
+/**
+ * A failure result.
+ */
+export interface Failure extends Result {
+  /**
+   * Used to identify the event as a failure one.
+   */
+  result: "Failure"
+
+  /**
+   * The reason for the failure.
+   */
+  error: string
+}

--- a/src/DeprecatedSchema/DeprecatedType.ts
+++ b/src/DeprecatedSchema/DeprecatedType.ts
@@ -1,0 +1,8 @@
+import { Type as _Type } from "./DeprecatedValues"
+
+export interface Type {
+  /**
+   * Identifier of the type of element being clicked
+   */
+  type: _Type
+}

--- a/src/DeprecatedSchema/DeprecatedValues.ts
+++ b/src/DeprecatedSchema/DeprecatedValues.ts
@@ -1,0 +1,476 @@
+/**
+ * Pages that the user can view.
+ */
+export enum PageName {
+  ArticlePage = "Article",
+  ArtistPage = "Artist",
+  ArtistAuctionResults = "Artist Auction Results",
+  ArtworkPage = "Artwork page",
+  AuctionRegistrationPage = "Auction Registration page",
+  AuctionConfirmBidPage = "Auction Confirm Bid page",
+  CollectPage = "Collect page",
+  CollectionPage = "Collection",
+  SearchPage = "Search page",
+  HomePage = "Home",
+  IdentityVerificationPage = "Identity Verification page",
+}
+
+/**
+ * An entity in the data model that has an ownership relationship to the entity
+ * being described, be it a straightforward model such as ‘Artist’ or a more
+ * conceptual one like a ‘Consignment Submission’
+ *
+ * @see {Result.owner}
+ * @see {PageView.owner}
+ */
+export enum OwnerType {
+  Article = "Article",
+  Artist = "Artist",
+  Artwork = "Artwork",
+  Collection = "Collection",
+  Consignment = "ConsignmentSubmission",
+  Conversation = "Conversation",
+  Gene = "Gene",
+  Invoice = "Invoice",
+  Partner = "Partner",
+  Show = "Show",
+}
+
+/**
+ * User actions, which can be active or passive ones.
+ *
+ * TODO: Distinguishing between Click and Tap is a little confusing. Do we always
+ *       use Click on Force or do we use Tap when browsing from a mobile device?
+ */
+export enum ActionType {
+  /**
+   * A click on a UI element using a mouse-like input device.
+   *
+   * TODO: Check if ‘Tap’ and this can be combined.
+   */
+  Click = "Click",
+  ClickedBid = 'Clicked "Bid"',
+  /**
+   * A click on 'Buy Now' or 'Make offer' buttons.
+   */
+  ClickedBuyNow = "Clicked buy now",
+  ClickedConsign = "Clicked consign",
+  ClickedContactGallery = 'Clicked "Contact Gallery"',
+  ClickedMakeOffer = "Clicked make offer",
+
+  /**
+   * Triggers a pageview in force, skips segment
+   */
+  ClickedReadMore = "Clicked read more",
+
+  AuctionResultFilterParamChanged = "Auction results filter params changed",
+  AuctionResultItemClicked = "Auction result item clicked",
+
+  /**
+   * A/B Test Experiments
+   */
+  ExperimentViewed = "Experiment Viewed",
+
+  /**
+   * Moving the mouse pointer over a UI element or, when browsing on a mobile
+   * device, by first tapping the UI element once making it switch into
+   * continuous hover mode.
+   */
+  Hover = "Hover",
+
+  /**
+   * A UI element was rendered in the viewport
+   */
+  Impression = "Impression",
+  AuthImpression = "Auth impression",
+
+  /**
+   * A UI element that links out to another location
+   */
+  Link = "Link",
+
+  /**
+   * Auctions
+   */
+  ClickedRequestConditionReport = "Clicked request condition report",
+  ConfirmBidSubmitted = "Confirmed bid on bid page",
+  ConfirmBidFailed = "Confirm bid failed",
+  PlacedMaxBid = "Placed Max Bid",
+  RegisteredToBid = "Registered To Bid",
+  SelectedMaxBid = "Selected max bid",
+  ViewedLot = "Lot Viewed",
+
+  /**
+   * A tap on a UI element using a finger-like input device.
+   *
+   * TODO: Check if ‘Click’ and this can be combined.
+   */
+  Tap = "Tap",
+
+  /**
+   * BNMO
+   */
+  SubmittedOrder = "submitted_order",
+  SubmittedOffer = "submitted_offer",
+  SubmittedCounterOffer = "submitted_counter_offer",
+  FocusedOnOfferInput = "Focused on offer input",
+
+  /**
+   * Paid Marketing - Retargeting
+   */
+  ViewedProduct = "Product Viewed",
+
+  // MO speedbumps
+  ViewedOfferTooLow = "Viewed offer too low",
+  ViewedOfferHigherThanListPrice = "Viewed offer higher than listed price",
+
+  FocusedOnAutosuggestInput = "Focused on search input",
+  SelectedItemFromSearch = "Selected item from search",
+  SelectedItemFromSearchPage = "Selected item from search page",
+  SearchedAutosuggestWithResults = "Searched from header with results",
+  SearchedAutosuggestWithoutResults = "Searched from header with no results",
+
+  /**
+   * Auction Registration flow
+   */
+  RegistrationSubmitFailed = "Registration failed to submit",
+  RegistrationSubmitted = "Registration submitted",
+
+  /**
+   * Identity Verification
+   */
+  ClickedContinueToIdVerification = "ClickedContinueToIdVerification",
+
+  /**
+   * Viewing Room
+   */
+  ClickedArtworkGroup = "clickedArtworkGroup",
+  ClickedBuyViewingGroup = "clickedBuyViewingRoom",
+
+  /**
+   * Artwork Submission
+   */
+  SubmitAnotherArtwork = "submitAnotherArtwork",
+  ClickedFAQ = "clickedFAQ",
+}
+
+/**
+ * The identifier that ties an interaction to a result.
+ */
+export enum ActionName {
+  /**
+   * Artist Page
+   */
+  ArtistFollow = "artistFollow",
+  ArtistUnfollow = "artistUnfollow",
+  ArtworkAboutTheWork = "Artwork about the work",
+
+  /**
+   * Authentication
+   */
+  ViewEditorial = "viewed editorial",
+  Dismiss = "dismiss",
+  EmailNextButton = "emailNextButton",
+  PasswordNextButton = "passwordNextButton",
+
+  /**
+   * Gene Page
+   */
+  GeneFollow = "geneFollow",
+  GeneUnfollow = "geneUnfollow",
+
+  /**
+   * Home page events
+   */
+  HomeArtistRailFollow = "homeArtistRailFollow",
+  HomeArtistArtworksBlockFollow = "homeArtistArtworksBlockFollow",
+
+  /**
+   * Conversations / Inbox / Messaging
+   */
+  ConversationSendReply = "conversationSendReply",
+  ConversationLink = "conversationLinkUsed",
+  InquiryCancel = "inquiryCancel",
+  InquirySend = "inquirySend",
+
+  /**
+   *  Saves And Follows Events
+   */
+  SavesAndFollowsWorks = "savesAndFollowsWorks",
+  SavesAndFollowsArtists = "savesAndFollowsArtists",
+  SavesAndFollowsCategories = "savesAndFollowsCategories",
+
+  /**
+   *  Consignment flow
+   */
+  ConsignmentDraftCreated = "consignmentDraftCreated",
+  ConsignmentSubmitted = "consignmentSubmitted",
+  ConsignmentInterest = "Interested in selling a work learn more", // TODO: Old schema
+
+  /**
+   * Bid flow
+   */
+  BidFlowAddBillingAddress = "addBillingAddress",
+  BidFlowPlaceBid = "placeBid",
+  BidFlowSaveBillingAddress = "saveBillingAddress",
+
+  /**
+   * Generic
+   */
+  ReadMoreExpanded = "readMoreExpanded", // TODO: This differs from old event
+  InSale = "In current auction", // TODO: Old schema
+  InShow = "In featured show", // TODO: Old schema
+}
+
+/**
+ * Identifier of content that was interacted with
+ */
+export enum Subject {
+  /**
+   * Generic events
+   */
+  ClickedNextButton = "clicked next button",
+
+  /*
+   * Articles
+   * TODO: Old schema
+   */
+  FurtherReading = "Further reading",
+  ReadMore = "Read more",
+  RelatedArticles = "Related articles",
+
+  /**
+   * Buy now checkout flow
+   */
+  BNMOAskSpecialist = "ask a specialist",
+  BNMOReadFAQ = "Visit our help center",
+  BNMOProvideShipping = "provide shipping address",
+  BNMOArrangePickup = "arrange for pickup",
+  BNMOUseShippingAddress = "use shipping address",
+  BNMOAddBankAccount = "addBankAccount",
+  BNMOHelpEmail = "orders@artsy.net",
+  BNMOBankTransferNotifcationCheckbox = "notifyCheckboxChecked",
+  BNMOBankTransferModalDismissed = "modalDismissed",
+
+  AuctionConditionsOfSale = "conditions of sale",
+  AuctionFAQ = "auction faq",
+  AuctionAskSpecialist = "ask a specialist",
+  AuctionBuyerPremium = "Buyer premium",
+
+  CollectorFAQ = "Visit our help center",
+
+  ConsignLearnMore = "learn more",
+
+  /**
+   * Artist Page
+   */
+  GetStarted = "Get Started",
+
+  /**
+   * Artwork Page
+   */
+  Classification = "Classification info",
+  ContactGallery = "Contact Gallery",
+  EnterLiveAuction = "Enter live auction",
+  ShowArtistInsights = "Show artist insights",
+  HistogramBar = "Histogram Bar",
+  BrowseWorks = "Browse works in this category",
+  QuestionMarkIcon = "Question Mark Informational Icon",
+  RequestConditionReport = "Request condition report",
+
+  /**
+   * Header
+   */
+  NotificationBell = "Notification Bell",
+  Notification = "Notification",
+  ViewAll = "View All",
+  Login = "Log In",
+  Signup = "Sign Up",
+  SmallScreenMenuSandwichIcon = "Small Screen Menu Sandwich Icon",
+  EmailConfirmationCTA = "Email Confirmation CTA",
+  EmailConfirmationLinkExpired = "Email Confirmation Link Expired",
+
+  /**
+   * CollectionHub
+   */
+  FeaturedCategories = "Featured Categories",
+
+  /**
+   * Consignments
+   */
+  ExploreAuctionResults = "Explore Auction Results",
+  Here = "here",
+  RequestPriceEstimate = "Request a price estimate",
+  SubmitForReview = "Submit for review",
+  SubmitWorksInterestedInSelling = "submit works you’re interested in selling here",
+
+  /**
+   * Viewing Room
+   */
+  Rail = "Rail",
+  ViewWorks = "View works",
+  ArtworkThumbnail = "ArtworkThumbnail",
+  ViewingRoomArtworkDetail = "ViewingRoomArtworkDetail",
+}
+
+/**
+ * Identifier of a conceptual module on the page.
+ */
+export enum ContextModule {
+  Header = "Header",
+  NavigationTabs = "NavigationTabs",
+  FlashBanner = "FlashBanner",
+  RecentlyViewedArtworks = "recently_viewed_artworks",
+  HeaderMoreDropdown = "HeaderMoreDropdown",
+  HeaderUserDropdown = "HeaderUserDropdown",
+  HeaderActivityDropdown = "HeaderActivityDropdown",
+  HeaderArtworksDropdown = "HeaderArtworksDropdown",
+  HeaderArtistsDropdown = "HeaderArtistsDropdown",
+
+  /**
+   * Artist page
+   */
+  ArtistConsignment = "ArtistConsignment",
+  ArtistPage = "Artist page",
+  AboutTheWork = "About the work",
+  AboutTheWorkPartner = "About the Work (Partner)",
+  ArtworkFilter = "ArtworkFilter",
+  ArtistOverview = "ArtistOverview",
+  ArtistBio = "ArtistBio",
+  ArtistInsights = "ArtistInsights",
+  Biography = "Biography",
+  Sidebar = "Sidebar",
+  WorksForSale = "Works For Sale",
+
+  /**
+   * Artwork page
+   */
+  AboutTheWorkCondition = "About the work condition",
+  ArtworkPage = "Artwork page",
+  ArtworkTabs = "Artwork tabs",
+  OtherWorksByArtist = "Other works by artist",
+  OtherWorksInAuction = "Other works in auction",
+  OtherWorksInFair = "Other works in fair",
+  OtherWorksFromGallery = "Other works from gallery",
+  OtherWorksFromShow = "Other works from show",
+  RecommendedArtists = "Recommended Artists",
+  RelatedArtists = "RelatedArtists",
+  RelatedWorks = "RelatedWorks",
+  ShareButton = "Share button",
+  Zoom = "Zoom",
+  ViewInRoom = "View in room",
+  PriceContext = "Price Context",
+
+  /*
+   * Articles
+   * TODO: Old schema
+   */
+  FurtherReading = "Further reading",
+  ReadMore = "Read more",
+  RelatedArticles = "Related articles",
+
+  /**
+   * Buy Now Make Offer ("Works For You")
+   */
+  BNMOBanner = "BNMO Banner",
+
+  /**
+   * Collection page
+   */
+  CollectionDescription = "CollectionDescription",
+  ArtworkBanner = "ArtworkBanner",
+
+  /**
+   * Collections Rails
+   */
+  CollectionsRail = "CollectionsRail",
+
+  /**
+   * CollectionHub Entry Point in home page
+   */
+  CollectionHubEntryPoint = "HubEntrypoint",
+
+  /**
+   * Consignments
+   */
+  FAQ = "FAQ",
+  HowToSellYourCollection = "How to sell your collection with Artsy",
+  SellArtFromYourCollection = "Sell Art From Your Collection",
+  SellWorksBy = "Sell Works by",
+
+  /**
+   * Other Collections Rail
+   */
+  OtherCollectionsRail = "OtherCollectionsRail",
+
+  /**
+   * Featured Collections Rail
+   */
+  FeaturedCollectionsRail = "FeaturedCollectionsRail",
+
+  /**
+   * Artist Series rail in the collection hub
+   */
+  ArtistCollectionsRail = "ArtistCollectionsRail",
+
+  /**
+   * Ad Server
+   */
+  AdServer = "AdServer",
+
+  /**
+   * Art Keeps Going Campaign
+   */
+  FeaturedThisWeek = "FeaturedThisWeek",
+  Editorial = "Editorial",
+  SelectedWorks = "SelectedWorks",
+  FeaturedArtists = "FeaturedArtists",
+  BrowseCollections = "BrowseCollections",
+  BrowseAuctions = "BrowseAuctions",
+  BrowseFairs = "BrowseFairs",
+
+  /**
+   * Viewing Room
+   */
+  ViewingRoomArtworkRail = "viewingRoomArtworkRail",
+
+  /**
+   * Artwork Submission
+   */
+  ConsignSubmissionFlow = "consignSubmissionFlow",
+}
+
+export enum Flow {
+  ArtworkAboutTheWork = "Artwork about the work",
+  ArtworkAboutTheArtist = "Artwork about the artist",
+  ArtworkShare = "Artwork share",
+  ArtworkZoom = "Artwork zoom",
+  ArtworkViewInRoom = "Artwork view in room",
+  ArtworkPriceContext = "Artwork Price Context",
+  Auctions = "Auctions",
+  BuyNow = "Buy now",
+  Consignments = "Consignments",
+  MakeOffer = "Make offer",
+  Header = "Header",
+}
+
+export enum Label {
+  AboutTheWork = "about_the_work",
+  Articles = "articles",
+  Biography = "biography",
+  ExhibitionHighlights = "exhibition_highlights",
+  ReadMore = "ReadMore",
+}
+
+export enum Type {
+  ArtistCard = "Artist card",
+  ArtworkBrick = "Artwork brick",
+  Button = "Button",
+  Link = "Link",
+  Tab = "Tab",
+  Thumbnail = "thumbnail",
+  Chart = "Chart",
+  RadioButton = "radio button",
+  EmailLink = "email link",
+  ModalDismissal = "modal dismissal",
+}

--- a/src/DeprecatedSchema/index.ts
+++ b/src/DeprecatedSchema/index.ts
@@ -1,0 +1,63 @@
+/**
+ * TODO:
+ * - See if we can get rid of all the namespacing and transform before sending.
+ *   E.g. inside the `ContextPage` interface have just a `page` field that
+ *   transforms to `context_page`.
+ * - If the above gets done, we could also dry up the ‘owner’ in both
+ *   `ContextPage` and `Result`.
+ */
+
+export * from "./DeprecatedValues"
+
+import { Event } from "../Schema"
+import { AuctionInfo } from "./DeprecatedAuctionInfo"
+import { ContextModule } from "./DeprecatedContextModule"
+import { ContextPage } from "./DeprecatedContextPage"
+import { Flow } from "./DeprecatedFlow"
+import { AuthenticationInteraction, Interaction } from "./DeprecatedInteraction"
+import { Label } from "./DeprecatedLabel"
+import { Failure, Success } from "./DeprecatedResult"
+import { Type } from "./DeprecatedType"
+import { ActionType } from "./DeprecatedValues"
+
+interface Uncategorized {
+  changed: any
+  current: any
+  item_type: any
+  item_id: any
+  query: any
+  item_number: number
+  experiment_id: string
+  experiment_name: string
+  variation_id: string
+  variation_name: string
+  nonInteraction: number
+  action_type: ActionType | string
+}
+
+export type Trackables =
+  | AuthenticationInteraction
+  | ContextModule
+  | ContextPage
+  | Flow
+  | Interaction
+  | Label
+  | Success
+  | Failure
+  | Type
+  | Uncategorized
+  | AuctionInfo
+  | Event
+
+/**
+ * A sentinel type used to signal that anything goes in order to be able to
+ * support old Force schema.
+ *
+ * @example
+ *
+ *     ```ts
+ *     import * as Schema from "@artsy/cohesion"
+ *
+ *     @track({ … } as Schema.Old)
+ */
+export type Old = any

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -645,7 +645,7 @@ export interface ClickedOnFramedMeasurementsDropdown {
 }
 
 /**
- * A Partner clicks on one of the options (Accept collector's offer, Send a counteroffer, Decline collector's offer) 
+ * A Partner clicks on one of the options (Accept collector's offer, Send a counteroffer, Decline collector's offer)
  * for offers on the orders page on CMS.
  *
  * This schema describes events sent to Segment from [[clickedOfferActions]]
@@ -660,11 +660,11 @@ export interface ClickedOnFramedMeasurementsDropdown {
  *    label: "Accept collector's offer"
  *    artwork_id: "60de173a47476c000fd5c4cc"
  *    flow: offer
- *    partner_id: "60de173a47476c000fd5c4cc" 
+ *    partner_id: "60de173a47476c000fd5c4cc"
  *  }
  * ```
  */
- export interface ClickedOfferActions {
+export interface ClickedOfferActions {
   action: ActionType.clickedOfferActions
   context_module: ContextModule
   context_page_owner_type: PageOwnerType
@@ -674,7 +674,6 @@ export interface ClickedOnFramedMeasurementsDropdown {
   artwork_id: string
   flow: string
   partner_id: string
-
 }
 
 /**
@@ -682,7 +681,7 @@ export interface ClickedOnFramedMeasurementsDropdown {
  * - Confirm order
  * - Confirm shipping contact and confirm order
  * - Accept offer
- * - Confirm shipping contact and accept offer 
+ * - Confirm shipping contact and accept offer
  * - Decline offer
  * - Send a counter offer
  * - Confirm shipping contact and send counter offer
@@ -699,11 +698,11 @@ export interface ClickedOnFramedMeasurementsDropdown {
  *    label: "Confirm order"
  *    artwork_id: "60de173a47476c000fd5c4cc"
  *    flow: buy
- *    partner_id: "60de173a47476c000fd5c4cc" 
+ *    partner_id: "60de173a47476c000fd5c4cc"
  *  }
  * ```
  */
- export interface ClickedOrderPage {
+export interface ClickedOrderPage {
   action: ActionType.clickedOrderPage
   context_module: ContextModule
   context_page_owner_type: PageOwnerType
@@ -712,7 +711,7 @@ export interface ClickedOnFramedMeasurementsDropdown {
   label: string
   artwork_id: string
   flow: string
-  partner_id: string  
+  partner_id: string
 }
 
 /**

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -43,12 +43,14 @@ import {
   ClickedLoadMore,
   ClickedMainArtworkGrid,
   ClickedNavigationTab,
+  ClickedOfferActions,
   ClickedOfferOption,
   ClickedOnArtworkShippingUnitsDropdown,
   ClickedOnArtworkShippingWeight,
   ClickedOnFramedMeasurements,
   ClickedOnFramedMeasurementsDropdown,
   ClickedOnSubmitOrder,
+  ClickedOrderPage,
   ClickedPartnerCard,
   ClickedPartnerLink,
   ClickedPaymentDetails,
@@ -61,8 +63,6 @@ import {
   ClickedSnooze,
   ClickedVerifyIdentity,
   ClickedViewingRoomCard,
-  ClickedOfferActions,
-  ClickedOrderPage,
 } from "./Click"
 import {
   ArtworkDetailsCompleted,
@@ -514,11 +514,11 @@ export enum ActionType {
   /**
    * Corresponds to {@link ClickedOfferActions}
    */
-   clickedOfferActions = "clickedOfferActions",
-    /**
+  clickedOfferActions = "clickedOfferActions",
+  /**
    * Corresponds to {@link ClickedOrderPage}
    */
-  clickedOrderPage = "clickedOrderPage",   
+  clickedOrderPage = "clickedOrderPage",
   /**
    * Corresponds to {@link CommercialFilterParamsChanged}
    */


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

We're in the process of cleaning up Force and noticed that we still have a copy of pre-cohesion events located inside, effectively duplicating the source of truth. This moves the deprecated schema out of there and into here, under the `DeprecatedSchema` folder. 

When we're ready to refactor out completely from force, we can search for the DeprecatedSchema pattern and swap out with new. 