### PR TITLE
chore: Add new submission artwork form owner types

### DIFF
--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -21,16 +21,16 @@ export enum OwnerType {
   artwork = "artwork",
 
   artworkFormStart = "artworkFormStart",
-	artworkFormSelectArtist = "artworkFormSelectArtist",
-	artworkFormAddTitle = "artworkFormAddTitle",
-	artworkFormAddPhotos = "artworkFormAddPhotos",
-	artworkFormAddDetails = "artworkFormAddDetails",
-	artworkFormPurchaseHistory = "artworkFormPurchaseHistory",
-	artworkFormAddDimensions = "artworkFormAddDimensions",
-	artworkFormAddPhoneNumber = "artworkFormAddPhoneNumber",
-	artworkFormCompleteYourSubmission = "artworkFormCompleteYourSubmission",
-	artworkFormArtistRejected = "artworkFormArtistRejected",
-	artworkFormSelectArtworkMyCollectionArtwork = "artworkFormSelectArtworkMyCollectionArtwork",
+  artworkFormSelectArtist = "artworkFormSelectArtist",
+  artworkFormAddTitle = "artworkFormAddTitle",
+  artworkFormAddPhotos = "artworkFormAddPhotos",
+  artworkFormAddDetails = "artworkFormAddDetails",
+  artworkFormPurchaseHistory = "artworkFormPurchaseHistory",
+  artworkFormAddDimensions = "artworkFormAddDimensions",
+  artworkFormAddPhoneNumber = "artworkFormAddPhoneNumber",
+  artworkFormCompleteYourSubmission = "artworkFormCompleteYourSubmission",
+  artworkFormArtistRejected = "artworkFormArtistRejected",
+  artworkFormSelectArtworkMyCollectionArtwork = "artworkFormSelectArtworkMyCollectionArtwork",
 
   artworkPriceFilter = "artworkPriceFilter",
   artworkRecommendations = "artworkRecommendations",
@@ -140,16 +140,16 @@ export type ScreenOwnerType =
   | OwnerType.artwork
 
   | OwnerType.artworkFormStart
-	| OwnerType.artworkFormSelectArtist
-	| OwnerType.artworkFormAddTitle
-	| OwnerType.artworkFormAddPhotos
-	| OwnerType.artworkFormAddDetails
-	| OwnerType.artworkFormPurchaseHistory
-	| OwnerType.artworkFormAddDimensions
-	| OwnerType.artworkFormAddPhoneNumber
-	| OwnerType.artworkFormCompleteYourSubmission
-	| OwnerType.artworkFormArtistRejected
-	| OwnerType.artworkFormSelectArtworkMyCollectionArtwork
+  | OwnerType.artworkFormSelectArtist
+  | OwnerType.artworkFormAddTitle
+  | OwnerType.artworkFormAddPhotos
+  | OwnerType.artworkFormAddDetails
+  | OwnerType.artworkFormPurchaseHistory
+  | OwnerType.artworkFormAddDimensions
+  | OwnerType.artworkFormAddPhoneNumber
+  | OwnerType.artworkFormCompleteYourSubmission
+  | OwnerType.artworkFormArtistRejected
+  | OwnerType.artworkFormSelectArtworkMyCollectionArtwork
 
   | OwnerType.artworkPriceFilter
   | OwnerType.artworkRecommendations
@@ -234,16 +234,16 @@ export type PageOwnerType =
   | OwnerType.artwork
 
   | OwnerType.artworkFormStart
-	| OwnerType.artworkFormSelectArtist
-	| OwnerType.artworkFormAddTitle
-	| OwnerType.artworkFormAddPhotos
-	| OwnerType.artworkFormAddDetails
-	| OwnerType.artworkFormPurchaseHistory
-	| OwnerType.artworkFormAddDimensions
-	| OwnerType.artworkFormAddPhoneNumber
-	| OwnerType.artworkFormCompleteYourSubmission
-	| OwnerType.artworkFormArtistRejected
-	| OwnerType.artworkFormSelectArtworkMyCollectionArtwork
+  | OwnerType.artworkFormSelectArtist
+  | OwnerType.artworkFormAddTitle
+  | OwnerType.artworkFormAddPhotos
+  | OwnerType.artworkFormAddDetails
+  | OwnerType.artworkFormPurchaseHistory
+  | OwnerType.artworkFormAddDimensions
+  | OwnerType.artworkFormAddPhoneNumber
+  | OwnerType.artworkFormCompleteYourSubmission
+  | OwnerType.artworkFormArtistRejected
+  | OwnerType.artworkFormSelectArtworkMyCollectionArtwork
 
   | OwnerType.auctions
   | OwnerType.collect

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -19,6 +19,19 @@ export enum OwnerType {
   artists = "artists",
   artistSeries = "artistSeries",
   artwork = "artwork",
+
+  artworkFormStart = "artworkFormStart",
+	artworkFormSelectArtist = "artworkFormSelectArtist",
+	artworkFormAddTitle = "artworkFormAddTitle",
+	artworkFormAddPhotos = "artworkFormAddPhotos",
+	artworkFormAddDetails = "artworkFormAddDetails",
+	artworkFormPurchaseHistory = "artworkFormPurchaseHistory",
+	artworkFormAddDimensions = "artworkFormAddDimensions",
+	artworkFormAddPhoneNumber = "artworkFormAddPhoneNumber",
+	artworkFormCompleteYourSubmission = "artworkFormCompleteYourSubmission",
+	artworkFormArtistRejected = "artworkFormArtistRejected",
+	artworkFormSelectArtworkMyCollectionArtwork = "artworkFormSelectArtworkMyCollectionArtwork",
+
   artworkPriceFilter = "artworkPriceFilter",
   artworkRecommendations = "artworkRecommendations",
   auction = "auction",
@@ -125,6 +138,19 @@ export type ScreenOwnerType =
   | OwnerType.artistAuctionResults
   | OwnerType.artistSeries
   | OwnerType.artwork
+
+  | OwnerType.artworkFormStart
+	| OwnerType.artworkFormSelectArtist
+	| OwnerType.artworkFormAddTitle
+	| OwnerType.artworkFormAddPhotos
+	| OwnerType.artworkFormAddDetails
+	| OwnerType.artworkFormPurchaseHistory
+	| OwnerType.artworkFormAddDimensions
+	| OwnerType.artworkFormAddPhoneNumber
+	| OwnerType.artworkFormCompleteYourSubmission
+	| OwnerType.artworkFormArtistRejected
+	| OwnerType.artworkFormSelectArtworkMyCollectionArtwork
+
   | OwnerType.artworkPriceFilter
   | OwnerType.artworkRecommendations
   | OwnerType.auctionResult
@@ -206,6 +232,19 @@ export type PageOwnerType =
   | OwnerType.artists
   | OwnerType.artistSeries
   | OwnerType.artwork
+
+  | OwnerType.artworkFormStart
+	| OwnerType.artworkFormSelectArtist
+	| OwnerType.artworkFormAddTitle
+	| OwnerType.artworkFormAddPhotos
+	| OwnerType.artworkFormAddDetails
+	| OwnerType.artworkFormPurchaseHistory
+	| OwnerType.artworkFormAddDimensions
+	| OwnerType.artworkFormAddPhoneNumber
+	| OwnerType.artworkFormCompleteYourSubmission
+	| OwnerType.artworkFormArtistRejected
+	| OwnerType.artworkFormSelectArtworkMyCollectionArtwork
+
   | OwnerType.auctions
   | OwnerType.collect
   | OwnerType.collection


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-953

- Eigen PR: https://github.com/artsy/eigen/pull/10330

## Description

This PR adds owner types for the new submission artwork form. Every new owner type represents a step in the flow.

I'm not 100% sure about the naming. I have prefixed them with `artworkForm`, but I'm happy to hear other suggestions.

```
artworkFormStart
artworkFormSelectArtist
artworkFormAddTitle
artworkFormAddPhotos
artworkFormAddDetails
artworkFormPurchaseHistory
artworkFormAddDimensions
artworkFormAddPhoneNumber
artworkFormCompleteYourSubmission
artworkFormArtistRejected
artworkFormSelectArtworkMyCollectionArtwork
  ```
