### PR TITLE
chore: remove TappedAddFilters event, modify ClickedAddFilters event

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -25,16 +25,12 @@ import { ActionType } from "."
  *  {
  *    action: "clickedAddFilters",
  *    context_module: "alertDetails",
- *    context_page_owner_type: "artist",
- *    context_page_owner_id: "4d8b92b34eb68a1b2c0003f4"
  *  }
  * ```
  */
 export interface ClickedAddFilters {
   action: ActionType.clickedAddFilters
   context_module: ContextModule
-  context_page_owner_type: PageOwnerType
-  context_page_owner_id: string
 }
 
 /**

--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -238,7 +238,7 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
 
 /**
  * User fills address and has/or not auto completion with results
- * 
+ *
  * This schema describes events sent to Segment from [[addressAutoCompletionResult]]
  *
  *  @example
@@ -249,17 +249,17 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
  *    context_owner_type: "orders-shipping",
  *    context_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
  *    input: "Weserstr."
- *    suggested_addresses_results: 3 
+ *    suggested_addresses_results: 3
  *  }
  * ```
  */
- export interface AddressAutoCompletionResult {
+export interface AddressAutoCompletionResult {
   action: ActionType.addressAutoCompletionResult
   context_module: ContextModule
   context_owner_type: PageOwnerType
   context_owner_id?: string
   input: string
-  suggested_addresses_results: number 
+  suggested_addresses_results: number
 }
 
 /**
@@ -279,7 +279,7 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
  *  }
  * ```
  */
- export interface SelectedItemFromAddressAutoCompletion {
+export interface SelectedItemFromAddressAutoCompletion {
   action: ActionType.selectedItemFromAddressAutoCompletion
   context_module: ContextModule
   context_owner_type: PageOwnerType
@@ -304,7 +304,7 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
  *  }
  * ```
  */
- export interface EditedAutocompletedAddress {
+export interface EditedAutocompletedAddress {
   action: ActionType.editedAutocompletedAddress
   context_module: ContextModule
   context_owner_type: PageOwnerType

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -10,31 +10,6 @@ import { ActionType } from "."
  */
 
 /**
- *  A user taps a grouping of entities on iOS
- *
- *  Events are separated by entity type
- *
- */
-
-/**
- *  User taps "Add Filters" button within the alert create/edit flow.
- *
- *  This schema describes events sent to Segment from [[tappedAddFilters]]
- *
- *  @example
- *  ```
- *  {
- *    action: "tappedAddFilters",
- *    context_screen_owner_type: "alertDetails",
- *  }
- * ```
- */
-export interface TappedAddFilters {
-  action: ActionType.tappedAddFilters
-  context_screen_owner_type: ScreenOwnerType
-}
-
-/**
  * A user taps a grouping of articles on iOS
  *
  *  This schema describes events sent to Segment from [[tappedArticleGroup]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -182,7 +182,6 @@ import { Share } from "./Share"
 import { SaleScreenLoadComplete, Screen, TimeOnPage } from "./System"
 import {
   TappedActivityGroup,
-  TappedAddFilters,
   TappedArticleGroup,
   TappedArticleShare,
   TappedArtistGroup,
@@ -365,7 +364,6 @@ export type Event =
   | SubmitAnotherArtwork
   | SuccessfullyLoggedIn
   | TappedActivityGroup
-  | TappedAddFilters
   | TappedArticleGroup
   | TappedArticleShare
   | TappedArtistGroup
@@ -1056,10 +1054,6 @@ export enum ActionType {
    * Corresponds to {@link TappedActivityGroup}
    */
   tappedActivityGroup = "tappedActivityGroup",
-  /**
-   * Corresponds to {@link TappedAddFilters}
-   */
-  tappedAddFilters = "tappedAddFilters",
   /**
    * Corresponds to {@link TappedArticleGroup}
    */


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CO-]

### Description

<!-- Implementation description -->

After reviewing the requirements for the new Create Alert flow, modified it's tracking
- remove TappedAddFilters event
- modify ClickedAddFilters event

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
