### PR TITLE
chore: add item type and id to ItemViewed

### DIFF
--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -41,6 +41,8 @@ export interface RailViewed {
  *    action: "item_viewed",
  *    context_screen: "home",
  *    context_module: "newWorksforYouRail"
+ *    item_id: "artwork-id"
+ *    item_type: "artwork"
  *    position: 2, // optional
  *  }
  * ```
@@ -50,6 +52,8 @@ export interface ItemViewed {
   action: ActionType.itemViewed
   context_screen: OwnerType
   context_module: ContextModule
+  item_id: string
+  item_type: "artwork"
   position?: number
 }
 


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-3463]

### Description

Add item type and id to ItemViewed

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[CX-3463]: https://artsyproduct.atlassian.net/browse/CX-3463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ