### PR TITLE
feat(FX-4379): Activity Panel tracking events

### DIFF
--- a/src/Schema/Events/ActivityPanel.ts
+++ b/src/Schema/Events/ActivityPanel.ts
@@ -1,0 +1,64 @@
+/**
+ * Schema describing Activity Panel related events
+ * @packageDocumentation
+ */
+
+import { ActionType } from "."
+
+/**
+ * A user clicked on a notifications bell.
+ *
+ * This schema describes events sent to Segment from [[clickedNotificationsBell]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedNotificationsBell",
+ *    user_id: "5bd8b675776bd6002c86526c"
+ *  }
+ * ```
+ */
+export interface ClickedNotificationsBell {
+  action: ActionType.clickedNotificationsBell
+  user_id: string
+}
+
+/**
+ * A user clicked on a notification in Activity Panel.
+ *
+ * This schema describes events sent to Segment from [[clickedActivityPanelNotificationItem]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedActivityPanelNotificationItem",
+ *    user_id: "5bd8b675776bd6002c86526c",
+ *    notification_type: "ARTWORK_ALERT"
+ *  }
+ * ```
+ */
+export interface ClickedActivityPanelNotificationItem {
+  action: ActionType.clickedActivityPanelNotificationItem
+  user_id: string
+  notification_type: string
+}
+
+/**
+ * A user clicked on a tab in Activity Panel.
+ *
+ * This schema describes events sent to Segment from [[clickedActivityPanelTab]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedActivityPanelTab",
+ *    user_id: "5bd8b675776bd6002c86526c",
+ *    tab_name: "Alerts"
+ *  }
+ * ```
+ */
+export interface ClickedActivityPanelTab {
+  action: ActionType.clickedActivityPanelTab
+  user_id: string
+  tab_name: string
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -1,5 +1,10 @@
 import { AddToCalendar } from "./AddToCalendar"
 import {
+  ClickedActivityPanelNotificationItem,
+  ClickedActivityPanelTab,
+  ClickedNotificationsBell
+} from "./ActivityPanel"
+import {
   AuctionPageView,
   BidPageView,
   ClickedActiveBid,
@@ -176,6 +181,8 @@ export type Event =
   | BidPageView
   | CreatedAccount
   | ClickedActiveBid
+  | ClickedActivityPanelNotificationItem
+  | ClickedActivityPanelTab
   | ClickedAddNewShippingAddress
   | ClickedAddWorksToFair
   | ClickedAppDownload
@@ -200,6 +207,7 @@ export type Event =
   | ClickedLoadMore
   | ClickedMainArtworkGrid
   | ClickedNavigationTab
+  | ClickedNotificationsBell
   | ClickedOfferOption
   | ClickedOnArtworkShippingWeight
   | ClickedOnArtworkShippingUnitsDropdown
@@ -355,6 +363,14 @@ export enum ActionType {
    */
   clickedActiveBid = "clickedActiveBid",
   /**
+   * Corresponds to {@link ClickedActivityPanelNotificationItem}
+   */
+  clickedActivityPanelNotificationItem = "clickedActivityPanelNotificationItem",
+  /**
+   * Corresponds to {@link ClickedActivityPanelTab}
+   */
+  clickedActivityPanelTab = "clickedActivityPanelTab",
+  /**
    * Corresponds to {@link ClickedAddNewShippingAddress}
    */
   clickedAddNewShippingAddress = "clickedAddNewShippingAddress",
@@ -458,6 +474,10 @@ export enum ActionType {
    * Corresponds to {@link ClickedNavigationTab}
    */
   clickedNavigationTab = "clickedNavigationTab",
+  /**
+   * Corresponds to {@link ClickedNotificationsBell}
+   */
+  clickedNotificationsBell = "clickedNotificationsBell",
   /**
    * Corresponds to {@link ClickedOfferActions}
    */


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [FX-4379]

### Description

Adds tracking events for activity panel:

- Clicks on the notification Bell 
- Clicks on tabs
- Clicks on individual notifications 
 
### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[FX-4379]: https://artsyproduct.atlassian.net/browse/FX-4379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ