### PR TITLE
chore(FX-4453): add `TappedTrendingArtist` event

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -252,6 +252,7 @@ export interface TappedEntityGroup {
     | ActionType.tappedExploreGroup
     | ActionType.tappedFairGroup
     | ActionType.tappedViewingRoomGroup
+    | ActionType.tappedTrendingArtist
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id?: string
@@ -522,9 +523,9 @@ export interface TappedTabBar {
 }
 
 /**
- * A user taps on a trending artist on a search tab
+ * A user taps a trending artist
  *
- * This schema describes events sent to Segment from [[TappedTrendingArtist]]
+ * This schema describes events sent to Segment from [[tappedTrendingArtist]]
  *
  *  @example
  *  ```
@@ -532,21 +533,15 @@ export interface TappedTabBar {
  *    action: "tappedTrendingArtist",
  *    context_module: "trendingArtistsRail",
  *    context_screen_owner_type: "search",
- *    destination_screen_owner_type: "artist",
- *    destination_screen_owner_slug: "banksy",
  *    destination_screen_owner_id: "4dd1584de0091e000100207c",
- *    position: 0
+ *    destination_screen_owner_slug: "banksy",
+ *    destination_screen_owner_type: "artist",
+ *    horizontal_slide_position: 0
  *  }
  * ```
  */
-export interface TappedTrendingArtist {
+export interface TappedTrendingArtist extends TappedEntityGroup {
   action: ActionType.tappedTrendingArtist
-  context_module: ContextModule.trendingArtistsRail
-  context_screen_owner_type: OwnerType.search
-  destination_screen_owner_type: OwnerType.artist
-  destination_screen_owner_slug: string
-  destination_screen_owner_id: string
-  position: number
 }
 
 /**

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -522,6 +522,34 @@ export interface TappedTabBar {
 }
 
 /**
+ * A user taps on a trending artist on a search tab
+ *
+ * This schema describes events sent to Segment from [[TappedTrendingArtist]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedTrendingArtist",
+ *    context_module: "trendingArtistsRail",
+ *    context_screen_owner_type: "search",
+ *    destination_screen_owner_type: "artist",
+ *    destination_screen_owner_slug: "banksy",
+ *    destination_screen_owner_id: "4dd1584de0091e000100207c",
+ *    position: 0
+ *  }
+ * ```
+ */
+export interface TappedTrendingArtist {
+  action: ActionType.tappedTrendingArtist
+  context_module: ContextModule.trendingArtistsRail
+  context_screen_owner_type: OwnerType.search
+  destination_screen_owner_type: OwnerType.artist
+  destination_screen_owner_slug: string
+  destination_screen_owner_id: string
+  position: number
+}
+
+/**
  * A user taps a grouping of viewing rooms on iOS
  *
  * This schema describes events sent to Segment from [[tappedEntityGroup]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -169,6 +169,7 @@ import {
   TappedShowMore,
   TappedSkip,
   TappedTabBar,
+  TappedTrendingArtist,
   TappedVerifyIdentity,
   TappedViewingRoomCard,
   TappedViewingRoomGroup,
@@ -326,6 +327,7 @@ export type Event =
   | TappedSkip
   | TappedTabBar
   | TappedToggleCameraFlash
+  | TappedTrendingArtist
   | TappedVerifyIdentity
   | TappedViewingRoomCard
   | TappedViewingRoomGroup
@@ -974,6 +976,10 @@ export enum ActionType {
    * Corresponds to {@link TappedToggleCameraFlash}
    */
   tappedToggleCameraFlash = "tappedToggleCameraFlash",
+  /**
+   * Corresponds to {@link TappedTrendingArtist}
+   */
+  tappedTrendingArtist = "tappedTrendingArtist",
   /**
    * Corresponds to {@link TappedUploadAnotherArtwork}
    */


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-4453]

### Description
This PR adds tracking event for a tap on a trending artist in search tab.

<img width="257" alt="Fix it Sprint – Figma 2022-11-25 12-55-14" src="https://user-images.githubusercontent.com/3513494/203954275-b7dad023-1fc7-40d5-9802-4047055c5f09.png">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[FX-4453]: https://artsyproduct.atlassian.net/browse/FX-4453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ