### PR TITLE
feat(article): Add article mobile events

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -268,6 +268,30 @@ export interface TappedEntityGroup {
 export type EntityModuleHeight = "single" | "double"
 
 /**
+ * A user taps the Article Share button in iOS
+ *
+ * This schema describes events sent to Segment from [[tappedArticleShare]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedArticleShare",
+ *    context_module: "article",
+ *    context_screen_owner_type: "article",
+ *    context_screen_owner_id: "some-article-id",
+ *    context_screen_owner_id: "some-article-slug",
+ *  }
+ * ```
+ */
+export interface TappedArticleShare {
+  action: ActionType.tappedArticleShare
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id: string
+  context_screen_owner_slug: string
+}
+
+/**
  * A user taps a Consign button in iOS
  *
  * This schema describes events sent to Segment from [[tappedConsign]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -170,6 +170,7 @@ import { Share } from "./Share"
 import { SaleScreenLoadComplete, Screen, TimeOnPage } from "./System"
 import {
   TappedArticleGroup,
+  TappedArticleShare,
   TappedArtistGroup,
   TappedArtistSeriesGroup,
   TappedArtworkGroup,
@@ -337,6 +338,7 @@ export type Event =
   | SubmitAnotherArtwork
   | SuccessfullyLoggedIn
   | TappedArticleGroup
+  | TappedArticleShare
   | TappedArtistGroup
   | TappedArtistSeriesGroup
   | TappedArtworkGroup
@@ -964,6 +966,10 @@ export enum ActionType {
    * Corresponds to {@link TappedArticleGroup}
    */
   tappedArticleGroup = "tappedArticleGroup",
+  /**
+   * Corresponds to {@link TappedArticleShare}
+   */
+  tappedArticleShare = "tappedArticleShare",
   /**
    * Corresponds to {@link TappedArtistGroup}
    */

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -10,6 +10,7 @@ export enum ContextModule {
   adServer = "adServer",
   articleArtist = "articleArtist",
   articleRail = "articleRail",
+  article = "article",
   articles = "articles",
   articleTab = "articleTab",
   artistAuctionResults = "artistAuctionResults",


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [MOPLAT-827]

### Description

This adds article tracking events for the new screen.

cc @artsy/mobile-platform 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[MOPLAT-827]: https://artsyproduct.atlassian.net/browse/MOPLAT-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ