### PR TITLE
feat: adds schema for cookie consent manager

### DIFF
--- a/src/Schema/Events/CookieConsent.ts
+++ b/src/Schema/Events/CookieConsent.ts
@@ -1,0 +1,29 @@
+import { ActionType } from "."
+
+/**
+ * Schemas describing cookie consent events
+ * @packageDocumentation
+ */
+
+/**
+ * A user has saved their cookie consent preferences.
+ *
+ * This schema describes events sent to Segment from [[savedCookieConsentPreferences]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "savedCookieConsentPreferences",
+ *    value: {
+ *      necessary: true,
+ *      functional: true,
+ *      performance: true,
+ *      targeting: false
+ *    }
+ *  }
+ * ```
+ */
+export interface SavedCookieConsentPreferences {
+  action: ActionType.savedCookieConsentPreferences
+  value: Record<string, boolean | null | undefined>
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -106,6 +106,7 @@ import {
   TappedMakeOffer,
   TappedViewOffer,
 } from "./Conversations"
+import { SavedCookieConsentPreferences } from "./CookieConsent"
 import { ExperimentViewed } from "./ExperimentViewed"
 import {
   AuctionResultsFilterParamsChanged,
@@ -309,6 +310,7 @@ export type Event =
   | ResetYourPassword
   | SaleScreenLoadComplete
   | SaveCollectedArtwork
+  | SavedCookieConsentPreferences
   | Screen
   | SearchedPriceDatabase
   | SearchedReverseImageWithNoResults
@@ -851,6 +853,10 @@ export enum ActionType {
    * Corresponds to {@link SaveCollectedArtwork}
    */
   saveCollectedArtwork = "saveCollectedArtwork",
+  /**
+   * Corresponds to {@link SavedCookieConsentPreferences}
+   */
+  savedCookieConsentPreferences = "savedCookieConsentPreferences",
   /**
    * Corresponds to {@link Screen}
    */


### PR DESCRIPTION
Schema to support the [cookie consent manager](https://github.com/artsy/force/pull/12280).

Closes [GRO-1688](https://artsyproduct.atlassian.net/browse/GRO-1688)

[GRO-1688]: https://artsyproduct.atlassian.net/browse/GRO-1688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.126.0--canary.432.6663.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/cohesion@4.126.0--canary.432.6663.0
  # or 
  yarn add @artsy/cohesion@4.126.0--canary.432.6663.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
