### PR TITLE
feat: add SelectedRecentPriceRange event for price filter

### DIFF
--- a/src/Schema/Events/FilterAndSort.ts
+++ b/src/Schema/Events/FilterAndSort.ts
@@ -85,3 +85,25 @@ export interface PriceDatabaseFilterParamsChanged {
   current: string
   changed: string
 }
+
+/**
+ * A user selects a recent price range from the price filter screen
+ *
+ * This schema describes events sent to Segment from [[selectedRecentPriceRange]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "selectedRecentPriceRange",
+ *    context_module: "recentPriceRanges",
+ *    context_screen_owner_type: "artworkPriceFilter",
+ *    collector_profile_sourced: true
+ *  }
+ * ```
+ */
+export interface SelectedRecentPriceRange {
+  action: ActionType.selectedRecentPriceRange
+  context_module: ContextModule.recentPriceRanges
+  context_screen_owner_type: OwnerType.artworkPriceFilter
+  collector_profile_sourced: boolean 
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -93,6 +93,7 @@ import {
   AuctionResultsFilterParamsChanged,
   CommercialFilterParamsChanged,
   PriceDatabaseFilterParamsChanged,
+  SelectedRecentPriceRange,
 } from "./FilterAndSort"
 import {
   MyCollectionOnboardingCompleted,
@@ -277,6 +278,7 @@ export type Event =
   | SelectedArtworkFromReverseImageSearch
   | SelectedItemFromSearch
   | SelectedItemFromPriceDatabaseSearch
+  | SelectedRecentPriceRange
   | SentConversationMessage
   | SentRequestPriceEstimate
   | Share
@@ -764,6 +766,10 @@ export enum ActionType {
    * Corresponds to {@link SelectedItemFromSearch}
    */
   selectedItemFromSearch = "selectedItemFromSearch",
+  /**
+   * Corresponds to {@link SelectedRecentPriceRange}
+   */
+  selectedRecentPriceRange = "selectedRecentPriceRange",
   /**
    * Corresponds to {@link sentArtworkInquiry}
    */

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -142,6 +142,7 @@ export enum ContextModule {
   pushNotifications = "pushNotifications",
   recentlySavedRail = "recentlySavedRail",
   recentlyViewedRail = "recentlyViewedRail",
+  recentPriceRanges = "recentPriceRanges",
   recommendedArtistsRail = "recommendedArtistsRail",
   recommendedWorksForYouRail = "recommendedWorksForYouRail",
   relatedArticles = "relatedArticles",
@@ -245,6 +246,7 @@ export type AuthContextModule =
   | ContextModule.presentingPartner
   | ContextModule.priceEstimate
   | ContextModule.recentlyViewedRail
+  | ContextModule.recentPriceRanges
   | ContextModule.recommendedArtistsRail
   | ContextModule.relatedArtistsRail
   | ContextModule.relatedWorksRail

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -12,6 +12,7 @@ export enum OwnerType {
   artists = "artists",
   artistSeries = "artistSeries",
   artwork = "artwork",
+  artworkPriceFilter = "artworkPriceFilter",
   auction = "auction",
   auctionResult = "auctionResult",
   auctionResultsForArtistsYouFollow = "auctionResultsForArtistsYouFollow",
@@ -93,6 +94,7 @@ export type ScreenOwnerType =
   | OwnerType.artistAuctionResults
   | OwnerType.artistSeries
   | OwnerType.artwork
+  | OwnerType.artworkPriceFilter
   | OwnerType.auctionResult
   | OwnerType.auctionResultsForArtistsYouFollow
   | OwnerType.auctions


### PR DESCRIPTION
This commits adds a new event to track when a user engages with a new feature in the mobile app — allowing users to quickly select a previously selected price range in the artwork grid price filter screen. This list will also include a price range persisted on a user's collector profile, if available.

Example:

```typescript
{
  action: "selectedRecentPriceRange",
  context_module: "recentPriceRanges",
  context_screen_owner_type: "artworkPriceFilter",
  collector_profile_sourced: true
}
```