### PR TITLE
Add SearchedWithResults event

### DIFF
--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -89,6 +89,32 @@ export interface SearchedWithNoResults {
 }
 
 /**
+ * A user searches with results
+ *
+ * This schema describes events sent to Segment from [[searchedWithResults]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "searchedWithResults",
+ *    context_module: "header",
+ *    context_owner_type: "home",
+ *    destination_owner_type: "search",
+ *    query: "Banksy"
+ *  }
+ * ```
+ */
+export interface SearchedWithResults {
+  action: ActionType.searchedWithResults
+  context_module: ContextModule
+  context_owner_type: PageOwnerType
+  context_owner_id?: string
+  context_owner_slug?: string
+  destination_owner_type?: PageOwnerType
+  query: string
+}
+
+/**
  * A user queries the Artsy Price Database, including the artist_id, string queried, and applied filters
  *
  * This schema describes events sent to Segment from [[searchedPriceDatabase]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -162,6 +162,7 @@ import {
   FocusedOnSearchInput,
   SearchedPriceDatabase,
   SearchedWithNoResults,
+  SearchedWithResults,
   SelectedItemFromPriceDatabaseSearch,
   SelectedItemFromSearch,
   SelectedSearchSuggestionQuickNavigationItem,
@@ -325,6 +326,7 @@ export type Event =
   | SearchedReverseImageWithNoResults
   | SearchedReverseImageWithResults
   | SearchedWithNoResults
+  | SearchedWithResults
   | SelectedArtworkFromReverseImageSearch
   | SelectedItemFromSearch
   | SelectedItemFromPriceDatabaseSearch
@@ -902,6 +904,10 @@ export enum ActionType {
    * Corresponds to {@link SearchedWithNoResults}
    */
   searchedWithNoResults = "searchedWithNoResults",
+  /**
+   * Corresponds to {@link SearchedWithResults}
+   */
+  searchedWithResults = "searchedWithResults",
   /**
    * Corresponds to {@link SelectArtistFromSearch}
    */


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

New search bar implementation [uses](https://github.com/artsy/force/blob/114efdb251f8d4719281455e2efbe8a937b78305/src/Components/Search/NewSearch/NewSearchBarInput.tsx#L90) deprecated search events, like:
- DeprecatedSchema.ActionType.SearchedAutosuggestWithResults
- DeprecatedSchema.ActionType.SearchedAutosuggestWithoutResults

I've added a new event for searching **with** results ([there is](https://github.com/artsy/cohesion/blob/60456c53822b8c29e3068fe53e70a43ff839d051/src/Schema/Events/Search.ts#L81) an event for searching **without** results in the schema already) In order to not drag along deprecated events.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
