### PR TITLE
[AS-4029] Adding new event to track address validation

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1608,37 +1608,14 @@ export interface ClickedOnDuplicateArtwork {
   flow: string
 }
 /**
- *  User clicks save & continue and the address validation modal pops up.
- *
- *  This schema describes events sent to Segment from [[clickedValidationAddress]]
- *
- *  @example
- *  ```
- *  {
- *    action: "clickedValidationAddress",
- *    context_module: "OrdersShipping",
- *    context_page_owner_type: "orders-shipping",
- *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
- *    user_id: "61bcda16515b038ce5000104"
- *  }
- * ```
- */
- export interface ClickedValidationAddress {
-  action: ActionType.clickedValidationAddress
-  context_module: ContextModule
-  context_page_owner_type: string
-  context_page_owner_id: string
-  user_id: string
-}
-/**
  *  User clicks on one of the buttons on the validation address modal.
  *
- *  This schema describes events sent to Segment from [[clickedValidationAddressButtons]]
+ *  This schema describes events sent to Segment from [[clickedValidationAddressOptions]]
  *
  *  @example
  *  ```
  *  {
- *    action: "clickedValidationAddressButtons",
+ *    action: "clickedValidationAddressOptions",
  *    context_module: "OrdersShipping",
  *    context_page_owner_type: "orders-shipping",
  *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
@@ -1648,8 +1625,8 @@ export interface ClickedOnDuplicateArtwork {
  *  }
  * ```
  */
- export interface ClickedValidationAddressButtons {
-  action: ActionType.clickedValidationAddressButtons
+ export interface ClickedValidationAddressOptions {
+  action: ActionType.clickedValidationAddressOptions
   context_module: ContextModule
   context_page_owner_type: string
   context_page_owner_id: string

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1608,7 +1608,7 @@ export interface ClickedOnDuplicateArtwork {
   flow: string
 }
 /**
- *  User clicks on one of the buttons on the validation address modal.
+ *  User clicks save & continue and the address validation modal pops up.
  *
  *  This schema describes events sent to Segment from [[clickedValidationAddress]]
  *
@@ -1620,13 +1620,36 @@ export interface ClickedOnDuplicateArtwork {
  *    context_page_owner_type: "orders-shipping",
  *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
  *    user_id: "61bcda16515b038ce5000104"
- *    subject: Check your delivery address
- *    label: Use This Address
  *  }
  * ```
  */
  export interface ClickedValidationAddress {
   action: ActionType.clickedValidationAddress
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
+  user_id: string
+}
+/**
+ *  User clicks on one of the buttons on the validation address modal.
+ *
+ *  This schema describes events sent to Segment from [[clickedValidationAddressButtons]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedValidationAddressButtons",
+ *    context_module: "OrdersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    user_id: "61bcda16515b038ce5000104"
+ *    subject: Check your delivery address
+ *    label: Use This Address
+ *  }
+ * ```
+ */
+ export interface ClickedValidationAddressButtons {
+  action: ActionType.clickedValidationAddressButtons
   context_module: ContextModule
   context_page_owner_type: string
   context_page_owner_id: string

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1621,6 +1621,7 @@ export interface ClickedOnDuplicateArtwork {
  *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
  *    user_id: "61bcda16515b038ce5000104"
  *    subject: Check your delivery address
+ *    option: Recommended
  *    label: Use This Address
  *  }
  * ```
@@ -1632,5 +1633,6 @@ export interface ClickedOnDuplicateArtwork {
   context_page_owner_id: string
   user_id: string
   subject: string
+  option: string
   label: string
 }

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1607,3 +1607,30 @@ export interface ClickedOnDuplicateArtwork {
   label: string
   flow: string
 }
+/**
+ *  User clicks on one of the buttons on the validation address modal.
+ *
+ *  This schema describes events sent to Segment from [[clickedValidationAddress]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedValidationAddress",
+ *    context_module: "OrdersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    user_id: "61bcda16515b038ce5000104"
+ *    subject: Check your delivery address
+ *    label: Use This Address
+ *  }
+ * ```
+ */
+ export interface ClickedValidationAddress {
+  action: ActionType.clickedValidationAddress
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
+  user_id: string
+  subject: string
+  label: string
+}

--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -109,3 +109,30 @@ export interface ErrorMessageViewed {
   error_code?: string
   flow: string
 }
+
+/**
+ * User sees address validation modals.
+ *
+ * This schema describes events sent to Segment from [[ValidationAddressViewed]].
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "validationAddressViewed",
+ *    context_module: "OrdersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    user_id: "61bcda16515b038ce5000104"
+ *    flow: "user adding shipping address"
+ *  }
+ * ```
+ *
+ */
+ export interface ValidationAddressViewed {
+  action: ActionType.validationAddressViewed
+  context_module: string
+  context_page_owner_type: string
+  context_page_owner_id: string
+  user_id: string
+  flow: string
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -89,8 +89,7 @@ import {
   ClickedSnooze,
   ClickedVerifyIdentity,
   ClickedViewingRoomCard,
-  ClickedValidationAddress,
-  ClickedValidationAddressButtons,  
+  ClickedValidationAddressOptions,  
 } from "./Click"
 import { EditedUserProfile } from "./CollectorProfile"
 import {
@@ -130,6 +129,7 @@ import {
   ItemViewed,
   RailViewed,
   TooltipViewed,
+  ValidationAddressViewed,
 } from "./ImpressionTracking"
 import {
   AddCollectedArtwork,
@@ -287,8 +287,7 @@ export type Event =
   | ClickedMarkSpam
   | ClickedMarkSold
   | ClickedConversationsFilter
-  | ClickedValidationAddress
-  | ClickedValidationAddressButtons 
+  | ClickedValidationAddressOptions 
   | CommercialFilterParamsChanged
   | CompletedOnboarding
   | ConfirmBid
@@ -319,6 +318,7 @@ export type Event =
   | PriceDatabaseFilterParamsChanged
   | PromptForReview
   | RailViewed
+  | ValidationAddressViewed
   | RegistrationPageView
   | RegistrationSubmitted
   | ResetYourPassword
@@ -713,13 +713,9 @@ export enum ActionType {
    */
   clickedViewingRoomCard = "clickedViewingRoomCard",
   /**
-   * Corresponds to {@link ClickedValidationAddress}
+   * Corresponds to {@link ClickedValidationAddressOptions}
    */
-  clickedValidationAddress = "clickedValidationAddress",
-  /**
-   * Corresponds to {@link ClickedValidationAddressButtons}
-   */
-  clickedValidationAddressButtons = "clickedValidationAddressButtons", 
+  clickedValidationAddressOptions = "clickedValidationAddressOptions", 
   /**
    * Corresponds to {@link CommercialFilterParamsChanged}
    */
@@ -868,6 +864,10 @@ export enum ActionType {
    * Corresponds to {@link RailViewed}
    */
   railViewed = "railViewed",
+  /**
+  * Corresponds to {@link ValidationAddressViewed}
+  */
+  validationAddressViewed = "validationAddressViewed",
   /**
    * Corresponds to {@link RegistrationPageView}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -89,6 +89,7 @@ import {
   ClickedSnooze,
   ClickedVerifyIdentity,
   ClickedViewingRoomCard,
+  ClickedValidationAddress,
 } from "./Click"
 import { EditedUserProfile } from "./CollectorProfile"
 import {
@@ -285,6 +286,7 @@ export type Event =
   | ClickedMarkSpam
   | ClickedMarkSold
   | ClickedConversationsFilter
+  | ClickedValidationAddress
   | CommercialFilterParamsChanged
   | CompletedOnboarding
   | ConfirmBid
@@ -708,6 +710,10 @@ export enum ActionType {
    * Corresponds to {@link ClickedViewingRoomCard}
    */
   clickedViewingRoomCard = "clickedViewingRoomCard",
+  /**
+   * Corresponds to {@link ClickedValidationAddress}
+   */
+  clickedValidationAddress = "clickedValidationAddress",
   /**
    * Corresponds to {@link CommercialFilterParamsChanged}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -90,6 +90,7 @@ import {
   ClickedVerifyIdentity,
   ClickedViewingRoomCard,
   ClickedValidationAddress,
+  ClickedValidationAddressButtons,  
 } from "./Click"
 import { EditedUserProfile } from "./CollectorProfile"
 import {
@@ -287,6 +288,7 @@ export type Event =
   | ClickedMarkSold
   | ClickedConversationsFilter
   | ClickedValidationAddress
+  | ClickedValidationAddressButtons 
   | CommercialFilterParamsChanged
   | CompletedOnboarding
   | ConfirmBid
@@ -714,6 +716,10 @@ export enum ActionType {
    * Corresponds to {@link ClickedValidationAddress}
    */
   clickedValidationAddress = "clickedValidationAddress",
+  /**
+   * Corresponds to {@link ClickedValidationAddressButtons}
+   */
+  clickedValidationAddressButtons = "clickedValidationAddressButtons", 
   /**
    * Corresponds to {@link CommercialFilterParamsChanged}
    */


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [EMI-1285](https://artsyproduct.atlassian.net/browse/EMI-1285)

### Description

This PR adds a new event to Cohesion to track when an user clicks on the buttons on the address verification modals

More details [here](https://www.notion.so/artsy/Address-auto-completion-and-verification-d3a89ec48845408f9d3a2724ce4e09b8?pvs=4#a6d4cf8409504609bdfdb309cd930de3)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[EMI-1285]: https://artsyproduct.atlassian.net/browse/EMI-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ