### PR TITLE
Adding event tracking for news taps on app

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -1037,3 +1037,29 @@ export interface TappedHighlightAchievement {
   context_screen_owner_id: string
   context_screen_owner_slug?: string
 }
+
+/**
+ * A user taps the dedicated section to news in the app
+ *
+ * This schema describes events sent to Segment from [[tappedNewsSection]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedNewsSection",
+ *    context_module : "", Home or News
+ *    context_screen_owner_type: "Home",
+ *    context_screen_owner_id: "58de681f275b2464fcdde097",
+ *    destination_screen_owner_type: "Artwork"
+ *    destination_screen_owner_id: "58de681f275b2464fcdde097"
+ *  }
+ * ```
+ */
+export interface TappedNewsSection {
+  action: ActionType.tappedNewsSection
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id: string
+  destination_screen_owner_type: ScreenOwnerType
+  destination_screen_owner_id: string
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -1340,6 +1340,10 @@ export enum ActionType {
    */
   tappedHighlightAchievement = "tappedHighlightAchievement",
   /**
+   * Corresponds to {@link TappedNewsSection}
+   */
+  tappedNewsSection = "tappedNewsSection",
+  /**
    * Corresponds to {@link TimeOnPage}
    */
   timeOnPage = "timeOnPage",


### PR DESCRIPTION
The type of this PR is an Enhancement of tracking on app
[link to slack thread](https://artsy.slack.com/archives/C05EEBNEF71/p1711644227011189)

**Resolves:** we’re adding a dedicated section to the news in the app and after some digging I don’t think we have enough tracking on cohesion available for it.