### PR TITLE
refactor: remove unused `user_id` field for `ActivityPanel` events

### DIFF
--- a/src/Schema/Events/ActivityPanel.ts
+++ b/src/Schema/Events/ActivityPanel.ts
@@ -13,14 +13,12 @@ import { ActionType } from "."
  *  @example
  *  ```
  *  {
- *    action: "clickedNotificationsBell",
- *    user_id: "5bd8b675776bd6002c86526c"
+ *    action: "clickedNotificationsBell"
  *  }
  * ```
  */
 export interface ClickedNotificationsBell {
   action: ActionType.clickedNotificationsBell
-  user_id: string
 }
 
 /**
@@ -32,14 +30,12 @@ export interface ClickedNotificationsBell {
  *  ```
  *  {
  *    action: "clickedActivityPanelNotificationItem",
- *    user_id: "5bd8b675776bd6002c86526c",
  *    notification_type: "ARTWORK_ALERT"
  *  }
  * ```
  */
 export interface ClickedActivityPanelNotificationItem {
   action: ActionType.clickedActivityPanelNotificationItem
-  user_id: string
   notification_type: string
 }
 
@@ -52,13 +48,11 @@ export interface ClickedActivityPanelNotificationItem {
  *  ```
  *  {
  *    action: "clickedActivityPanelTab",
- *    user_id: "5bd8b675776bd6002c86526c",
  *    tab_name: "Alerts"
  *  }
  * ```
  */
 export interface ClickedActivityPanelTab {
   action: ActionType.clickedActivityPanelTab
-  user_id: string
   tab_name: string
 }

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -1,9 +1,9 @@
-import { AddToCalendar } from "./AddToCalendar"
 import {
   ClickedActivityPanelNotificationItem,
   ClickedActivityPanelTab,
-  ClickedNotificationsBell
+  ClickedNotificationsBell,
 } from "./ActivityPanel"
+import { AddToCalendar } from "./AddToCalendar"
 import {
   AuctionPageView,
   BidPageView,


### PR DESCRIPTION
The type of this PR is: **Refactor**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->
Initial PR: artsy/cohesion#356

### Description
Remove unused `user_id` field from `ActivityPanel` events

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
