### PR TITLE
feat(FX-4209): add events for reverse image search

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -822,10 +822,10 @@ export interface ClickedPaymentDetails {
   subject: string
 }
 /**
- * After choosing Bank Transfer, when user clicks on save & continue 
+ * After choosing Bank Transfer, when user clicks on save & continue
  * on the payment page, the balance account is checked
  *
- *  This schema describes events sent 
+ *  This schema describes events sent
  * to Segment from [[clickedBalanceAccountCheck]]
  *
  *  @example
@@ -843,7 +843,7 @@ export interface ClickedPaymentDetails {
  *  }
  * ```
  */
- export interface CheckedAccountBalance {
+export interface CheckedAccountBalance {
   action: ActionType.checkedAccountBalance
   flow: string
   context_page_owner_type: string

--- a/src/Schema/Events/ReverseImageSearch.ts
+++ b/src/Schema/Events/ReverseImageSearch.ts
@@ -1,0 +1,165 @@
+import { ScreenOwnerType } from "../Values/OwnerType"
+import { ActionType } from "."
+
+/**
+ * Schema describing 'Reverse Image Search' events
+ * @packageDocumentation
+ */
+
+/**
+ * A user taps the reverse image search button on a fair or show screen
+ *
+ * This schema describes events sent to Segment from [[tappedReverseImageSearch]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedReverseImageSearch",
+ *    context_screen_owner_type: "reverseImageSearch",
+ *    owner_type: "fair",
+ *    owner_id: "6303add6f2f46c000d17c449",
+ *    owner_slug: "spring-slash-break-art-show-2022"
+ *  }
+ * ```
+ */
+export interface TappedReverseImageSearch {
+  action: ActionType.tappedReverseImageSearch
+  context_screen_owner_type: ScreenOwnerType
+  owner_type: ScreenOwnerType
+  owner_id?: string
+  owner_slug?: string
+}
+
+/**
+ * A user taps the flash button on the reverse image search camera screen
+ *
+ * This schema describes events sent to Segment from [[tappedToggleCameraFlash]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedToggleCameraFlash",
+ *    context_screen_owner_type: "reverseImageSearch"
+ *    owner_type: "fair",
+ *    owner_id: "6303add6f2f46c000d17c449",
+ *    owner_slug: "spring-slash-break-art-show-2022",
+ *  }
+ * ```
+ */
+export interface TappedToggleCameraFlash {
+  action: ActionType.tappedToggleCameraFlash
+  context_screen_owner_type: ScreenOwnerType
+  owner_type: ScreenOwnerType
+  owner_id?: string
+  owner_slug?: string
+}
+
+/**
+ * A user taps the library button on the reverse image search camera screen
+ *
+ * This schema describes events sent to Segment from [[tappedPickImageFromLibrary]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedPickImageFromLibrary",
+ *    context_screen_owner_type: "reverseImageSearch"
+ *    owner_type: "fair",
+ *    owner_id: "6303add6f2f46c000d17c449",
+ *    owner_slug: "spring-slash-break-art-show-2022",
+ *  }
+ * ```
+ */
+export interface TappedPickImageFromLibrary {
+  action: ActionType.tappedPickImageFromLibrary
+  context_screen_owner_type: ScreenOwnerType
+  owner_type: ScreenOwnerType
+  owner_id?: string
+  owner_slug?: string
+}
+
+/**
+ * A user searches with a reverse image query with results
+ *
+ * This schema describes events sent to Segment from [[searchedReverseImageWithResults]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "searchedReverseImageWithResults",
+ *    context_screen_owner_type: "reverseImageSearch",
+ *    owner_type: "fair",
+ *    owner_id: "6303add6f2f46c000d17c449",
+ *    owner_slug: "spring-slash-break-art-show-2022",
+ *    total_matches_count: 3
+ *    artwork_ids: "5f7190cc9e4a6f000d02085c,60b755f8052e35000f05820d,611ab14f3bb0e9000fc1a057"
+ *  }
+ * ```
+ */
+export interface searchedReverseImageWithResults {
+  action: ActionType.searchedReverseImageWithResults
+  context_screen_owner_type?: ScreenOwnerType
+  owner_type: ScreenOwnerType
+  owner_id?: string
+  owner_slug?: string
+  total_matches_count: number
+  artwork_ids: string
+}
+
+/**
+ * A user searches with a reverse image query with no results
+ *
+ * This schema describes events sent to Segment from [[searchedReverseImageWithNoResults]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "searchedReverseImageWithNoResults",
+ *    context_screen_owner_type: "reverseImageSearch",
+ *    owner_type: "fair",
+ *    owner_id: "6303add6f2f46c000d17c449",
+ *    owner_slug: "spring-slash-break-art-show-2022"
+ *  }
+ * ```
+ */
+export interface SearchedReverseImageWithNoResults {
+  action: ActionType.searchedReverseImageWithNoResults
+  context_screen_owner_type: ScreenOwnerType
+  owner_type: ScreenOwnerType
+  owner_id?: string
+  owner_slug?: string
+}
+
+/**
+ * A user selects an artwork from reverse image search results
+ *
+ * This schema describes events sent to Segment from [[selectedArtworkFromReverseImageSearch]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "selectedArtworkFromReverseImageSearch",
+ *    context_screen_owner_type: "reverseImageSearch",
+ *    destination_owner_type: "artwork",
+ *    destination_owner_id: "5f7190cc9e4a6f000d02085c",
+ *    destination_owner_slug: "kaarina-kaikkonen-i-no-longer-hear-you-singing",
+ *    owner_type: "fair",
+ *    owner_id: "6303add6f2f46c000d17c449",
+ *    owner_slug: "spring-slash-break-art-show-2022"
+ *    total_matches_count: 3,
+ *    position: 1
+ *  }
+ * ```
+ */
+export interface SelectedArtworkFromReverseImageSearch {
+  action: ActionType.selectedArtworkFromReverseImageSearch
+  context_screen_owner_type: ScreenOwnerType
+  destination_owner_type?: ScreenOwnerType
+  destination_owner_id?: string
+  destination_owner_slug?: string
+  owner_type: ScreenOwnerType
+  owner_id: string
+  owner_slug: string
+  total_matches_count: number
+  position: number
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -21,6 +21,7 @@ import {
   SuccessfullyLoggedIn,
 } from "./Authentication"
 import {
+  CheckedAccountBalance,
   ClickedAddNewShippingAddress,
   ClickedAddWorksToFair,
   ClickedAppDownload,
@@ -57,7 +58,6 @@ import {
   ClickedPartnerLink,
   ClickedPaymentDetails,
   ClickedPaymentMethod,
-  CheckedAccountBalance,
   ClickedPromoSpace,
   ClickedSelectShippingOption,
   ClickedShippingAddress,
@@ -98,6 +98,14 @@ import {
   TappedRequestPriceEstimate,
 } from "./MyCollection"
 import { PromptForReview } from "./PromptForReview"
+import {
+  SearchedReverseImageWithNoResults,
+  searchedReverseImageWithResults,
+  SelectedArtworkFromReverseImageSearch,
+  TappedPickImageFromLibrary,
+  TappedReverseImageSearch,
+  TappedToggleCameraFlash,
+} from "./ReverseImageSearch"
 import { DeletedSavedSearch, EditedSavedSearch } from "./SavedSearch"
 import { FollowEvents } from "./SavesAndFollows"
 import {
@@ -234,7 +242,10 @@ export type Event =
   | SaleScreenLoadComplete
   | Screen
   | SearchedPriceDatabase
+  | SearchedReverseImageWithNoResults
+  | searchedReverseImageWithResults
   | SearchedWithNoResults
+  | SelectedArtworkFromReverseImageSearch
   | SelectedItemFromSearch
   | SelectedItemFromPriceDatabaseSearch
   | SentConversationMessage
@@ -267,14 +278,17 @@ export type Event =
   | TappedMainArtworkGrid
   | TappedMakeOffer
   | TappedPartnerCard
+  | TappedPickImageFromLibrary
   | TappedPromoSpace
   | TappedRequestPriceEstimate
+  | TappedReverseImageSearch
   | TappedSell
   | TappedSellArtwork
   | TappedShowMore
   | TappedLearnMore
   | TappedSkip
   | TappedTabBar
+  | TappedToggleCameraFlash
   | TappedVerifyIdentity
   | TappedViewingRoomCard
   | TappedViewingRoomGroup
@@ -480,10 +494,10 @@ export enum ActionType {
   /**
    * Corresponds to {@link ClickedPaymentDetails}
    */
-   checkedAccountBalance = "checkedAccountBalance",
-   /**
-    * Corresponds to {@link CheckedAccountBalance}
-    */
+  checkedAccountBalance = "checkedAccountBalance",
+  /**
+   * Corresponds to {@link CheckedAccountBalance}
+   */
   clickedPromoSpace = "clickedPromoSpace",
   /**
    * Corresponds to {@link ClickedRegisterToBid}
@@ -658,9 +672,21 @@ export enum ActionType {
    */
   searchedPriceDatabase = "searchedPriceDatabase",
   /**
+   * Corresponds to {@link SearchedReverseImageWithNoResults}
+   */
+  searchedReverseImageWithNoResults = "searchedReverseImageWithNoResults",
+  /**
+   * Corresponds to {@link SearchedReverseImageWithResults}
+   */
+  searchedReverseImageWithResults = "searchedReverseImageWithResults",
+  /**
    * Corresponds to {@link SearchedWithNoResults}
    */
   searchedWithNoResults = "searchedWithNoResults",
+  /**
+   * Corresponds to {@link SelectedArtworkFromReverseImageSearch}
+   */
+  selectedArtworkFromReverseImageSearch = "selectedArtworkFromReverseImageSearch",
   /**
    * Corresponds to {@link SelectedItemFromSearch}
    */
@@ -806,6 +832,10 @@ export enum ActionType {
    */
   tappedPartnerCard = "tappedPartnerCard",
   /**
+   * Corresponds to {@link TappedPickImageFromLibrary}
+   */
+  tappedPickImageFromLibrary = "tappedPickImageFromLibrary",
+  /**
    * Corresponds to {@link TappedPromoSpace}
    */
   tappedPromoSpace = "tappedPromoSpace",
@@ -817,6 +847,10 @@ export enum ActionType {
    * Corresponds to {@link TappedRequestPriceEstimate}
    */
   tappedRequestPriceEstimate = "tappedRequestPriceEstimate",
+  /**
+   * Corresponds to {@link TappedReverseImageSearch}
+   */
+  tappedReverseImageSearch = "tappedReverseImageSearch",
   /**
    * Corresponds to {@link TappedSell}
    */
@@ -841,6 +875,10 @@ export enum ActionType {
    * Corresponds to {@link TappedTabBar}
    */
   tappedTabBar = "tappedTabBar",
+  /**
+   * Corresponds to {@link TappedToggleCameraFlash}
+   */
+  tappedToggleCameraFlash = "tappedToggleCameraFlash",
   /**
    * Corresponds to {@link TappedVerifyIdentity}
    */

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -60,6 +60,7 @@ export enum OwnerType {
   partnerShowsArtworks = "partnerShowsArtworks",
   priceDatabase = "priceDatabase",
   profile = "profile",
+  reverseImageSearch = "reverseImageSearch",
   sale = "sale",
   saleInformation = "saleInformation",
   savedSearch = "savedSearch",


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [FX-4209]

### Changes
* Added reverse image events
* Added `reverseImageSearch` screen owner type

### Added events
* `tappedReverseImageSearch`
* `tappedToggleCameraFlash`
* `tappedPickImageFromLibrary`
* `searchedReverseImageWithResults`
* `searchedReverseImageWithNoResults`
* `selectedArtworkFromReverseImageSearch`


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common `index.ts`
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
