### PR TITLE
fix: updates the context_owner_type for ClickedBuyNow event

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -294,7 +294,7 @@ export interface ClickedBuyerProtection {
 
 export interface ClickedBuyNow {
   action: ActionType.clickedBuyNow
-  context_owner_type: OwnerType.artwork
+  context_owner_type: OwnerType
   context_owner_slug: string
   context_owner_id: string
   impulse_conversation_id?: string


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves []

### Description
This PR updates the type of `context_owner_type` in the `ClickedBuyNow` event to accept both Notification and Artwork pages, similar to `TappedBuyNow`

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
