### PR TITLE
fix: broken TappedBuyNow flow type

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -798,7 +798,7 @@ export interface TappedBuyNow {
   context_owner_id: string
   context_owner_slug: string
   impulse_conversation_id?: string
-  flow: string
+  flow?: "Buy now" | "Partner offer"
 }
 
 /**


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Hey @daytavares - I noticed that this change broke the type check CI step on force https://github.com/artsy/force/pull/13792. I believe some changes need to be made there in order to support the new property "flow" since it's now required. 

Because I don't see any PR doing that currently, I am adjusting the type, temporarily hopefully until such changes are made in Force, to unblock the cohesion upgrade. 

I also noticed that the `flow` property is a string, I changed that to a literal string to make sure we don't send a wrong string.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
