### PR TITLE
chore: PX-5596 adding new event for duplicate artwork functionality

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1594,16 +1594,16 @@ export interface ClickedOnMakeOfferCheckbox {
  *  {
  *    action: "clickedOnDuplicateArtwork",
  *    context_module: "voltArtworksEdit",
- *    context_page_owner_type: "artwork",
- *    context_page_owner_id: "60de173a47476c000fd5c4cc"
- *    label: ["duplicate", "cancel"]
+ *    original_artwork_id: "60de173a47476c000fd5c4cc"
+ *    duplicate_artwork_id: "6487822214765c000d34cbe8"
+ *    label: ["duplicate", "cancel", "open modal"]
  *  }
  * ```
  */
 export interface ClickedOnDuplicateArtwork {
   action: ActionType.clickedOnDuplicateArtwork
   context_module: ContextModule
-  context_page_owner_type: PageOwnerType
-  context_page_owner_id?: string
+  original_artwork_id: string
+  duplicate_artwork_id?: string
   label: string
 }

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1595,8 +1595,8 @@ export interface ClickedOnMakeOfferCheckbox {
  *    action: "clickedOnDuplicateArtwork",
  *    context_module: "voltArtworksEdit",
  *    original_artwork_id: "60de173a47476c000fd5c4cc"
- *    duplicate_artwork_id: "6487822214765c000d34cbe8"
- *    label: ["duplicate", "cancel", "open modal"]
+ *    label: "Duplicate"
+ *    flow: ["artworksList", "duplicateModal"]
  *  }
  * ```
  */
@@ -1604,6 +1604,6 @@ export interface ClickedOnDuplicateArtwork {
   action: ActionType.clickedOnDuplicateArtwork
   context_module: ContextModule
   original_artwork_id: string
-  duplicate_artwork_id?: string
   label: string
+  flow: string
 }

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1583,3 +1583,27 @@ export interface ClickedOnMakeOfferCheckbox {
   context_page_owner_id?: string
   label: boolean
 }
+
+/**
+ * A Partner clicks on the Duplicate button for duplicating an artwork in the CMS.
+ *
+ * This schema describes events sent to Segment from [[clickedOnDuplicateArtwork]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedOnDuplicateArtwork",
+ *    context_module: "voltArtworksEdit",
+ *    context_page_owner_type: "artwork",
+ *    context_page_owner_id: "60de173a47476c000fd5c4cc"
+ *    label: ["duplicate", "cancel"]
+ *  }
+ * ```
+ */
+export interface ClickedOnDuplicateArtwork {
+  action: ActionType.clickedOnDuplicateArtwork
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  label: string
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -68,6 +68,7 @@ import {
   ClickedOnArtworkShippingUnitsDropdown,
   ClickedOnArtworkShippingWeight,
   ClickedOnBuyNowCheckbox,
+  ClickedOnDuplicateArtwork,
   ClickedOnFramedMeasurements,
   ClickedOnFramedMeasurementsDropdown,
   ClickedOnMakeOfferCheckbox,
@@ -257,6 +258,7 @@ export type Event =
   | ClickedOnFramedMeasurements
   | ClickedOnFramedMeasurementsDropdown
   | ClickedOnMakeOfferCheckbox
+  | ClickedOnDuplicateArtwork
   | ClickedOnPriceDisplayDropdown
   | ClickedPublish
   | ClickedOnSubmitOrder
@@ -603,6 +605,9 @@ export enum ActionType {
    */
   clickedOnMakeOfferCheckbox = "clickedOnMakeOfferCheckbox",
   /**
+   * Corresponds to {@link ClickedOnDuplicateArtwork}
+   */
+  clickedOnDuplicateArtwork = "clickedOnDuplicateArtwork",
   /**
    * Corresponds to {@link ClickedOnPriceDisplayDropdown}
    */


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR is required to complete [PX-5596]

### Description

This PR adds a new event to Cohesion to track when an artwork is being duplicated in CMS.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[PX-5596]: https://artsyproduct.atlassian.net/browse/PX-5596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ