### PR TITLE
chore: add `artworkClosedLotHeader` context module

### DIFF
--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -22,6 +22,7 @@ export enum ContextModule {
   artistSeriesTab = "artistSeriesTab",
   artistsTab = "artistsTab",
   artistsToFollowRail = "artistsToFollowRail",
+  artworkClosedLotHeader = "artworkClosedLotHeader",
   artworkDetails = "artworkDetails",
   artworkGrid = "artworkGrid",
   artworkImage = "artworkImage",
@@ -208,6 +209,7 @@ export type AuthContextModule =
   | ContextModule.artistSeriesTab
   | ContextModule.artistsTab
   | ContextModule.artistsToFollowRail
+  | ContextModule.artworkClosedLotHeader
   | ContextModule.artworkGrid
   | ContextModule.artworkImage
   | ContextModule.artworkSidebar


### PR DESCRIPTION
### Description

We've recently added a new section to the artwork page, only visible on closed auction log pages. The section embeds a Create Alert CTA and button. We'd like to differentiate between clicks on that button vs a similar button within the sidebar.

#### Closed Lot Header (new)

<img width="1434" alt="Screenshot 2023-08-30 at 09 25 49" src="https://github.com/artsy/cohesion/assets/123595/0fc91303-9278-4874-a151-f0cd8f6239d3">

#### Artwork Sidebar (existing)

<img width="501" alt="Screenshot 2023-08-30 at 09 27 51" src="https://github.com/artsy/cohesion/assets/123595/393fead0-0a69-4d4b-9a7a-1e27a9f58fe8">

cc/ @tam-kis 

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
