### PR TITLE
feat(CX-3203): Add Tracking For Inquiry Tap and Sent

### DIFF
--- a/src/Schema/Events/Consignments.ts
+++ b/src/Schema/Events/Consignments.ts
@@ -158,3 +158,11 @@ export interface ViewArtworkMyCollection {
   user_email: string
   user_id?: string
 }
+
+export interface SentConsignmentInquiry {
+  action: ActionType.sentConsignmentInquiry
+  context_module: ContextModule.consignmentInquiryForm
+  context_screen: OwnerType.consignmentInquiry
+  context_screen_owner_type: OwnerType.consignmentInquiry
+  consignment_inquiry_id?: bigint
+}

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -836,6 +836,32 @@ export interface TappedSellArtwork {
 }
 
 /**
+ * A user taps a Get in Touch button to begin an Inquiry about Consignments
+ *
+ * This schema describes events sent to Segment from [[tappedConsignmentInquiry]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedConsignmentInquiry",
+ *    context_module : "sellHeader"
+ *    context_screen: "sell",
+ *    context_screen_owner_type: "sell",
+ *    subject: "Get in Touch"
+ *  }
+ * ```
+ */
+export interface TappedConsignmentInquiry {
+  action: ActionType.tappedConsignmentInquiry
+  context_module: ContextModule
+  context_screen: OwnerType
+  context_screen_owner_type: OwnerType
+  /** The text of the tapped button */
+  subject: string
+}
+
+
+/**
  * A user taps a Learn More button in SWA banner on My Collection Artwork page
  *
  * This schema describes events sent to Segment from [[tappedLearnMore]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -78,6 +78,7 @@ import {
   ArtworkDetailsCompleted,
   ConsignmentSubmitted,
   ContactInformationCompleted,
+  SentConsignmentInquiry,
   SubmitAnotherArtwork,
   UploadPhotosCompleted,
   ViewArtworkMyCollection,
@@ -172,6 +173,7 @@ import {
   TappedVerifyIdentity,
   TappedViewingRoomCard,
   TappedViewingRoomGroup,
+  TappedConsignmentInquiry
 } from "./Tap"
 import { ToggledNotification, ToggledSavedSearch } from "./Toggle"
 import { UploadSizeLimitExceeded } from "./UploadSizeLimitExceeded"
@@ -282,6 +284,7 @@ export type Event =
   | SelectedItemFromSearch
   | SelectedItemFromPriceDatabaseSearch
   | SelectedRecentPriceRange
+  | SentConsignmentInquiry
   | SentConversationMessage
   | SentRequestPriceEstimate
   | Share
@@ -301,6 +304,7 @@ export type Event =
   | TappedCollectionGroup
   | TappedConsign
   | TappedContactGallery
+  | TappedConsignmentInquiry
   | TappedCreateAlert
   | TappedExploreGroup
   | TappedExploreMyCollection
@@ -785,6 +789,10 @@ export enum ActionType {
    */
   sentArtworkInquiry = "sentArtworkInquiry",
   /**
+   * Corresponds to {@link SentConsignmentInquiry}
+   */
+   sentConsignmentInquiry = "sentConsignmentInquiry",
+  /**
    * Corresponds to {@link SentConversationMessage}
    */
   sentConversationMessage = "sentConversationMessage",
@@ -860,6 +868,10 @@ export enum ActionType {
    * Corresponds to {@link TappedContactGallery}
    */
   tappedContactGallery = "tappedContactGallery",
+  /**
+   * Corresponds to {@link TappedConsignmentInquiry}
+   */
+  tappedConsignmentInquiry = "tappedConsignmentInquiry",
   /**
    * Corresponds to {@link TappedCreateAlert}
    */

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -50,6 +50,7 @@ export enum ContextModule {
   collectionCard = "collectionCard",
   collectionDescription = "collectionDescription",
   collectionRail = "collectionRail",
+  consignmentInquiryForm = "consignmentInquiryForm",
   consignSubmissionFlow = "consignSubmissionFlow",
   contactInformation = "contactInformation",
   createAlert = "createAlert",

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -26,6 +26,7 @@ export enum OwnerType {
   collections = "collections",
   consign = "consign",
   consignmentFlow = "consignmentFlow",
+  consignmentInquiry = "consignmentInquiry",
   consignmentSubmission = "consignmentSubmission",
   conversation = "conversation",
   conversationMakeOfferConfirmArtwork = "conversationMakeOfferConfirmArtwork",
@@ -104,6 +105,7 @@ export type ScreenOwnerType =
   | OwnerType.collection
   | OwnerType.consign
   | OwnerType.consignmentFlow
+  | OwnerType.consignmentInquiry
   | OwnerType.consignmentSubmission
   | OwnerType.conversation
   | OwnerType.conversationMakeOfferConfirmArtwork


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-3203]

### Description
- Adds the necessary interface for tracking ConsignmentInquiry button tapped and ConsignmentInquiry sent
<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[CX-3203]: https://artsyproduct.atlassian.net/browse/CX-3203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ