### PR TITLE
feat: add ClickedBuyNow in events schema

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -275,6 +275,33 @@ export interface ClickedBuyerProtection {
 }
 
 /**
+ * User clicks "Purchase" on an artwork page (BNMO)
+ *
+ * This schema describes events sent to Segment from [[clickedBuyNow]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedBuyNow",
+ *    context_owner_type: "Artwork",
+ *    context_owner_slug: "radna-segal-pearl",
+ *    context_owner_id: "6164889300d643000db86504",
+ *    impulse_conversation_id: "198",
+ *    flow: "Buy now" | "Partner offer"
+ *  }
+ * ```
+ */
+
+export interface ClickedBuyNow {
+  action: ActionType.clickedBuyNow
+  context_owner_type: OwnerType.artwork
+  context_owner_slug: string
+  context_owner_id: string
+  impulse_conversation_id?: string
+  flow?: string
+}
+
+/**
  *  User clicks on Change Payment Method on the orders review page.
  *
  *  This schema describes events sent to Segment from [[clickedChangePaymentMethod]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -580,6 +580,10 @@ export enum ActionType {
    */
   clickedBuyerProtection = "clickedBuyerProtection",
   /**
+   * Corresponds to {@link ClickedBuyNow}
+   */
+  clickedBuyNow = "clickedBuyNow",
+  /**
    * Corresponds to {@link ClickedChangePage}
    */
   clickedChangePage = "clickedChangePage",


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR involves [EMI-1783]

### Description
This PR adds `ClickedBuyNow` event into the Events schema for Force to match the events we have in Eigen
This is a prerequisite to the work for tracking Parter Offer tracking in Force ([ticket details](https://artsyproduct.atlassian.net/browse/EMI-1783) 🔒)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[EMI-1783]: https://artsyproduct.atlassian.net/browse/EMI-1783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ