### PR TITLE
(feat): add modalType option to address validation event

### DIFF
--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -123,7 +123,9 @@ export interface ErrorMessageViewed {
  *    context_page_owner_type: "orders-shipping",
  *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
  *    user_id: "61bcda16515b038ce5000104"
- *    flow: "user adding shipping address"
+ *    flow: "user adding shipping address",
+ *    subject: "Check your delivery address",
+      option: "review and confirm",
  *  }
  * ```
  *
@@ -135,4 +137,6 @@ export interface ErrorMessageViewed {
   context_page_owner_id: string
   user_id: string
   flow: string
+  subject: string
+  option: string
 }


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

The goal of this PR is to add an option and subject property to the `ValidationAddressViewed` tracking event so that analytics can differentiate which modal (address suggestions or general verification error) is viewed by user. We will better be able to analyze triggers here, per @starsirius's notes on this PR: https://github.com/artsy/cohesion/pull/443

@daytavares please let me know if I have things in the right place or if changes are requested. My goal was to make some quick edits to the schema so that we can keep progressing on analytics tracking.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
