### PR TITLE
chore: AMBER-591 - add private artwork tracking methods

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -2061,3 +2061,95 @@ export interface ClickedUpdateArtwork {
   partner_id: string
   artwork_id: string
 }
+
+/**
+ * A user clicks on the read more link on the private artwork page.
+ *
+ * This schema describes events sent to Segment from [[ClickedOnReadMore]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedOnReadMore",
+ *    context_module: "About the work" | "About the artist" | "Sidebar",
+ *    subject: "Read more"
+ *    type: "Link"
+ *  }
+ * ```
+ */
+export interface ClickedOnReadMore {
+  action: ActionType.clickedOnReadMore
+  context_module: string
+  subject: string
+  type: string
+}
+
+/**
+ * A user clicks on the learn more link on the private artwork page.
+ *
+ * This schema describes events sent to Segment from [[ClickedOnLearnMore]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedOnLearnMore",
+ *    context_module: "Sidebar",
+ *    subject: "Learn more"
+ *    type: "Link"
+ *    flow: "Shipping" | "Artsy Guarantee"
+ *  }
+ * ```
+ */
+export interface ClickedOnLearnMore {
+  action: ActionType.clickedOnLearnMore
+  context_module: string
+  subject: string
+  type: string
+  flow: string
+}
+
+/**
+ * A user clicks on the Gallery name on the private artwork page.
+ *
+ * This schema describes events sent to Segment from [[ClickedOnGalleryName]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedOnGalleryName",
+ *    context_module: "Sidebar",
+ *    subject: "Gallery Name"
+ *    type: "Link"
+ *    flow: "Exclusive Access"
+ *  }
+ * ```
+ */
+export interface ClickedOnGalleryName {
+  action: ActionType.clickedOnGalleryName
+  context_module: string
+  subject: string
+  type: string
+  flow: string
+}
+
+/**
+ * A user clicks on the private listing in the artwork header on the private artwork page.
+ *
+ * This schema describes events sent to Segment from [[ClickedOnPrivateListing]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "ClickedOnPrivateListing",
+ *    context_module: "artworkHeader",
+ *    subject: "Private listing"
+ *    type: "Link"
+ *  }
+ * ```
+ */
+export interface ClickedOnPrivateListing {
+  action: ActionType.clickedOnPrivateListing
+  context_module: string
+  subject: string
+  type: string
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -78,9 +78,13 @@ import {
   ClickedOnDuplicateArtwork,
   ClickedOnFramedMeasurements,
   ClickedOnFramedMeasurementsDropdown,
+  ClickedOnGalleryName,
+  ClickedOnLearnMore,
   ClickedOnMakeOfferCheckbox,
   ClickedOnPagination,
   ClickedOnPriceDisplayDropdown,
+  ClickedOnPrivateListing,
+  ClickedOnReadMore,
   ClickedOnSubmitOrder,
   ClickedOrderPage,
   ClickedOrderSummary,
@@ -290,12 +294,16 @@ export type Event =
   | ClickedOnArtworkShippingWeight
   | ClickedOnArtworkShippingUnitsDropdown
   | ClickedOnBuyNowCheckbox
+  | ClickedOnDuplicateArtwork
   | ClickedOnFramedMeasurements
   | ClickedOnFramedMeasurementsDropdown
+  | ClickedOnGalleryName
+  | ClickedOnLearnMore
   | ClickedOnMakeOfferCheckbox
-  | ClickedOnDuplicateArtwork
   | ClickedOnPagination
   | ClickedOnPriceDisplayDropdown
+  | ClickedOnPrivateListing
+  | ClickedOnReadMore
   | ClickedPublish
   | ClickedOnSubmitOrder
   | ClickedSnooze
@@ -668,6 +676,10 @@ export enum ActionType {
    */
   clickedOnBuyNowCheckbox = "clickedOnBuyNowCheckbox",
   /**
+   * Corresponds to {@link ClickedOnDuplicateArtwork}
+   */
+  clickedOnDuplicateArtwork = "clickedOnDuplicateArtwork",
+  /**
    * Corresponds to {@link ClickedOnFramedMeasurements}
    */
   clickedOnFramedMeasurements = "clickedOnFramedMeasurements",
@@ -676,13 +688,17 @@ export enum ActionType {
    */
   clickedOnFramedMeasurementsDropdown = "clickedOnFramedMeasurementsDropdown",
   /**
+   * Corresponds to {@link ClickedOnGalleryName}
+   */
+  clickedOnGalleryName = "clickedOnGalleryName",
+  /**
+   * Corresponds to {@link ClickedOnLearnMore}
+   */
+  clickedOnLearnMore = "clickedOnLearnMore",
+  /**
    * Corresponds to {@link ClickedOnMakeOfferCheckbox}
    */
   clickedOnMakeOfferCheckbox = "clickedOnMakeOfferCheckbox",
-  /**
-   * Corresponds to {@link ClickedOnDuplicateArtwork}
-   */
-  clickedOnDuplicateArtwork = "clickedOnDuplicateArtwork",
   /**
    * Corresponds to {@link ClickedOnPagination}
    */
@@ -692,9 +708,17 @@ export enum ActionType {
    */
   clickedOnPriceDisplayDropdown = "clickedOnPriceDisplayDropdown",
   /**
+   * Corresponds to {@link ClickedOnPrivateListing}
+   */
+  clickedOnPrivateListing = "clickedOnPrivateListing",
+  /**
    * Corresponds to {@link ClickedPublish}
    */
   clickedPublish = "clickedPublish",
+  /**
+   * Corresponds to {@link ClickedOnReadMore}
+   */
+  clickedOnReadMore = "clickedOnReadMore",
   /**
    * Corresponds to {@link ClickedOnSubmitOrder}
    */


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR partially resolves [AMBER-591]

### Description

<!-- Implementation description -->

This PR adds a few new events to deal with the new events that will take place on the newly created private artwork page.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[AMBER-591]: https://artsyproduct.atlassian.net/browse/AMBER-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ