### PR TITLE
Fix examples for address auto completion events

### DIFF
--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -246,8 +246,8 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
  *  {
  *    action: "addressAutoCompletionResult",
  *    context_module:"OrdersShipping",
- *    context_page_owner_type: "orders-shipping",
- *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    context_owner_type: "orders-shipping",
+ *    context_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
  *    input: "Weserstr."
  *    suggested_addresses_results: 3 
  *  }
@@ -272,8 +272,8 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
  *  {
  *    action: "selectedItemFromAddressAutoCompletion",
  *    context_module:"OrdersShipping",
- *    context_page_owner_type: "orders-shipping",
- *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    context_owner_type: "orders-shipping",
+ *    context_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
  *    input: "Wes"
  *    item: "Weserstr."
  *  }
@@ -298,8 +298,8 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
  *  {
  *    action: "editedAutocompletedAddress",
  *    context_module:"OrdersShipping",
- *    context_page_owner_type: "orders-shipping",
- *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    context_owner_type: "orders-shipping",
+ *    context_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
  *    field: "Address line 2"
  *  }
  * ```


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [EMI-1446]

### Description

Fixing examples:
Update the context_page_owner_type and context_page_owner_id to context_owner_type and context_owner_id.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[EMI-1446]: https://artsyproduct.atlassian.net/browse/EMI-1446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ