### PR TITLE
[AS-4137] Address auto completion tracking

### DIFF
--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -237,27 +237,29 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
 }
 
 /**
- * A user focuses out an address line box when there is input
- *
- * This schema describes events sent to Segment from [[focusedOutAddresssBox]]
+ * User fills shipping address and has/or not auto completion with results
+ * 
+ * This schema describes events sent to Segment from [[addressAutoCompletionResult]]
  *
  *  @example
  *  ```
  *  {
- *    action: "focusedOutAddresssBox",
+ *    action: "addressAutoCompletionResult",
  *    context_module:"OrdersShipping",
  *    context_page_owner_type: "orders-shipping",
  *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
  *    input: "Weserstr."
+ *    suggested_addresses_results: 3 
  *  }
  * ```
  */
- export interface FocusedOutAddresssBox {
-  action: ActionType.focusedOutAddresssBox
+ export interface AddressAutoCompletionResult {
+  action: ActionType.addressAutoCompletionResult
   context_module: ContextModule
   context_owner_type: PageOwnerType
   context_owner_id?: string
   input: string
+  suggested_addresses_results: number 
 }
 
 /**
@@ -274,8 +276,6 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
  *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
  *    input: "Wes"
  *    item: "Weserstr."
- *    fetches: 3
- *    results: 2
  *  }
  * ```
  */
@@ -286,6 +286,29 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
   context_owner_id?: string
   input: string
   item: string
-  fecthes: number
-  results: number
+}
+
+/**
+ * User edits a suggested address
+ *
+ * This schema describes events sent to Segment from [[editedAutocompletedAddress]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "editedAutocompletedAddress",
+ *    context_module:"OrdersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    field: "Address line 2"
+ *  }
+ * ```
+ */
+ export interface EditedAutocompletedAddress {
+  action: ActionType.editedAutocompletedAddress
+  context_module: ContextModule
+  context_owner_type: PageOwnerType
+  context_owner_id?: string
+  input: string
+  field: string
 }

--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -235,3 +235,77 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
   destination_path: string
   label: "Artworks" | "Auction Results"
 }
+
+/**
+ * A User fills shipping address and has auto completion with results
+ *
+ * This schema describes events sent to Segment from [[addressAutoCompletionWithResults]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "addressAutoCompletionWithResults",
+ *    context_module:"OrdersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    input: "Weserstr."
+ *  }
+ * ```
+ */
+ export interface AddressAutoCompletionWithResults {
+  action: ActionType.addressAutoCompletionWithResults
+  context_module: ContextModule
+  context_owner_type: PageOwnerType
+  context_owner_id?: string
+  input: string
+}
+
+/**
+ * A User fills shipping address and has auto completion with no results
+ *
+ * This schema describes events sent to Segment from [[addressAutoCompletionWithNoResults]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "addressAutoCompletionWithNoResults",
+ *    context_module:"OrdersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    input: "Wes"
+ *  }
+ * ```
+ */
+ export interface AddressAutoCompletionWithNoResults {
+  action: ActionType.addressAutoCompletionWithNoResults
+  context_module: ContextModule
+  context_owner_type: PageOwnerType
+  context_owner_id?: string
+  input: string
+}
+
+/**
+ * A User selects one address from the address auto completion options
+ *
+ * This schema describes events sent to Segment from [[selectedItemFromAddressAutoCompletion]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "selectedItemFromAddressAutoCompletion",
+ *    context_module:"OrdersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    input: "Wes"
+ *    item: "Weserstr."
+ *  }
+ * ```
+ */
+ export interface SelectedItemFromAddressAutoCompletion {
+  action: ActionType.selectedItemFromAddressAutoCompletion
+  context_module: ContextModule
+  context_owner_type: PageOwnerType
+  context_owner_id?: string
+  input: string
+  item: string
+}

--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -237,7 +237,7 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
 }
 
 /**
- * User fills shipping address and has/or not auto completion with results
+ * User fills address and has/or not auto completion with results
  * 
  * This schema describes events sent to Segment from [[addressAutoCompletionResult]]
  *

--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -309,6 +309,5 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
   context_module: ContextModule
   context_owner_type: PageOwnerType
   context_owner_id?: string
-  input: string
   field: string
 }

--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -237,14 +237,14 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
 }
 
 /**
- * A User fills shipping address and has auto completion with results
+ * A user focuses out an address line box when there is input
  *
- * This schema describes events sent to Segment from [[addressAutoCompletionWithResults]]
+ * This schema describes events sent to Segment from [[focusedOutAddresssBox]]
  *
  *  @example
  *  ```
  *  {
- *    action: "addressAutoCompletionWithResults",
+ *    action: "focusedOutAddresssBox",
  *    context_module:"OrdersShipping",
  *    context_page_owner_type: "orders-shipping",
  *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
@@ -252,32 +252,8 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
  *  }
  * ```
  */
- export interface AddressAutoCompletionWithResults {
-  action: ActionType.addressAutoCompletionWithResults
-  context_module: ContextModule
-  context_owner_type: PageOwnerType
-  context_owner_id?: string
-  input: string
-}
-
-/**
- * A User fills shipping address and has auto completion with no results
- *
- * This schema describes events sent to Segment from [[addressAutoCompletionWithNoResults]]
- *
- *  @example
- *  ```
- *  {
- *    action: "addressAutoCompletionWithNoResults",
- *    context_module:"OrdersShipping",
- *    context_page_owner_type: "orders-shipping",
- *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
- *    input: "Wes"
- *  }
- * ```
- */
- export interface AddressAutoCompletionWithNoResults {
-  action: ActionType.addressAutoCompletionWithNoResults
+ export interface FocusedOutAddresssBox {
+  action: ActionType.focusedOutAddresssBox
   context_module: ContextModule
   context_owner_type: PageOwnerType
   context_owner_id?: string
@@ -298,6 +274,8 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
  *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
  *    input: "Wes"
  *    item: "Weserstr."
+ *    fetches: 3
+ *    results: 2
  *  }
  * ```
  */
@@ -308,4 +286,6 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
   context_owner_id?: string
   input: string
   item: string
+  fecthes: number
+  results: number
 }

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -171,6 +171,9 @@ import {
   SelectedItemFromPriceDatabaseSearch,
   SelectedItemFromSearch,
   SelectedSearchSuggestionQuickNavigationItem,
+  AddressAutoCompletionWithResults,
+  AddressAutoCompletionWithNoResults,
+  SelectedItemFromAddressAutoCompletion,
 } from "./Search"
 import { Share } from "./Share"
 import { SaleScreenLoadComplete, Screen, TimeOnPage } from "./System"
@@ -222,6 +225,8 @@ export type Event =
   | AddedArtworkToArtworkList
   | AddToCalendar
   | AddCollectedArtwork
+  | AddressAutoCompletionWithResults
+  | AddressAutoCompletionWithNoResults
   | ArtworkDetailsCompleted
   | AuctionPageView
   | AuctionResultsFilterParamsChanged
@@ -340,6 +345,7 @@ export type Event =
   | SelectedArtworkFromReverseImageSearch
   | SelectedItemFromSearch
   | SelectedItemFromPriceDatabaseSearch
+  |SelectedItemFromAddressAutoCompletion
   | SelectedRecentPriceRange
   | SelectedSearchSuggestionQuickNavigationItem
   | SentConsignmentInquiry
@@ -434,6 +440,14 @@ export enum ActionType {
    * Corresponds to {@link AddToCalendar}
    */
   addToCalendar = "addToCalendar",
+  /**
+   * Corresponds to {@link AddressAutoCompletionWithResults}
+   */
+   addressAutoCompletionWithResults = "addressAutoCompletionWithResults",
+  /**
+   * Corresponds to {@link AddressAutoCompletionWithNoResults}
+   */
+   addressAutoCompletionWithNoResults = "addressAutoCompletionWithNoResults",
   /**
    * Corresponds to {@link ArtworkDetailsCompleted}
    */
@@ -962,6 +976,10 @@ export enum ActionType {
    * Corresponds to {@link SelectedItemFromSearch}
    */
   selectedItemFromSearch = "selectedItemFromSearch",
+  /**
+   * Corresponds to {@link SelectedItemFromAddressAutoCompletion}
+   */
+  selectedItemFromAddressAutoCompletion = "selectedItemFromAddressAutoCompletion",
   /**
    * Corresponds to {@link SelectedRecentPriceRange}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -165,14 +165,13 @@ import {
   ConsignmentArtistFailed,
   FocusedOnPriceDatabaseSearchInput,
   FocusedOnSearchInput,
+  FocusedOutAddresssBox,
   SearchedPriceDatabase,
   SearchedWithNoResults,
   SearchedWithResults,
   SelectedItemFromPriceDatabaseSearch,
   SelectedItemFromSearch,
   SelectedSearchSuggestionQuickNavigationItem,
-  AddressAutoCompletionWithResults,
-  AddressAutoCompletionWithNoResults,
   SelectedItemFromAddressAutoCompletion,
 } from "./Search"
 import { Share } from "./Share"
@@ -225,8 +224,6 @@ export type Event =
   | AddedArtworkToArtworkList
   | AddToCalendar
   | AddCollectedArtwork
-  | AddressAutoCompletionWithResults
-  | AddressAutoCompletionWithNoResults
   | ArtworkDetailsCompleted
   | AuctionPageView
   | AuctionResultsFilterParamsChanged
@@ -321,6 +318,7 @@ export type Event =
   | FocusedOnConversationMessageInput
   | FocusedOnSearchInput
   | FocusedOnPriceDatabaseSearchInput
+  | FocusedOutAddresssBox
   | FollowEvents
   | Impression
   | MaxBidSelected
@@ -440,14 +438,6 @@ export enum ActionType {
    * Corresponds to {@link AddToCalendar}
    */
   addToCalendar = "addToCalendar",
-  /**
-   * Corresponds to {@link AddressAutoCompletionWithResults}
-   */
-   addressAutoCompletionWithResults = "addressAutoCompletionWithResults",
-  /**
-   * Corresponds to {@link AddressAutoCompletionWithNoResults}
-   */
-   addressAutoCompletionWithNoResults = "addressAutoCompletionWithNoResults",
   /**
    * Corresponds to {@link ArtworkDetailsCompleted}
    */
@@ -848,6 +838,10 @@ export enum ActionType {
    * Corresponds to {@link FocusedOnSearchInput}
    */
   focusedOnSearchInput = "focusedOnSearchInput",
+  /**
+   * Corresponds to {@link FocusedOutAddresssBox}
+   */
+   focusedOutAddresssBox = "focusedOutAddresssBox",
   /**
    * Corresponds to {@link FollowedArtist}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -435,7 +435,7 @@ export enum ActionType {
   /**
    * Corresponds to {@link AddressAutoCompletionResult}
    */
-   addressAutoCompletionResult = "addressAutoCompletionResult",
+  addressAutoCompletionResult = "addressAutoCompletionResult",
   /**
    * Corresponds to {@link AddNewArtistName}
    */
@@ -803,7 +803,7 @@ export enum ActionType {
   /**
    * Corresponds to {@link EditedAutocompletedAddress}
    */
-   editedAutocompletedAddress = "editedAutocompletedAddress",
+  editedAutocompletedAddress = "editedAutocompletedAddress",
   /**
    * Corresponds to {@link EditedArtworkList}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -162,10 +162,11 @@ import {
 import { DeletedSavedSearch, EditedSavedSearch } from "./SavedSearch"
 import { FollowEvents } from "./SavesAndFollows"
 import {
+  AddressAutoCompletionResult,
   ConsignmentArtistFailed,
+  EditedAutocompletedAddress,
   FocusedOnPriceDatabaseSearchInput,
   FocusedOnSearchInput,
-  FocusedOutAddresssBox,
   SearchedPriceDatabase,
   SearchedWithNoResults,
   SearchedWithResults,
@@ -224,6 +225,7 @@ export type Event =
   | AddedArtworkToArtworkList
   | AddToCalendar
   | AddCollectedArtwork
+  | AddressAutoCompletionResult
   | ArtworkDetailsCompleted
   | AuctionPageView
   | AuctionResultsFilterParamsChanged
@@ -308,6 +310,7 @@ export type Event =
   | DeletedSavedSearch
   | EditCollectedArtwork
   | EditedArtworkList
+  | EditedAutocompletedAddress
   | EditedSavedSearch
   | EditedUserProfile
   | EnterLiveAuction
@@ -318,7 +321,6 @@ export type Event =
   | FocusedOnConversationMessageInput
   | FocusedOnSearchInput
   | FocusedOnPriceDatabaseSearchInput
-  | FocusedOutAddresssBox
   | FollowEvents
   | Impression
   | MaxBidSelected
@@ -430,6 +432,10 @@ export enum ActionType {
    * Corresponds to {@link AddCollectedArtwork}
    */
   addCollectedArtwork = "addCollectedArtwork",
+  /**
+   * Corresponds to {@link AddressAutoCompletionResult}
+   */
+   addressAutoCompletionResult = "addressAutoCompletionResult",
   /**
    * Corresponds to {@link AddNewArtistName}
    */
@@ -795,6 +801,10 @@ export enum ActionType {
    */
   editCollectedArtwork = "editCollectedArtwork",
   /**
+   * Corresponds to {@link EditedAutocompletedAddress}
+   */
+   editedAutocompletedAddress = "editedAutocompletedAddress",
+  /**
    * Corresponds to {@link EditedArtworkList}
    */
   editedArtworkList = "editedArtworkList",
@@ -838,10 +848,6 @@ export enum ActionType {
    * Corresponds to {@link FocusedOnSearchInput}
    */
   focusedOnSearchInput = "focusedOnSearchInput",
-  /**
-   * Corresponds to {@link FocusedOutAddresssBox}
-   */
-   focusedOutAddresssBox = "focusedOutAddresssBox",
   /**
    * Corresponds to {@link FollowedArtist}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -345,7 +345,7 @@ export type Event =
   | SelectedArtworkFromReverseImageSearch
   | SelectedItemFromSearch
   | SelectedItemFromPriceDatabaseSearch
-  |SelectedItemFromAddressAutoCompletion
+  | SelectedItemFromAddressAutoCompletion
   | SelectedRecentPriceRange
   | SelectedSearchSuggestionQuickNavigationItem
   | SentConsignmentInquiry


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [AS-4137]

### Description

This PR adds a new event to Cohesion to track user interactions with shipping address auto completion

More details [here](https://docs.google.com/spreadsheets/d/1c65vugkF2C4YuXwBXno8aqsBh4B2fTwxiLmgY_MhjWc/edit#gid=0)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[AS-4137]: https://artsyproduct.atlassian.net/browse/AS-4137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ