### PR TITLE
feat(CX-3066): Add MyC Insights web tracking events

### DIFF
--- a/src/Schema/Events/MyCollectionInsights.ts
+++ b/src/Schema/Events/MyCollectionInsights.ts
@@ -8,6 +8,32 @@ import { ActionType } from "."
  */
 
 /**
+ * A user clicks on My Collection Insights Median Auction Rail item.
+ *
+ * This schema describes events sent to Segment from [[clickedMyCollectionInsightsMedianAuctionRailItem]]
+ *
+ * @example
+ *  ```
+ *  {
+ *    action: "clickedMyCollectionInsightsMedianAuctionRailItem",
+ *    context_module: "myCollectionInsightsMedianAuctionRail",
+ *    context_screen: "myCollectionInsights",
+ *    context_screen_owner_type: "myCollectionInsights",
+ *    artist_id: "4212691337420",
+ *    category: "Print"
+ *  }
+ * ```
+ */
+export interface ClickedMyCollectionInsightsMedianAuctionRailItem {
+  action: ActionType.clickedMyCollectionInsightsMedianAuctionRailItem
+  context_module: ContextModule.myCollectionInsightsMedianAuctionRail
+  context_screen: OwnerType.myCollectionInsights
+  context_screen_owner_type: OwnerType.myCollectionInsights
+  artist_id: string
+  category: string
+}
+
+/**
  * A user taps on the MyCollectionInsightsMedianAuctionRailItem
  *
  * This schema describes events sent to Segment from [[tappedMyCollectionInsightsMedianAuctionRailItem]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -455,6 +455,10 @@ export enum ActionType {
    */
   clickedMainArtworkGrid = "clickedMainArtworkGrid",
   /**
+   * Corresponds to {@link ClickedMyCollectionInsightsMedianAuctionRailItem}
+   */
+  clickedMyCollectionInsightsMedianAuctionRailItem = "clickedMyCollectionInsightsMedianAuctionRailItem",
+  /**
    * Corresponds to {@link ClickedNavigationTab}
    */
   clickedNavigationTab = "clickedNavigationTab",


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-3066]

### Description
This PR adds `ClickedMyCollectionInsightsMedianAuctionRailItem` event to My Collection Insights events for the web

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[CX-3066]: https://artsyproduct.atlassian.net/browse/CX-3066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ