### PR TITLE
refactor: remove unused code

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -252,7 +252,6 @@ export interface TappedEntityGroup {
     | ActionType.tappedExploreGroup
     | ActionType.tappedFairGroup
     | ActionType.tappedViewingRoomGroup
-    | ActionType.tappedTrendingArtist
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id?: string
@@ -291,34 +290,6 @@ export interface TappedConsign {
   destination_screen_owner_type: ScreenOwnerType
   /** The text of the tapped button */
   subject: string
-}
-
-/**
- * A user taps on an Artsy curated collection on a search tab
- *
- * This schema describes events sent to Segment from [[tappedCuratedCollection]]
- *
- * @example
- * ```
- * {
- *   action: "tappedCuratedCollection",
- *   context_module: "curatedCollections",
- *   context_screen_owner_type: "search",
- *   destination_screen_owner_type: "collection",
- *   destination_screen_owner_slug: "trending-this-week",
- *   destination_screen_owner_id: "d78e9a17-ccf6-4104-b4e9-95c18f6412df",
- *   position: 1
- * }
- * ```
- */
-export interface TappedCuratedCollection {
-  action: ActionType.tappedCuratedCollection
-  context_module: ContextModule.curatedCollections
-  context_screen_owner_type: ScreenOwnerType
-  destination_screen_owner_type: ScreenOwnerType
-  destination_screen_owner_slug: string
-  destination_screen_owner_id: string
-  position: number
 }
 
 /**
@@ -520,28 +491,6 @@ export interface TappedTabBar {
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
   tab: Tab
-}
-
-/**
- * A user taps a trending artist
- *
- * This schema describes events sent to Segment from [[tappedTrendingArtist]]
- *
- *  @example
- *  ```
- *  {
- *    action: "tappedTrendingArtist",
- *    context_module: "trendingArtistsRail",
- *    context_screen_owner_type: "search",
- *    destination_screen_owner_id: "4dd1584de0091e000100207c",
- *    destination_screen_owner_slug: "banksy",
- *    destination_screen_owner_type: "artist",
- *    horizontal_slide_position: 0
- *  }
- * ```
- */
-export interface TappedTrendingArtist extends TappedEntityGroup {
-  action: ActionType.tappedTrendingArtist
 }
 
 /**

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -153,7 +153,6 @@ import {
   TappedConsign,
   TappedContactGallery,
   TappedCreateAlert,
-  TappedCuratedCollection,
   TappedExploreGroup,
   TappedFairCard,
   TappedFairGroup,
@@ -169,7 +168,6 @@ import {
   TappedShowMore,
   TappedSkip,
   TappedTabBar,
-  TappedTrendingArtist,
   TappedVerifyIdentity,
   TappedViewingRoomCard,
   TappedViewingRoomGroup,
@@ -300,7 +298,6 @@ export type Event =
   | TappedConsign
   | TappedContactGallery
   | TappedCreateAlert
-  | TappedCuratedCollection
   | TappedExploreGroup
   | TappedExploreMyCollection
   | TappedFairCard
@@ -327,7 +324,6 @@ export type Event =
   | TappedSkip
   | TappedTabBar
   | TappedToggleCameraFlash
-  | TappedTrendingArtist
   | TappedVerifyIdentity
   | TappedViewingRoomCard
   | TappedViewingRoomGroup
@@ -857,10 +853,6 @@ export enum ActionType {
    */
   tappedCreateAlert = "tappedCreateAlert",
   /**
-   * Corresponds to {@link TappedCuratedCollection}
-   */
-  tappedCuratedCollection = "tappedCuratedCollection",
-  /**
    * Corresponds to {@link TappedExploreGroup}
    */
   tappedExploreGroup = "tappedExploreGroup",
@@ -976,10 +968,6 @@ export enum ActionType {
    * Corresponds to {@link TappedToggleCameraFlash}
    */
   tappedToggleCameraFlash = "tappedToggleCameraFlash",
-  /**
-   * Corresponds to {@link TappedTrendingArtist}
-   */
-  tappedTrendingArtist = "tappedTrendingArtist",
   /**
    * Corresponds to {@link TappedUploadAnotherArtwork}
    */


### PR DESCRIPTION
The type of this PR is: **Refactor**

<!-- Bugfix/Feature/Enhancement/Documentation -->

### Description
We decided to use:
* `tappedArtistGroup` instead of `tappedTrendingArtist`
* `tappedCollectionGroup` instead of `tappedCuratedCollection`

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
