### PR TITLE
feat: Add activity context module

### DIFF
--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -212,6 +212,7 @@ export enum ContextModule {
  * Limited ContextModules available for web authentication events
  */
 export type AuthContextModule =
+  | ContextModule.activity
   | ContextModule.aboutTheWork
   | ContextModule.articleTab
   | ContextModule.artistHeader

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -8,6 +8,7 @@ export enum ContextModule {
   aboutTheWork = "aboutTheWork",
   aboutThisAuction = "aboutThisAuction",
   adServer = "adServer",
+  activity = "activity",
   activityRail = "activityRail",
   alertConfirmation = "alertConfirmation",
   alertDetails = "alertDetails",


### PR DESCRIPTION
## Description

Add `activity` as a context module (and `AuthContextModule` because it's required by Force's artwork metadata component) for the new notification/activity page and screen.