### PR TITLE
chore(CX-3187): add exceeded upload size event type

### DIFF
--- a/src/Schema/Events/ExceededUploadSize.ts
+++ b/src/Schema/Events/ExceededUploadSize.ts
@@ -1,0 +1,29 @@
+import { OwnerType } from "../Values/OwnerType"
+import { ActionType } from "."
+
+/**
+ * Schemas describing events for specific user experience design types.
+ * @packageDocumentation
+ */
+
+/**
+ * User has exceeded the upload size limit
+ *
+ * This schema describes events sent to Segment from [[exceededUploadSize]].
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "exceededUploadSize",
+ *    context_owner_type: "sell",
+ *    upload_size_in_kb: 30134512,
+ *    expand: TRUE
+ *  }
+ * ```
+ */
+export interface ExceededUploadSize {
+  action: ActionType.exceededUploadSize
+  context_owner_type: OwnerType
+  upload_size_in_kb: number
+  number_of_files: number
+}

--- a/src/Schema/Events/FilterAndSort.ts
+++ b/src/Schema/Events/FilterAndSort.ts
@@ -105,5 +105,5 @@ export interface SelectedRecentPriceRange {
   action: ActionType.selectedRecentPriceRange
   context_module: ContextModule.recentPriceRanges
   context_screen_owner_type: OwnerType.artworkPriceFilter
-  collector_profile_sourced: boolean 
+  collector_profile_sourced: boolean
 }

--- a/src/Schema/Events/UploadSizeLimitExceeded.ts
+++ b/src/Schema/Events/UploadSizeLimitExceeded.ts
@@ -9,20 +9,20 @@ import { ActionType } from "."
 /**
  * User has exceeded the upload size limit
  *
- * This schema describes events sent to Segment from [[exceededUploadSize]].
+ * This schema describes events sent to Segment from [[uploadSizeLimitExceeded]].
  *
  *  @example
  *  ```
  *  {
- *    action: "exceededUploadSize",
+ *    action: "uploadSizeLimitExceeded",
  *    context_owner_type: "sell",
  *    upload_size_in_kb: 30134512,
  *    expand: TRUE
  *  }
  * ```
  */
-export interface ExceededUploadSize {
-  action: ActionType.exceededUploadSize
+export interface UploadSizeLimitExceeded {
+  action: ActionType.uploadSizeLimitExceeded
   context_owner_type: OwnerType
   upload_size_in_kb: number
   number_of_files: number

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -88,7 +88,6 @@ import {
   TappedMakeOffer,
   TappedViewOffer,
 } from "./Conversations"
-import { ExceededUploadSize } from "./ExceededUploadSize"
 import { ExperimentViewed } from "./ExperimentViewed"
 import {
   AuctionResultsFilterParamsChanged,
@@ -174,6 +173,7 @@ import {
   TappedViewingRoomGroup,
 } from "./Tap"
 import { ToggledNotification, ToggledSavedSearch } from "./Toggle"
+import { UploadSizeLimitExceeded } from "./UploadSizeLimitExceeded"
 import { ToggledAccordion } from "./UserExperienceInteractions"
 import { ViewedVideo } from "./Video"
 
@@ -255,7 +255,7 @@ export type Event =
   | EditedSavedSearch
   | EnterLiveAuction
   | ExperimentViewed
-  | ExceededUploadSize
+  | UploadSizeLimitExceeded
   | FocusedOnConversationMessageInput
   | FocusedOnSearchInput
   | FocusedOnPriceDatabaseSearchInput
@@ -663,9 +663,9 @@ export enum ActionType {
    */
   experimentViewed = "experimentViewed",
   /**
-   * Corresponds to {@link ExceededUploadSize}
+   * Corresponds to {@link UploadSizeLimitExceeded}
    */
-  exceededUploadSize = "exceededUploadSize",
+  uploadSizeLimitExceeded = "uploadSizeLimitExceeded",
   /**
    * Corresponds to {@link FocusedOnConversationMessageInput}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -88,6 +88,7 @@ import {
   TappedMakeOffer,
   TappedViewOffer,
 } from "./Conversations"
+import { ExceededUploadSize } from "./ExceededUploadSize"
 import { ExperimentViewed } from "./ExperimentViewed"
 import {
   AuctionResultsFilterParamsChanged,
@@ -254,6 +255,7 @@ export type Event =
   | EditedSavedSearch
   | EnterLiveAuction
   | ExperimentViewed
+  | ExceededUploadSize
   | FocusedOnConversationMessageInput
   | FocusedOnSearchInput
   | FocusedOnPriceDatabaseSearchInput
@@ -660,6 +662,10 @@ export enum ActionType {
    * Corresponds to {@link ExperimentViewed}
    */
   experimentViewed = "experimentViewed",
+  /**
+   * Corresponds to {@link ExceededUploadSize}
+   */
+  exceededUploadSize = "exceededUploadSize",
   /**
    * Corresponds to {@link FocusedOnConversationMessageInput}
    */


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-3187]

### Description

Add exceeded upload size event type


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[CX-3187]: https://artsyproduct.atlassian.net/browse/CX-3187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ