### PR TITLE
feat(CX-3105): Tracking for ContactInformation SWA step

### DIFF
--- a/src/Schema/Events/Consignments.ts
+++ b/src/Schema/Events/Consignments.ts
@@ -80,7 +80,33 @@ export interface UploadPhotosCompleted {
   action: ActionType.uploadPhotosCompleted
   context_module: ContextModule.uploadPhotos
   context_owner_type: OwnerType.consignmentFlow
-  submission_id: string
+  submission_id?: string
+  user_email: string
+  user_id?: string
+}
+
+/**
+ * First or Final step of the consignment submission flow; user provides their contact information.
+ *
+ * This schema describes events sent to Segment from [[contactInformation]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "contactInformationCompleted",
+ *    context_module: "contactInformation",
+ *    context_owner_type: "consignmentFlow",
+ *    submission_id: "52521",
+ *    user_email: "kieranmbh@gmail.com"
+ *    user_id: "5cd6b173746be6109c86321d"
+ *  }
+ * ```
+ */
+ export interface ContactInformationCompleted {
+  action: ActionType.contactInformationCompleted
+  context_module: ContextModule.contactInformation
+  context_owner_type: OwnerType.consignmentFlow
+  submission_id?: string // submission_id may be undefined if this is the first step in submission flow
   user_email: string
   user_id?: string
 }

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -75,6 +75,7 @@ import {
 import {
   ArtworkDetailsCompleted,
   ConsignmentSubmitted,
+  ContactInformationCompleted,
   SubmitAnotherArtwork,
   UploadPhotosCompleted,
   ViewArtworkMyCollection,
@@ -237,6 +238,7 @@ export type Event =
   | ConfirmRegistrationPageview
   | ConsignmentArtistFailed
   | ConsignmentSubmitted
+  | ContactInformationCompleted
   | DeleteCollectedArtwork
   | DeletedSavedSearch
   | EditCollectedArtwork


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-3105]

### Description

<!-- Implementation description -->
- With dynamic ordering of submission steps, this PR adds support to track ContactInformation step independently from ConsignmentSubmitted since ContactInformation step can now be the first step.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[CX-3105]: https://artsyproduct.atlassian.net/browse/CX-3105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ