### PR TITLE
chore: add tracking event for clicking publish button in artwork form 

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1405,10 +1405,9 @@ export interface ClickedOnPriceDisplayDropdown {
  * ```
  * {
  *    action: "clickedPublish",
- *    context_module: voltArtworksEdit ,
- *    context_page_owner_type: "artwork",
- *    context_page_owner_id: "60de173a47476c000fd5c4cc",
- *    label: "publish"
+ *    context_module: "artworkDetails" ,
+ *    artwork_id: "60de173a47476c000fd5c4cc"
+ *    label: "Publish"
  * }
  * ```
  */

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1397,6 +1397,31 @@ export interface ClickedOnPriceDisplayDropdown {
 }
 
 /**
+ * A partner clicks the publish button on the artwork form page in CMS.
+ *
+ * This schema describes events sent to Segment from [[ClickedPublish]]
+ *
+ * @example
+ * ```
+ * {
+ *    action: "clickedPublish",
+ *    context_module: voltArtworksEdit ,
+ *    context_page_owner_type: "artwork",
+ *    context_page_owner_id: "60de173a47476c000fd5c4cc",
+ *    label: "publish"
+ * }
+ * ```
+ */
+
+export interface ClickedPublish {
+  action: ActionType.clickedPublish
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  label: string
+}
+
+/**
  * A Partner selects a filter on the conversations page in CMS.
  *
  * This schema describes events sent to Segment from [[ClickedConversationsFilter]]
@@ -1503,7 +1528,7 @@ export interface ClickedMarkSpam {
  *  }
  * ```
  */
- export interface ClickedMarkSold {
+export interface ClickedMarkSold {
   action: ActionType.clickedMarkSold
   conversation_id: string
   context_module: string

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1416,8 +1416,7 @@ export interface ClickedOnPriceDisplayDropdown {
 export interface ClickedPublish {
   action: ActionType.clickedPublish
   context_module: ContextModule
-  context_page_owner_type: PageOwnerType
-  context_page_owner_id?: string
+  artwork_id: string
   label: string
 }
 

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -53,8 +53,8 @@ import {
   ClickedGalleryGroup,
   ClickedLoadMore,
   ClickedMainArtworkGrid,
-  ClickedMarkSpam,
   ClickedMarkSold,
+  ClickedMarkSpam,
   ClickedNavigationTab,
   ClickedOfferActions,
   ClickedOfferOption,
@@ -73,6 +73,7 @@ import {
   ClickedPaymentDetails,
   ClickedPaymentMethod,
   ClickedPromoSpace,
+  ClickedPublish,
   ClickedSelectShippingOption,
   ClickedShippingAddress,
   ClickedShowGroup,
@@ -241,6 +242,7 @@ export type Event =
   | ClickedOnFramedMeasurementsDropdown
   | ClickedOnMakeOfferCheckbox
   | ClickedOnPriceDisplayDropdown
+  | ClickedPublish
   | ClickedOnSubmitOrder
   | ClickedSnooze
   | ClickedPartnerCard
@@ -580,6 +582,10 @@ export enum ActionType {
    */
   clickedOnPriceDisplayDropdown = "clickedOnPriceDisplayDropdown",
   /**
+   * Corresponds to {@link ClickedPublish}
+   */
+  clickedPublish = "clickedPublish",
+  /**
    * Corresponds to {@link ClickedOnSubmitOrder}
    */
   clickedOnSubmitOrder = "clickedOnSubmitOrder",
@@ -602,10 +608,10 @@ export enum ActionType {
   /**
    * Corresponds to {@link ClickedMarkSpam}
    */
-   clickedMarkSold = "clickedMarkSold",
-   /**
-    * Corresponds to {@link ClickedMarkSold}
-    */
+  clickedMarkSold = "clickedMarkSold",
+  /**
+   * Corresponds to {@link ClickedMarkSold}
+   */
   clickedPartnerCard = "clickedPartnerCard",
   /**
    * Corresponds to {@link ClickedPartnerLink}


### PR DESCRIPTION
The type of this PR is: Chore

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

This PR adds a new event to cohesion for the publish button, resolving the first part of [PX-5499] 
(additional PR for volt changes *add link here*)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[PX-5499]: https://artsyproduct.atlassian.net/browse/PX-5499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ