### PR TITLE
feat(ONYX-255): add clickedBrowseSimilarArtworks action type

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -208,30 +208,6 @@ export interface ClickedAuctionResultItem extends ClickedEntityGroup {
 }
 
 /**
- * A user clicks the Browse Similar Artworks button on an closed auction artwork page
- *
- * This schema describes events sent to Segment from [[clickedBrowseSimilarArtworks]]
- *
- *  @example
- *  ```
- *  {
- *    action: "clickedBrowseSimilarArtworks",
- *    context_module: "artworkClosedLotHeader",
- *    context_page_owner_type: "artwork",
- *    context_screen_owner_id: "5fad78273c8451000d0c53b9",
- *    context_screen_owner_slug: "andy-warhol",
- *  }
- * ```
- */
-export interface ClickedBrowseSimilarArtworks {
-  action: ActionType.clickedBrowseSimilarArtworks
-  context_module: ContextModule
-  context_page_owner_type: string
-  context_screen_owner_id?: string
-  context_screen_owner_slug?: string
-}
-
-/**
  * A user clicks a grouping of collections on web
  *
  * This schema describes events sent to Segment from [[clickedEntityGroup]]

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -210,7 +210,7 @@ export interface ClickedAuctionResultItem extends ClickedEntityGroup {
 /**
  * A user clicks the Browse Similar Artworks button on an closed auction artwork page
  *
- * This schema describes events sent to Segment from [[clickedEntityGroup]]
+ * This schema describes events sent to Segment from [[clickedBrowseSimilarArtworks]]
  *
  *  @example
  *  ```
@@ -218,11 +218,17 @@ export interface ClickedAuctionResultItem extends ClickedEntityGroup {
  *    action: "clickedBrowseSimilarArtworks",
  *    context_module: "artworkClosedLotHeader",
  *    context_page_owner_type: "artwork",
+ *    context_screen_owner_id: "5fad78273c8451000d0c53b9",
+ *    context_screen_owner_slug: "andy-warhol",
  *  }
  * ```
  */
-export interface ClickedBrowseSimilarArtworks extends ClickedEntityGroup {
-  acttion: ActionType.clickedBrowseSimilarArtworks
+export interface ClickedBrowseSimilarArtworks {
+  action: ActionType.clickedBrowseSimilarArtworks
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_screen_owner_id?: string
+  context_screen_owner_slug?: string
 }
 
 /**

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -208,6 +208,24 @@ export interface ClickedAuctionResultItem extends ClickedEntityGroup {
 }
 
 /**
+ * A user clicks the Browse Similar Artworks button on an closed auction artwork page
+ *
+ * This schema describes events sent to Segment from [[clickedEntityGroup]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedBrowseSimilarArtworks",
+ *    context_module: "artworkClosedLotHeader",
+ *    context_page_owner_type: "artwork",
+ *  }
+ * ```
+ */
+export interface ClickedBrowseSimilarArtworks extends ClickedEntityGroup {
+  acttion: ActionType.clickedBrowseSimilarArtworks
+}
+
+/**
  * A user clicks a grouping of collections on web
  *
  * This schema describes events sent to Segment from [[clickedEntityGroup]]

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -167,6 +167,26 @@ export interface TappedAuctionResultGroup extends TappedEntityGroup {
 }
 
 /**
+ * A user clicks the Browse Similar Artworks button on an closed auction artwork page
+ *
+ * This schema describes events sent to Segment from [[tappedBrowseSimilarArtworks]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedBrowseSimilarArtworks",
+ *    context_module: "artworkClosedLotHeader",
+ *    context_page_owner_type: "artwork",
+ *    context__owner_id: "5fad78273c8451000d0c53b9",
+ *    context_screen_owner_slug: "andy-warhol",
+ *  }
+ * ```
+ */
+export interface TappedBrowseSimilarArtworks extends TappedEntityGroup {
+  action: ActionType.tappedBrowseSimilarArtworks
+}
+
+/**
  * A user taps a grouping of collections on iOS
  *
  * This schema describes events sent to Segment from [[tappedEntityGroup]]
@@ -248,6 +268,7 @@ export interface TappedEntityGroup {
     | ActionType.tappedArtworkGroup
     | ActionType.tappedAuctionGroup
     | ActionType.tappedAuctionResultGroup
+    | ActionType.tappedBrowseSimilarArtworks
     | ActionType.tappedCollectionGroup
     | ActionType.tappedExploreGroup
     | ActionType.tappedFairGroup

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -43,7 +43,6 @@ import {
   ClickedArtworkGroup,
   ClickedAuctionGroup,
   ClickedAuctionResultItem,
-  ClickedBrowseSimilarArtworks,
   ClickedBuyerProtection,
   ClickedChangePage,
   ClickedChangePaymentMethod,
@@ -184,6 +183,7 @@ import {
   TappedAuctionGroup,
   TappedAuctionResultGroup,
   TappedBid,
+  TappedBrowseSimilarArtworks,
   TappedBuyNow,
   TappedCollectionGroup,
   TappedConsign,
@@ -242,7 +242,6 @@ export type Event =
   | ClickedArtworkGroup
   | ClickedAuctionGroup
   | ClickedAuctionResultItem
-  | ClickedBrowseSimilarArtworks
   | ClickedBuyerProtection
   | ClickedChangePage
   | ClickedChangePaymentMethod
@@ -359,6 +358,7 @@ export type Event =
   | TappedAuctionGroup
   | TappedAuctionResultGroup
   | TappedBid
+  | TappedBrowseSimilarArtworks
   | TappedBuyNow
   | TappedCollectedArtwork
   | TappedCollectedArtworkImages
@@ -512,10 +512,6 @@ export enum ActionType {
    *    * Corresponds to {@link ClickedAuctionResultItem}
    */
   clickedAuctionResultItem = "clickedAuctionResultItem",
-  /**
-   * Corresponds to {@link ClickedBrowseSimilarArtworks}
-   */
-  clickedBrowseSimilarArtworks = "clickedBrowseSimilarArtworks",
   /**
    * Corresponds to {@link ClickedBuyerProtection}
    */
@@ -1036,6 +1032,10 @@ export enum ActionType {
    * Corresponds to {@link TappedBid}
    */
   tappedBid = "tappedBid",
+  /**
+   * Corresponds to {@link TappedBrowseSimilarArtworks}
+   */
+  tappedBrowseSimilarArtworks = "tappedBrowseSimilarArtworks",
   /**
    * Corresponds to {@link TappedBuyNow}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -43,6 +43,7 @@ import {
   ClickedArtworkGroup,
   ClickedAuctionGroup,
   ClickedAuctionResultItem,
+  ClickedBrowseSimilarArtworks,
   ClickedBuyerProtection,
   ClickedChangePage,
   ClickedChangePaymentMethod,
@@ -241,6 +242,7 @@ export type Event =
   | ClickedArtworkGroup
   | ClickedAuctionGroup
   | ClickedAuctionResultItem
+  | ClickedBrowseSimilarArtworks
   | ClickedBuyerProtection
   | ClickedChangePage
   | ClickedChangePaymentMethod
@@ -510,6 +512,10 @@ export enum ActionType {
    *    * Corresponds to {@link ClickedAuctionResultItem}
    */
   clickedAuctionResultItem = "clickedAuctionResultItem",
+  /**
+   * Corresponds to {@link ClickedBrowseSimilarArtworks}
+   */
+  clickedBrowseSimilarArtworks = "clickedBrowseSimilarArtworks",
   /**
    * Corresponds to {@link ClickedBuyerProtection}
    */


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [ONYX-255]

### Description

<!-- Implementation description -->

Add `clickedBrowseSimilarArtworks`
To be used for the "Browse Similar Works" button in the Create Alert Header on the artwork page

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[ONYX-255]: https://artsyproduct.atlassian.net/browse/ONYX-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ