### PR TITLE
feat: add create alert header contextmodule and screen ownertype

### DIFF
--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -62,6 +62,7 @@ export enum ContextModule {
   conversationBuyNowConfirmArtwork = "conversationBuyNowConfirmArtwork",
   conversationMakeOfferConfirmArtwork = "conversationMakeOfferConfirmArtwork",
   createAlert = "createAlert",
+  createAlertHeader = "createAlertHeader",
   curatedCollections = "curatedCollections",
   curatedHighlightsRail = "curatedHighlightsRail",
   curatedTrendingArtistsRail = "curatedTrendingArtistsRail",

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -31,6 +31,7 @@ export enum OwnerType {
   consignmentSubmission = "consignmentSubmission",
   conversation = "conversation",
   conversationMakeOfferConfirmArtwork = "conversationMakeOfferConfirmArtwork",
+  createAlert = "createAlert",
   demand = "demand",
   editProfile = "editProfile",
   explore = "explore",
@@ -120,6 +121,7 @@ export type ScreenOwnerType =
   | OwnerType.consignmentSubmission
   | OwnerType.conversation
   | OwnerType.conversationMakeOfferConfirmArtwork
+  | OwnerType.createAlert
   | OwnerType.editProfile
   | OwnerType.explore
   | OwnerType.fair


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [ONYX-307]

### Description

This PR adds the required context module and owner type needed in order to track create alert info button press

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[ONYX-307]: https://artsyproduct.atlassian.net/browse/ONYX-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ