### PR TITLE
feat(long-press): add event for long pressing artworks

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -886,3 +886,27 @@ export interface TappedLearnMore {
   /** The text of the tapped button */
   subject: string
 }
+
+/**
+ * A user long presses an artwork in the app to show a menu
+ *
+ * This schema describes events sent to Segment from [[longPressedArtwork]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "longPressedArtwork",
+ *    context_module: "artworkGrid",
+ *    context_screen_owner_type: "artist",
+ *    context_owner_id: "6164889300d643000db86504",
+ *    context_owner_slug: "radna-segal-pearl",
+ *  }
+ * ```
+ */
+export interface LongPressedArtwork {
+  action: ActionType.longPressedArtwork
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id?: string
+  context_screen_owner_slug?: string
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -820,6 +820,10 @@ export enum ActionType {
    */
   impression = "impression",
   /**
+   * Corresponds to {@link LongPressedArtwork}
+   */
+  longPressedArtwork = "longPressedArtwork",
+  /**
    * Corresponds to {@link MaxBidSelected}
    */
   maxBidSelected = "maxBidSelected",


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [MOPLAT-790]

### Description

<!-- Implementation description -->

Adds a long press event for tracking long presses on artworks in the mobile application. This is a new feature mobile platform team is working on that will show a context menu with quick actions. 
You can see it in action here:
https://github.com/artsy/eigen/pull/8797

Let me know if anything needs changing!

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[MOPLAT-790]: https://artsyproduct.atlassian.net/browse/MOPLAT-790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ