### PR TITLE
chore: add fieldsProvided to event ConsignmentSubmitted

### DIFF
--- a/src/Schema/Events/Consignments.ts
+++ b/src/Schema/Events/Consignments.ts
@@ -21,6 +21,7 @@ import { ActionType } from "."
  *    submission_id: "66355",
  *    user_email: "xx@gmail.com"
  *    user_id: "5bd8b675776bd6002c86526c"
+ *    fieldsProvided: ["artistId", "title", "height", "width", "depth", "year"]
  *  }
  * ```
  */
@@ -31,6 +32,7 @@ export interface ConsignmentSubmitted {
   submission_id: string
   user_email: string
   user_id?: string
+  fieldsProvided: string[]
 }
 
 /**


### PR DESCRIPTION
The type of this PR is: Chore

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [ONYX-906](https://artsyproduct.atlassian.net/browse/ONYX-906)

### Description

Add `fieldsProvided` to event `ConsignmentSubmitted` in order to track specific fields when the ArtworkDetails form is submitted.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[ONYX-906]: https://artsyproduct.atlassian.net/browse/ONYX-906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ