### PR TITLE
feat: add rail viewed event

### DIFF
--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -1,0 +1,31 @@
+import { ContextModule } from "../Values/ContextModule"
+import { OwnerType } from "../Values/OwnerType"
+import { ActionType } from "."
+
+/**
+ * Schemas describing rail_viewed events
+ * @packageDocumentation
+ */
+
+/**
+ * A user sees a rail of content
+ *
+ * This schema describes events sent to Segment from [[RailViewed]].
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "rail_viewed",
+ *    context_screen: "home",
+ *    context_module: "Home"
+ *    position_y: 2, // optional
+ *  }
+ * ```
+ *
+ */
+export interface RailViewed {
+  action: ActionType.railViewed
+  context_module: ContextModule
+  context_screen: OwnerType
+  position_y?: number
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -109,6 +109,7 @@ import {
   VisitMyCollectionOnboardingSlide,
 } from "./HomeFeedMyCollectionOnboarding"
 import { Impression } from "./Impression"
+import { RailViewed } from "./ImpressionTracking"
 import {
   AddCollectedArtwork,
   DeleteCollectedArtwork,
@@ -280,6 +281,7 @@ export type Event =
   | OnboardingUserInputData
   | PriceDatabaseFilterParamsChanged
   | PromptForReview
+  | RailViewed
   | RegistrationPageView
   | RegistrationSubmitted
   | ResetYourPassword
@@ -762,6 +764,10 @@ export enum ActionType {
    * Corresponds to {@link PromptForReview}
    */
   promptForReview = "promptForReview",
+  /**
+   * Corresponds to {@link RailViewed}
+   */
+  railViewed = "railViewed",
   /**
    * Corresponds to {@link RegistrationPageView}
    */


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-3385]

### Description

Add rail_viewed event to cohesion

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[CX-3385]: https://artsyproduct.atlassian.net/browse/CX-3385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ