### PR TITLE
feat(FX-4446): track tap on curated collection on search tab

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -293,6 +293,26 @@ export interface TappedConsign {
 }
 
 /**
+ * A user taps on an Artsy curated collection on a search tab
+ *
+ * This schema describes events sent to Segment from [[tappedCuratedCollection]]
+ *
+ * @example
+ * ```
+ * {
+ *   action: "tappedCuratedCollection",
+ *   context_module: "searchTab",
+ *   slug: "trending-this-week"
+ * }
+ * ```
+ */
+export interface TappedCuratedCollection {
+  action: ActionType.tappedCuratedCollection
+  context_module: ContextModule.searchTab
+  collection_slug: string
+}
+
+/**
  * A user taps a fair card
  *
  * This schema describes events sent to Segment from [[tappedFairCard]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -152,6 +152,7 @@ import {
   TappedConsign,
   TappedContactGallery,
   TappedCreateAlert,
+  TappedCuratedCollection,
   TappedExploreGroup,
   TappedFairCard,
   TappedFairGroup,
@@ -296,6 +297,7 @@ export type Event =
   | TappedConsign
   | TappedContactGallery
   | TappedCreateAlert
+  | TappedCuratedCollection
   | TappedExploreGroup
   | TappedExploreMyCollection
   | TappedFairCard
@@ -846,6 +848,10 @@ export enum ActionType {
    * Corresponds to {@link TappedCreateAlert}
    */
   tappedCreateAlert = "tappedCreateAlert",
+  /**
+   * Corresponds to {@link TappedCuratedCollection}
+   */
+  tappedCuratedCollection = "tappedCuratedCollection",
   /**
    * Corresponds to {@link TappedExploreGroup}
    */

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -148,6 +148,7 @@ export enum ContextModule {
   relatedCollectionsRail = "relatedCollectionsRail",
   relatedWorksRail = "relatedWorksRail",
   saveWorksCTA = "saveWorksCTA",
+  searchTab = "searchTab",
   sellFooter = "sellFooter",
   sellHeader = "sellHeader",
   showHeader = "showHeader",


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [FX-4446]

### Description

We are introducing a new section "Artsy Curated Collections" to a search tab. This PR adds tracking event for a tap on an Artsy curated collection in search tab.

![Screenshot 2022-11-18 at 12 08 12](https://user-images.githubusercontent.com/3934579/202691856-29398e8f-e51d-4f45-9b7c-791116089149.png)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
