### PR TITLE
DIA-112 Adding tracking of clicks on the gallery verified rep pill

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1727,23 +1727,19 @@ export interface ClickedUploadArtwork {
  *  ```
  *  {
  *    action: "clickedVerifiedRepresentative",
- *    context_module: "alerts-price"
+ *    context_module: ""
  *    context_page_owner_type: PageOwnerType
- *    context_page_owner_id?: string
- *    context_page_owner_slug?: string
- *    artist_id?: string
+ *    context_page_owner_id?: "artist_id"
  *    destination_page_owner_type: PageOwnerType
- *    destination_page_owner_id?: string
- *    destination_page_owner_slug?: string
+ *    destination_page_owner_id?: "partner_id"
  *  }
  * ```
  */
 export interface ClickedVerifiedRepresentative {
   action: ActionType.clickedVerifiedRepresentative
-  context_module: ContextModule
+  context_module?: ContextModule
   context_page_owner_type: PageOwnerType
   context_page_owner_id: string
-  context_page_owner_slug?: string
   destination_page_owner_type: PageOwnerType
   destination_page_owner_id: string
 }

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1717,3 +1717,33 @@ export interface ClickedUploadArtwork {
   search_criteria_id?: string
   subject: string
 }
+
+/**
+ *  User clicks on the gallery representation pill under featured representation on the artist page 
+ *
+ *  This schema describes events sent to Segment from [[clickedVerifiedRepresentative]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedVerifiedRepresentative",
+ *    context_module: "alerts-price"
+ *    context_page_owner_type: PageOwnerType
+ *    context_page_owner_id?: string
+ *    context_page_owner_slug?: string
+ *    artist_id?: string
+ *    destination_page_owner_type: PageOwnerType
+ *    destination_page_owner_id?: string
+ *    destination_page_owner_slug?: string
+ *  }
+ * ```
+ */
+export interface ClickedVerifiedRepresentative {
+  action: ActionType.clickedVerifiedRepresentative
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id: string
+  context_page_owner_slug?: string
+  destination_page_owner_type: PageOwnerType
+  destination_page_owner_id: string
+}

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -960,3 +960,29 @@ export interface LongPressedArtwork {
   context_screen_owner_id?: string
   context_screen_owner_slug?: string
 }
+
+/**
+ *  User taps on the gallery representation pill under featured representation on the artist page 
+ *
+ *  This schema describes events sent to Segment from [[tappeddVerifiedRepresentative]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedVerifiedRepresentative",
+ *    context_module: ""
+ *    context_screen_owner_type: PageOwnerType
+ *    context_screen_owner_id?: "artist_id"
+ *    destination_screen_owner_type: PageOwnerType
+ *    destination_screen_owner_id?: "partner_id"
+ *  }
+ * ```
+ */
+export interface TappedVerifiedRepresentative {
+  action: ActionType.tappedVerifiedRepresentative
+  context_module?: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id: string
+  destination_screen_owner_type: ScreenOwnerType
+  destination_screen_owner_id: string
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -739,6 +739,10 @@ export enum ActionType {
    */
   clickedCloseValidationAddressModal = "clickedCloseValidationAddressModal",
   /**
+   * Corresponds to {@link ClickedVerifiedRepresentative}
+   */
+  clickedVerifiedRepresentative = "clickedVerifiedRepresentative",
+  /**
    * Corresponds to {@link CommercialFilterParamsChanged}
    */
   commercialFilterParamsChanged = "commercialFilterParamsChanged",

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -1223,6 +1223,10 @@ export enum ActionType {
    */
   tappedViewOffer = "tappedViewOffer",
   /**
+   * Corresponds to {@link TappedVerifiedRepresentative}
+   */
+  tappedVerifiedRepresentative = "tappedVerifiedRepresentative",
+  /**
    * Corresponds to {@link TimeOnPage}
    */
   timeOnPage = "timeOnPage",


### PR DESCRIPTION
The type of this PR is: Enhancement

[DIA-112]

### Description

As we rollout the new gallery verified representation feature on the artist page we want to track users who are clicking on the pill
The new event is surfaced within the already existing click table


[DIA-112]: https://artsyproduct.atlassian.net/browse/DIA-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ