### PR TITLE
DIA-207 Adding tracking for genes clicks and Highlights on the artist page

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1747,12 +1747,12 @@ export interface ClickedVerifiedRepresentative {
 /**
  * A user clicks one of the related categories(genes) in the artist about tab
  *
- *  This schema describes events sent to Segment from [[clickedRelatedCategory]]
+ *  This schema describes events sent to Segment from [[clickedGene]]
  *
  *  @example
  *  ```
  *  {
- *    action: "clickedRelatedCategory",
+ *    action: "clickedGene",
  *    context_module : "Young British Artists",
  *    context_screen_owner_type: "Artwork",
  *    context_screen_owner_id: "58de681f275b2464fcdde097",
@@ -1763,14 +1763,14 @@ export interface ClickedVerifiedRepresentative {
  *  }
  * ```
  */
-export interface ClickedRelatedCategory {
-  action: ActionType.clickedRelatedCategory
+export interface ClickedGene {
+  action: ActionType.clickedGene
   context_module: ContextModule
-  context_screen_owner_type: PageOwnerType
-  context_screen_owner_id: string
-  context_screen_owner_slug?: string
-  destination_screen_owner_type: PageOwnerType
-  destination_screen_owner_id: string
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id: string
+  context_page_owner_slug?: string
+  destination_page_owner_type: PageOwnerType
+  destination_page_owner_id: string
   subject?: string
 }
 
@@ -1796,7 +1796,7 @@ export interface ClickedRelatedCategory {
 export interface ClickedHighlightAchievement {
   action: ActionType.clickedHighlightAchievement
   context_module: ContextModule
-  context_screen_owner_type: PageOwnerType
-  context_screen_owner_id: string
-  context_screen_owner_slug?: string
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id: string
+  context_page_owner_slug?: string
 }

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1754,11 +1754,11 @@ export interface ClickedVerifiedRepresentative {
  *  {
  *    action: "clickedGene",
  *    context_module : "Young British Artists",
- *    context_screen_owner_type: "Artwork",
- *    context_screen_owner_id: "58de681f275b2464fcdde097",
- *    context_screen_owner_slug: "damien-hirst",
- *    destination_screen_owner_type: "Gene"
- *    destination_screen_owner_id: "58de681f275b2464fcdde097"
+ *    context_page_owner_type: "Artwork",
+ *    context_page_owner_id: "58de681f275b2464fcdde097",
+ *    context_page_owner_slug: "damien-hirst",
+ *    destination_page_owner_type: "Gene"
+ *    destination_page_owner_id: "58de681f275b2464fcdde097"
  *    subject: ""
  *  }
  * ```
@@ -1784,11 +1784,11 @@ export interface ClickedGene {
  *  {
  *    action: "clickedHighlightAchievement",
  *    context_module : "Active Secondary Market",
- *    context_screen_owner_type: "Artwork",
- *    context_screen_owner_id: "58de681f275b2464fcdde097",
- *    context_screen_owner_slug: "damien-hirst",
- *    destination_screen_owner_type: "Gene"
- *    destination_screen_owner_id: "58de681f275b2464fcdde097"
+ *    context_page_owner_type: "Artwork",
+ *    context_page_owner_id: "58de681f275b2464fcdde097",
+ *    context_page_owner_slug: "damien-hirst",
+ *    destination_page_owner_type: "Gene"
+ *    destination_page_owner_id: "58de681f275b2464fcdde097"
  *    subject: ""
  *  }
  * ```

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1743,3 +1743,60 @@ export interface ClickedVerifiedRepresentative {
   destination_page_owner_type: PageOwnerType
   destination_page_owner_id: string
 }
+
+/**
+ * A user clicks one of the related categories(genes) in the artist about tab
+ *
+ *  This schema describes events sent to Segment from [[clickedRelatedCategory]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedRelatedCategory",
+ *    context_module : "Young British Artists",
+ *    context_screen_owner_type: "Artwork",
+ *    context_screen_owner_id: "58de681f275b2464fcdde097",
+ *    context_screen_owner_slug: "damien-hirst",
+ *    destination_screen_owner_type: "Gene"
+ *    destination_screen_owner_id: "58de681f275b2464fcdde097"
+ *    subject: ""
+ *  }
+ * ```
+ */
+export interface ClickedRelatedCategory {
+  action: ActionType.clickedRelatedCategory
+  context_module: ContextModule
+  context_screen_owner_type: PageOwnerType
+  context_screen_owner_id: string
+  context_screen_owner_slug?: string
+  destination_screen_owner_type: PageOwnerType
+  destination_screen_owner_id: string
+  subject?: string
+}
+
+/**
+ * A user clicks one of the Highlight and Achievement toggles in the artist header
+ *
+ * This schema describes events sent to Segment from [[clickedHighlightAchievement]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedHighlightAchievement",
+ *    context_module : "Active Secondary Market",
+ *    context_screen_owner_type: "Artwork",
+ *    context_screen_owner_id: "58de681f275b2464fcdde097",
+ *    context_screen_owner_slug: "damien-hirst",
+ *    destination_screen_owner_type: "Gene"
+ *    destination_screen_owner_id: "58de681f275b2464fcdde097"
+ *    subject: ""
+ *  }
+ * ```
+ */
+export interface ClickedHighlightAchievement {
+  action: ActionType.clickedHighlightAchievement
+  context_module: ContextModule
+  context_screen_owner_type: PageOwnerType
+  context_screen_owner_id: string
+  context_screen_owner_slug?: string
+}

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -986,3 +986,61 @@ export interface TappedVerifiedRepresentative {
   destination_screen_owner_type: ScreenOwnerType
   destination_screen_owner_id: string
 }
+
+/**
+ * A user taps one of the related categories (genes) in the artist about tab
+ *
+ * This schema describes events sent to Segment from [[tappedRelatedCategory]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedRelatedCategory",
+ *    context_module : "Young British Artists",
+ *    context_screen_owner_type: "Artwork",
+ *    context_screen_owner_id: "58de681f275b2464fcdde097",
+ *    context_screen_owner_slug: "damien-hirst",
+ *    destination_screen_owner_type: "Gene"
+ *    destination_screen_owner_id: "58de681f275b2464fcdde097"
+ *    subject: ""
+ *  }
+ * ```
+ */
+export interface TappedRelatedCategory {
+  action: ActionType.tappedRelatedCategory
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id: string
+  context_screen_owner_slug?: string
+  destination_screen_owner_type: ScreenOwnerType
+  destination_screen_owner_id: string
+  /** The text of the tapped button */
+  subject: string
+}
+
+/**
+ * A user taps one of the Highlight and Achievement toggles in the artist header
+ *
+ * This schema describes events sent to Segment from [[tappedHighlightAchievement]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedHighlightAchievement",
+ *    context_module : "Active Secondary Market",
+ *    context_screen_owner_type: "Artwork",
+ *    context_screen_owner_id: "58de681f275b2464fcdde097",
+ *    context_screen_owner_slug: "damien-hirst",
+ *    destination_screen_owner_type: "Gene"
+ *    destination_screen_owner_id: "58de681f275b2464fcdde097"
+ *    subject: ""
+ *  }
+ * ```
+ */
+export interface TappedHighlightAchievement {
+  action: ActionType.tappedHighlightAchievement
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id: string
+  context_screen_owner_slug?: string
+}

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -990,12 +990,12 @@ export interface TappedVerifiedRepresentative {
 /**
  * A user taps one of the related categories (genes) in the artist about tab
  *
- * This schema describes events sent to Segment from [[tappedRelatedCategory]]
+ * This schema describes events sent to Segment from [[tappedGene]]
  *
  *  @example
  *  ```
  *  {
- *    action: "tappedRelatedCategory",
+ *    action: "tappedGene",
  *    context_module : "Young British Artists",
  *    context_screen_owner_type: "Artwork",
  *    context_screen_owner_id: "58de681f275b2464fcdde097",
@@ -1006,8 +1006,8 @@ export interface TappedVerifiedRepresentative {
  *  }
  * ```
  */
-export interface TappedRelatedCategory {
-  action: ActionType.tappedRelatedCategory
+export interface TappedGene {
+  action: ActionType.tappedGene
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id: string

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -753,6 +753,14 @@ export enum ActionType {
    */
   clickedVerifiedRepresentative = "clickedVerifiedRepresentative",
   /**
+   * Corresponds to {@link ClickedRelatedCategory}
+   */
+  clickedRelatedCategory = "clickedRelatedCategory",
+  /**
+   * Corresponds to {@link ClickedHighlightAchievement}
+   */
+  clickedHighlightAchievement = "clickedHighlightAchievement",
+  /**
    * Corresponds to {@link CommercialFilterParamsChanged}
    */
   commercialFilterParamsChanged = "commercialFilterParamsChanged",
@@ -1244,6 +1252,14 @@ export enum ActionType {
    * Corresponds to {@link TappedVerifiedRepresentative}
    */
   tappedVerifiedRepresentative = "tappedVerifiedRepresentative",
+  /**
+   * Corresponds to {@link TappedRelatedCategory}
+   */
+  tappedRelatedCategory = "tappedRelatedCategory",
+  /**
+   * Corresponds to {@link TappedHighlightAchievement}
+   */
+  tappedHighlightAchievement = "tappedHighlightAchievement",
   /**
    * Corresponds to {@link TimeOnPage}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -753,9 +753,9 @@ export enum ActionType {
    */
   clickedVerifiedRepresentative = "clickedVerifiedRepresentative",
   /**
-   * Corresponds to {@link ClickedRelatedCategory}
+   * Corresponds to {@link ClickedGene}
    */
-  clickedRelatedCategory = "clickedRelatedCategory",
+  clickedGene = "clickedGene",
   /**
    * Corresponds to {@link ClickedHighlightAchievement}
    */
@@ -1253,9 +1253,9 @@ export enum ActionType {
    */
   tappedVerifiedRepresentative = "tappedVerifiedRepresentative",
   /**
-   * Corresponds to {@link TappedRelatedCategory}
+   * Corresponds to {@link TappedGene}
    */
-  tappedRelatedCategory = "tappedRelatedCategory",
+  tappedGene = "tappedGene",
   /**
    * Corresponds to {@link TappedHighlightAchievement}
    */


### PR DESCRIPTION
The type of this PR is: Enhancement

This PR resolves [DIA-207]

### Description

This PR adds tracking in Cohesion for both Eigen and Force for 2 events:
- click on one of the gens in the "related categories" section in the about tab of an artist page
- click on one of the accordion in Highlight and Achievements in the Artist header

[DIA-207]: https://artsyproduct.atlassian.net/browse/DIA-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ