### PR TITLE
chore: Adds optional flow metadata to TappedLearnMore interface

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -918,7 +918,8 @@ export interface TappedConsignmentInquiry {
  *    context_screen_owner_type: "fair",
  *    context_screen_owner_id: "5f4d80c972737e000deff1ed",
  *    context_screen_owner_slug: "latitude-art-fair-2020",
- *    subject: "Learn More"
+ *    subject: "Learn More",
+ *    flow: "Artsy Guarantee"
  *  }
  * ```
  */
@@ -930,6 +931,7 @@ export interface TappedLearnMore {
   context_screen_owner_slug?: string
   /** The text of the tapped button */
   subject: string
+  flow?: string
 }
 
 /**


### PR DESCRIPTION
The type of this PR is: Chore

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->



### Description

Noticed a discrepancy issue between the `Click*` and `Tap*` events while working on the Private Artworks feature in eigen
https://github.com/artsy/eigen/pull/10195

From this project's tracking requirements, we do want to track additional `flow` metadata attrs on the `TappedLearnMore` type events so adding a new optional field to `TappedLearnMore`

Without adjusting this type, we are doing a lot of events by hand in eigen



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
