### PR TITLE
[AS-3677] CMS conversation page events

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1423,8 +1423,8 @@ export interface ClickedOnPriceDisplayDropdown {
 }
 
 /**
- * Partner clicks on dismiss inquiry on the conversations page in CMS. 
- * A pop up will open and then they can click on: Select a reason, Cancel, Dismiss inquiry 
+ * Partner clicks on dismiss inquiry modal on the conversations page in CMS.
+ * They can click on: Select a reason, Cancel, Dismiss inquiry 
  *
  * This schema describes events sent to Segment from [[clickedDismissInquiry]]
  *
@@ -1453,8 +1453,8 @@ export interface ClickedOnPriceDisplayDropdown {
   partner_id: string
 }
 /**
- * Partner clicks on mark as spam on the conversations page in CMS. 
- * A pop up will open and then they can click on: Cancel or Delete and Mark as Spam
+ * Partner clicks on mark as spam modal on the conversations page in CMS. 
+ * They can click on: Cancel or Delete and Mark as Spam
  *
  * This schema describes events sent to Segment from [[clickedMarkSpam]]
  *

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1395,3 +1395,88 @@ export interface ClickedOnPriceDisplayDropdown {
   context_page_owner_id?: string
   label: string
 }
+
+/**
+ * A Partner selects a filter on the conversations page in CMS.
+ *
+ * This schema describes events sent to Segment from [[selectedConversationsFilter]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    label: [selected filter all, selected filter new, selected filter replied],
+ *    context_module: "conversations",
+ *    context_page_owner_type: "conversation",
+ *    context_page_owner_id: "60de173a47476c000fd5c4cc"
+ *    artwork_id: "60de173a47476c000fd5c4cc"
+ *    partner_id: "35de173a47476c111fd5c4cc"
+ *  }
+ * ```
+ */
+ export interface SelectedConversationsFilter {
+  label: string
+  context_module: string
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  artwork_id: string
+  partner_id: string
+}
+
+/**
+ * Partner clicks on dismiss inquiry on the conversations page in CMS. 
+ * A pop up will open and then they can click on: Select a reason, Cancel, Dismiss inquiry 
+ *
+ * This schema describes events sent to Segment from [[clickedDismissInquiry]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    conversation_id: 123456
+ *    label: [select a reason, cancel dismiss inquiry, dismiss inquiry]
+ *    reason: [The artwork is no longer available, I already contacted this person, Other]
+ *    context_module: "conversations",
+ *    context_page_owner_type: "conversation",
+ *    context_page_owner_id: "60de173a47476c000fd5c4cc"
+ *    artwork_id: "60de173a47476c000fd5c4cc"
+ *    partner_id: "35de173a47476c111fd5c4cc"
+ *  }
+ * ```
+ */
+ export interface ClickedDismissInquiry {
+  conversation_id: string
+  label: string
+  reason: string
+  context_module: string
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  artwork_id: string
+  partner_id: string
+}
+/**
+ * Partner clicks on mark as spam on the conversations page in CMS. 
+ * A pop up will open and then they can click on: Cancel or Delete and Mark as Spam
+ *
+ * This schema describes events sent to Segment from [[clickedMarkSpam]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    conversation_id: 123456
+ *    label: [mark as spam, cancel mark as spam, delete and mark as spam]
+ *    context_module: "conversations",
+ *    context_page_owner_type: "conversation",
+ *    context_page_owner_id: "60de173a47476c000fd5c4cc"
+ *    artwork_id: "60de173a47476c000fd5c4cc"
+ *    partner_id: "35de173a47476c111fd5c4cc"
+ *  }
+ * ```
+ */
+ export interface ClickedMarkSpam {
+  conversation_id: string
+  label: string
+  context_module: string
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  artwork_id: string
+  partner_id: string
+}

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1399,7 +1399,7 @@ export interface ClickedOnPriceDisplayDropdown {
 /**
  * A Partner selects a filter on the conversations page in CMS.
  *
- * This schema describes events sent to Segment from [[selectedConversationsFilter]]
+ * This schema describes events sent to Segment from [[ClickedConversationsFilter]]
  *
  *  @example
  *  ```
@@ -1413,7 +1413,7 @@ export interface ClickedOnPriceDisplayDropdown {
  *  }
  * ```
  */
- export interface SelectedConversationsFilter {
+ export interface ClickedConversationsFilter {
   label: string
   context_module: string
   context_page_owner_type: PageOwnerType

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -76,6 +76,7 @@ import {
   ClickedSnooze,
   ClickedVerifyIdentity,
   ClickedViewingRoomCard,
+  ClickedConversationsFilter
 } from "./Click"
 import { EditedUserProfile } from "./CollectorProfile"
 import {
@@ -253,6 +254,7 @@ export type Event =
   | ClickedOrderSummary
   | ClickedDismissInquiry
   | ClickedMarkSpam
+  | ClickedConversationsFilter
   | CommercialFilterParamsChanged
   | CompletedOnboarding
   | ConfirmBid
@@ -289,7 +291,6 @@ export type Event =
   | SearchedReverseImageWithResults
   | SearchedWithNoResults
   | SelectedArtworkFromReverseImageSearch
-  | SelectedConversationsFilter
   | SelectedItemFromSearch
   | SelectedItemFromPriceDatabaseSearch
   | SelectedRecentPriceRange
@@ -816,9 +817,9 @@ export enum ActionType {
   /**
    * Corresponds to {@link SelectedItemFromPriceDatabaseSearch}
    */
-   selectedConversationsFilter = "selectedConversationsFilter",
+   clickedConversationsFilter = "clickedConversationsFilter",
    /**
-    * Corresponds to {@link SelectedConversationsFilter}
+    * Corresponds to {@link ClickedConversationsFilter}
     */
   selectedItemFromPriceDatabaseSearch = "selectedItemFromPriceDatabaseSearch",
   /**

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -249,6 +249,8 @@ export type Event =
   | ClickedOfferActions
   | ClickedOrderPage
   | ClickedOrderSummary
+  | ClickedDismissInquiry
+  | ClickedMarkSpam
   | CommercialFilterParamsChanged
   | CompletedOnboarding
   | ConfirmBid
@@ -285,6 +287,7 @@ export type Event =
   | SearchedReverseImageWithResults
   | SearchedWithNoResults
   | SelectedArtworkFromReverseImageSearch
+  | SelectedConversationsFilter
   | SelectedItemFromSearch
   | SelectedItemFromPriceDatabaseSearch
   | SelectedRecentPriceRange
@@ -567,6 +570,14 @@ export enum ActionType {
   /**
    * Corresponds to {@link ClickedPartnerCard}
    */
+   clickedDismissInquiry = "clickedDismissInquiry",
+  /**
+   * Corresponds to {@link ClickedDismissInquiry}
+   */
+   clickedMarkSpam = "clickedMarkSpam",
+  /**
+   * Corresponds to {@link ClickedMarkSpam}
+   */
   clickedPartnerCard = "clickedPartnerCard",
   /**
    * Corresponds to {@link ClickedPartnerLink}
@@ -803,6 +814,10 @@ export enum ActionType {
   /**
    * Corresponds to {@link SelectedItemFromPriceDatabaseSearch}
    */
+   selectedConversationsFilter = "selectedConversationsFilter",
+   /**
+    * Corresponds to {@link SelectedConversationsFilter}
+    */
   selectedItemFromPriceDatabaseSearch = "selectedItemFromPriceDatabaseSearch",
   /**
    * Corresponds to {@link SelectedItemFromSearch}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -62,6 +62,8 @@ import {
   ClickedOnSubmitOrder,
   ClickedOrderPage,
   ClickedOrderSummary,
+  ClickedDismissInquiry,
+  ClickedMarkSpam,
   ClickedPartnerCard,
   ClickedPartnerLink,
   ClickedPaymentDetails,


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CO-]

### Description
With the conversations revamp, we want to migrate server events to client events.

Our approach to cover the previous server events is:
* we will track most of clicks on the conversation page with click event (`volt_client_production.click`), probably another NX ticket. 
* we will create some specific events that are relevant to be separated

List of server events to be migrated:

- **conversations_index** -> [tracked using pageviews](https://artsyproduct.atlassian.net/browse/AS-3676)
- **conversations_sent** -> tracked with the new event in this PR `ClickedConversationsFilter`
- **conversations_new_inquiries** -> tracked with the new event in this PR `ClickedConversationsFilter`
- **conversations_show** -> will be tracked with click
- **conversations_update_seller_outcome** -> tracked with the new event in this PR `ClickedDismissInquiry`
- **conversations_messages_create** -> will be tracked with click
- **conversations_messages_mark_as_spam** -> tracked with the new event in this PR `ClickedMarkSpam`
- **artworks_update** -> tracked with the new event in this PR `ClickedDismissInquiry`

More details [here](https://docs.google.com/spreadsheets/d/1pc1tlSlNuVmRfNJBgvwb3CBxo5gH6ewuL0-Qle4bwOA/edit#gid=1140630574)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
