### PR TITLE
[AS-4029] Adding new event to track close address validation modal

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1636,3 +1636,30 @@ export interface ClickedOnDuplicateArtwork {
   option: string
   label: string
 }
+/**
+ *  User clicks in one of the options that closes the modal (buttons, x or away from the screen).
+ *
+ *  This schema describes events sent to Segment from [[clickedCloseValidationAddressModal]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedCloseValidationAddressModal",
+ *    context_module: "OrdersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    subject: Check your delivery address
+ *    option: Recommended
+ *    label: X
+ *  }
+ * ```
+ */
+ export interface ClickedCloseValidationAddressModal {
+  action: ActionType.clickedCloseValidationAddressModal
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
+  subject: string
+  option: string
+  label: string
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -89,7 +89,8 @@ import {
   ClickedSnooze,
   ClickedVerifyIdentity,
   ClickedViewingRoomCard,
-  ClickedValidationAddressOptions,  
+  ClickedValidationAddressOptions,
+  ClickedCloseValidationAddressModal,  
 } from "./Click"
 import { EditedUserProfile } from "./CollectorProfile"
 import {
@@ -287,7 +288,8 @@ export type Event =
   | ClickedMarkSpam
   | ClickedMarkSold
   | ClickedConversationsFilter
-  | ClickedValidationAddressOptions 
+  | ClickedValidationAddressOptions
+  | ClickedCloseValidationAddressModal 
   | CommercialFilterParamsChanged
   | CompletedOnboarding
   | ConfirmBid
@@ -716,6 +718,10 @@ export enum ActionType {
    * Corresponds to {@link ClickedValidationAddressOptions}
    */
   clickedValidationAddressOptions = "clickedValidationAddressOptions", 
+  /**
+   * Corresponds to {@link ClickedCloseValidationAddressModal}
+   */
+  clickedCloseValidationAddressModal = "clickedCloseValidationAddressModal",
   /**
    * Corresponds to {@link CommercialFilterParamsChanged}
    */


### PR DESCRIPTION

The type of this PR is: Feature

This PR resolves [EMI-1285](https://artsyproduct.atlassian.net/browse/EMI-1285)

### Description

This PR adds a new event to Cohesion to track when an user clicks on the buttons on the address verification modals

More details [here](https://docs.google.com/spreadsheets/d/1c65vugkF2C4YuXwBXno8aqsBh4B2fTwxiLmgY_MhjWc/edit#gid=0)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[EMI-1285]: https://artsyproduct.atlassian.net/browse/EMI-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ