### PR TITLE
feat(AMBER-207): add context module for demand page, use page owner types

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1629,7 +1629,7 @@ export interface ClickedOnDuplicateArtwork {
 export interface ClickedValidationAddressOptions {
   action: ActionType.clickedValidationAddressOptions
   context_module: ContextModule
-  context_page_owner_type: string
+  context_page_owner_type: PageOwnerType
   context_page_owner_id: string
   user_id: string
   subject: string
@@ -1657,7 +1657,7 @@ export interface ClickedValidationAddressOptions {
 export interface ClickedCloseValidationAddressModal {
   action: ActionType.clickedCloseValidationAddressModal
   context_module: ContextModule
-  context_page_owner_type: string
+  context_page_owner_type: PageOwnerType
   context_page_owner_id: string
   subject: string
   option: string
@@ -1684,7 +1684,7 @@ export interface ClickedCloseValidationAddressModal {
 export interface ClickedNavBar {
   action: ActionType.clickedNavBar
   context_module: ContextModule
-  context_page_owner_type: string
+  context_page_owner_type: PageOwnerType
   context_page_owner_id?: string
   destination_path: string
   subject: string
@@ -1711,7 +1711,7 @@ export interface ClickedNavBar {
 export interface ClickedUploadArtwork {
   action: ActionType.clickedUploadArtwork
   context_module: ContextModule
-  context_page_owner_type: string
+  context_page_owner_type: PageOwnerType
   context_page_owner_id?: string
   artist_id?: string
   search_criteria_id?: string

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -9,6 +9,8 @@ export enum ContextModule {
   aboutThisAuction = "aboutThisAuction",
   adServer = "adServer",
   activityRail = "activityRail",
+  alertsWithPrice = "alertsWithPrice",
+  alertsWithoutPrice = "alertsWithoutPrice",
   articleArtist = "articleArtist",
   articleRail = "articleRail",
   article = "article",


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [AMBER-207]

### Description

Adds context modules for CMS /demand page, and updates a few Click events to use proper pageOwnerType.

Not sure if we also need to add more events for other demand tracking. Question in slack [here](https://artsy.slack.com/archives/C05F8TNKGAV/p1694795397204869).

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[AMBER-207]: https://artsyproduct.atlassian.net/browse/AMBER-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ