### PR TITLE
[AS-3324] Adding event for balance account check

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -821,6 +821,39 @@ export interface ClickedPaymentDetails {
   order_id: string
   subject: string
 }
+/**
+ * After choosing Bank Transfer, when user clicks on save & continue 
+ * on the payment page, the balance account is checked
+ *
+ *  This schema describes events sent 
+ * to Segment from [[clickedBalanceAccountCheck]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedBalanceAccountCheck",
+ *    flow: "Make Offer",
+ *    context_page_owner_type: "orders-payment",
+ *    order_id: "407dd09f-4afd-4aad-a6cc-1d6704dc2b11"
+ *    amount: 2000,
+ *    currency: "USD"
+ *    payment_method: "bank transfer"
+ *    subject: "balance account check"
+ *    outcome: "sucess"
+ *  }
+ * ```
+ */
+ export interface ClickedBalanceAccountCheck {
+  action: ActionType.clickedBalanceAccountCheck
+  flow: string
+  context_page_owner_type: string
+  order_id: string
+  amount: number
+  currency: string
+  payment_method: string
+  subject: string
+  outcome: string
+}
 
 /**
  *  User selects existing shipping address when entering the orders

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -831,7 +831,7 @@ export interface ClickedPaymentDetails {
  *  @example
  *  ```
  *  {
- *    action: "clickedBalanceAccountCheck",
+ *    action: "checkedAccountBalance",
  *    flow: "Make Offer",
  *    context_page_owner_type: "orders-payment",
  *    order_id: "407dd09f-4afd-4aad-a6cc-1d6704dc2b11"
@@ -843,8 +843,8 @@ export interface ClickedPaymentDetails {
  *  }
  * ```
  */
- export interface ClickedBalanceAccountCheck {
-  action: ActionType.clickedBalanceAccountCheck
+ export interface CheckedAccountBalance {
+  action: ActionType.checkedAccountBalance
   flow: string
   context_page_owner_type: string
   order_id: string

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -57,7 +57,7 @@ import {
   ClickedPartnerLink,
   ClickedPaymentDetails,
   ClickedPaymentMethod,
-  ClickedBalanceAccountCheck,
+  CheckedAccountBalance,
   ClickedPromoSpace,
   ClickedSelectShippingOption,
   ClickedShippingAddress,
@@ -196,7 +196,7 @@ export type Event =
   | ClickedPartnerLink
   | ClickedPaymentMethod
   | ClickedPaymentDetails
-  | ClickedBalanceAccountCheck
+  | CheckedAccountBalance
   | ClickedPromoSpace
   | ClickedRegisterToBid
   | ClickedSelectShippingOption
@@ -480,9 +480,9 @@ export enum ActionType {
   /**
    * Corresponds to {@link ClickedPaymentDetails}
    */
-   clickedBalanceAccountCheck = "clickedBalanceAccountCheck",
+   checkedAccountBalance = "checkedAccountBalance",
    /**
-    * Corresponds to {@link ClickedBalanceAccountCheck}
+    * Corresponds to {@link CheckedAccountBalance}
     */
   clickedPromoSpace = "clickedPromoSpace",
   /**

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -57,6 +57,7 @@ import {
   ClickedPartnerLink,
   ClickedPaymentDetails,
   ClickedPaymentMethod,
+  ClickedBalanceAccountCheck,
   ClickedPromoSpace,
   ClickedSelectShippingOption,
   ClickedShippingAddress,
@@ -195,6 +196,7 @@ export type Event =
   | ClickedPartnerLink
   | ClickedPaymentMethod
   | ClickedPaymentDetails
+  | ClickedBalanceAccountCheck
   | ClickedPromoSpace
   | ClickedRegisterToBid
   | ClickedSelectShippingOption
@@ -478,6 +480,10 @@ export enum ActionType {
   /**
    * Corresponds to {@link ClickedPaymentDetails}
    */
+   clickedBalanceAccountCheck = "clickedBalanceAccountCheck",
+   /**
+    * Corresponds to {@link ClickedBalanceAccountCheck}
+    */
   clickedPromoSpace = "clickedPromoSpace",
   /**
    * Corresponds to {@link ClickedRegisterToBid}


### PR DESCRIPTION

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [AS-3324]

### Description

The balance check is currently performed on the client side for the buyers, so that they can switch to a different payment method right away. 

We want to measure how many times buyers run into insufficient funds from the balance check on the client side.

 **How it works now?**

Check is performed for new accounts (saved accounts are not checked). When user clicks save&continue -> checks for balance depending on how fresh of the bank account balance is. The outcomes:

- Able to get back a fresh balance that is higher than price
- Able to get back a fresh balance that is lower than price
- We don’t know (bank cannot give fresh balance or cannot have balance in the 5 seconds)

Details [here](https://docs.google.com/spreadsheets/d/1mEwdJ71ts-MtY7vHKzCMPAePnC_OnlpL3i4VfwTpQjI/edit#gid=1731346450)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common `index.ts`
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[AS-3324]: https://artsyproduct.atlassian.net/browse/AS-3324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ