### PR TITLE
chore: update experiment_viewed event to requirements asked by analytics

### DIFF
--- a/src/Schema/Events/ExperimentViewed.ts
+++ b/src/Schema/Events/ExperimentViewed.ts
@@ -14,13 +14,13 @@ import { ActionType } from "."
  *  @example
  *  ```
  *  {
- *    action: "experimentViewed",
- *    service: "unleash",
+ *    action: "experiment_viewed",
  *    experiment_name: "some_experiment_we_are_running",
  *    variant_name: "cool_new_variant",
  *    payload: "10", // optional
  *    context_owner_type: "artwork",
  *    context_owner_id: "55ed8ca57261693d930000b8",
+ *    context_owner_slug: "slug"
  *  }
  * ```
  *
@@ -30,11 +30,11 @@ import { ActionType } from "."
  */
 export interface ExperimentViewed {
   action: ActionType.experimentViewed
-  service: "unleash" | string
   experiment_name: string
-  variant_name: "control" | string // usually it will be "control" or the other names of the variants
+  // usually "control" or "experiment"
+  // can be checked https://unleash.artsy.net/projects/default/features/[feature-flag]/variants
+  variant_name: string
   payload?: string
-
   context_owner_type: OwnerType
   context_owner_id?: string
   context_owner_slug?: string

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -661,7 +661,7 @@ export enum ActionType {
   /**
    * Corresponds to {@link ExperimentViewed}
    */
-  experimentViewed = "experimentViewed",
+  experimentViewed = "experiment_viewed", // intentional snake case to match tracked event
   /**
    * Corresponds to {@link UploadSizeLimitExceeded}
    */


### PR DESCRIPTION
The type of this PR is: **chore**

### Description

This PR updates the experiment_viewed event type to match the requirements asked by the analytics team.
Bonus: remove unleash as a ff since that can be inferred by app version in mobile and in web no need for it anyway since updates are immediate to everyone.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
