### PR TITLE
feat: add searchSuggestionQuickNavigationItemSelected event

### DIFF
--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -198,24 +198,14 @@ export interface ConsignmentArtistFailed {
  *  {
  *    action: "searchSuggestionQuickNavigationItemSelected",
  *    context_module: "header",
- *    context_owner_type: "home",
- *    destination_owner_type: "artist",
- *    destination_owner_id: "4d8b92b34eb68a1b2c0003f4",
- *    destination_owner_slug: "andy-warhol",
  *    destination_path: "/artist/andy-warhol/works-for-sale",
- *    label: "Auction Results",
- *    query: "andy warhol"
+ *    label: "Auction Results"
  *  }
  *  ```
  */
 export interface SearchSuggestionQuickNavigationItemSelected {
   action: ActionType.searchSuggestionQuickNavigationItemSelected
   context_module?: ContextModule
-  context_owner_type: PageOwnerType
-  destination_owner_type: PageOwnerType
-  destination_owner_id?: string
-  destination_owner_slug?: string
   destination_path: string
   label: "Artworks" | "Auction Results"
-  query: string 
 }

--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -187,3 +187,35 @@ export interface ConsignmentArtistFailed {
   context_owner_type: OwnerType.consign
   query: string
 }
+
+/**
+ * A user selects a quick navigation item within a search suggestion
+ *
+ * This schema describes events sent to Segment from [[searchSuggestionQuickNavigationItemSelected]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "searchSuggestionQuickNavigationItemSelected",
+ *    context_module: "header",
+ *    context_owner_type: "home",
+ *    destination_owner_type: "artist",
+ *    destination_owner_id: "4d8b92b34eb68a1b2c0003f4",
+ *    destination_owner_slug: "andy-warhol",
+ *    destination_path: "/artist/andy-warhol/works-for-sale",
+ *    label: "Auction Results",
+ *    query: "andy warhol"
+ *  }
+ *  ```
+ */
+export interface SearchSuggestionQuickNavigationItemSelected {
+  action: ActionType.searchSuggestionQuickNavigationItemSelected
+  context_module?: ContextModule
+  context_owner_type: PageOwnerType
+  destination_owner_type: PageOwnerType
+  destination_owner_id?: string
+  destination_owner_slug?: string
+  destination_path: string
+  label: "Artworks" | "Auction Results"
+  query: string 
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -807,6 +807,10 @@ export enum ActionType {
    */
   screen = "screen",
   /**
+   * Corresponds to {@link SearchSuggestionQuickNavigationItemSelected}
+   */
+  searchSuggestionQuickNavigationItemSelected = "searchSuggestionQuickNavigationItemSelected",
+  /**
    * Corresponds to {@link SearchedPriceDatabase}
    */
   searchedPriceDatabase = "searchedPriceDatabase",


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-4629](https://artsyproduct.atlassian.net/browse/FX-4629)

### Description

This PR adds a new event to track when a user selects one of the quick navigation items in a search suggestion (right now only for relevant artist suggestions).

Example:

```typescript
{
  action: "searchSuggestionQuickNavigationItemSelected",
  context_module: "header",
  destination_path: "/artist/andy-warhol/works-for-sale",
  label: "Auction Results"
}
```


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[FX-4629]: https://artsyproduct.atlassian.net/browse/FX-4629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ