### PR TITLE
chore: make sale id optional for IDV

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1123,7 +1123,7 @@ export interface ClickedVerifyIdentity {
   context_page_owner_type: PageOwnerType
   context_page_owner_id?: string
   context_page_owner_slug?: string
-  sale_id: string
+  sale_id?: string
   subject: string
 }
 


### PR DESCRIPTION
The type of this PR is: **CHORE**

Jira ticket: https://artsyproduct.atlassian.net/browse/PRO-107

### Description

Since we want to start sending these events when uses click from the profile page, which does not have an associated auction, `sale_id` should become optional.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
