### PR TITLE
[AS-3848] Adding new event for mark as sold

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1484,6 +1484,34 @@ export interface ClickedMarkSpam {
   artwork_id: string
   partner_id: string
 }
+/**
+ * User clicks on "Set this work as sold" on the dismiss inquiry modal on the CMS conversation page
+ * after selecting the option "The work is no longer available"
+ *
+ * This schema describes events sent to Segment from [[clickedMarkSold]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: clickedMarkSold
+ *    conversation_id: 123456
+ *    context_module: "conversations",
+ *    context_page_owner_type: "conversation",
+ *    context_page_owner_id: "60de173a47476c000fd5c4cc"
+ *    artwork_id: "60de173a47476c000fd5c4cc"
+ *    partner_id: "35de173a47476c111fd5c4cc"
+ *  }
+ * ```
+ */
+ export interface ClickedMarkSold {
+  action: ActionType.clickedMarkSold
+  conversation_id: string
+  context_module: string
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  artwork_id: string
+  partner_id: string
+}
 
 /**
  * A Partner clicks on the Buy Now checkbox for selecting selling options in the artwork edit page in the CMS.

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -54,6 +54,7 @@ import {
   ClickedLoadMore,
   ClickedMainArtworkGrid,
   ClickedMarkSpam,
+  ClickedMarkSold,
   ClickedNavigationTab,
   ClickedOfferActions,
   ClickedOfferOption,
@@ -260,6 +261,7 @@ export type Event =
   | ClickedOrderSummary
   | ClickedDismissInquiry
   | ClickedMarkSpam
+  | ClickedMarkSold
   | ClickedConversationsFilter
   | CommercialFilterParamsChanged
   | CompletedOnboarding
@@ -600,6 +602,10 @@ export enum ActionType {
   /**
    * Corresponds to {@link ClickedMarkSpam}
    */
+   clickedMarkSold = "clickedMarkSold",
+   /**
+    * Corresponds to {@link ClickedMarkSold}
+    */
   clickedPartnerCard = "clickedPartnerCard",
   /**
    * Corresponds to {@link ClickedPartnerLink}


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CO-]

### Description
Add tracking for the mark as sold checkbox in the Dismiss Inquiry modal on CMS conversation page.

When the checkbox is selected (for the work_unavailable reason) we mark the artwork as sold after dismissing the inquiry.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
