### PR TITLE
Adding tracking for Complete your profile prompt on web and app

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -2175,3 +2175,19 @@ export interface ClickedViewFullConversationHistory {
   partner_id: string
   inquiry_id: string
 }
+
+/**
+ * A user clicks on the complete your profile prompt within the activity pannel
+ *
+ * This schema describes events sent to Segment from [[clickedCompleteYourProfile]]
+ *
+ */
+
+export interface ClickedCompleteYourProfile {
+  action: ActionType.clickedCompleteYourProfile
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id: string
+  context_page_owner_slug?: string
+  user_id: string
+}

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -1093,3 +1093,20 @@ export interface TappedViewWork {
   artwork_id: string
   notification_type: string
 }
+
+/**
+ * A user taps on the complete your profile prompt within the activity pannel
+ *
+ * This schema describes events sent to Segment from [[tappedCompleteYourProfile]]
+ *
+ */
+
+export interface TappedCompleteYourProfile {
+  action: ActionType.tappedCompleteYourProfile
+  context_module: ContextModule
+  context_screen_owner_type: PageOwnerType
+  context_screen_owner_id: string
+  context_screen_owner_slug?: string
+  user_id: string
+}
+

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -1104,7 +1104,7 @@ export interface TappedViewWork {
 export interface TappedCompleteYourProfile {
   action: ActionType.tappedCompleteYourProfile
   context_module: ContextModule
-  context_screen_owner_type: PageOwnerType
+  context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id: string
   context_screen_owner_slug?: string
   user_id: string

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -604,6 +604,10 @@ export enum ActionType {
    */
   clickedCollectionGroup = "clickedCollectionGroup",
   /**
+   * Corresponds to {@link ClickedCompleteYourProfile}
+   */
+  clickedCompleteYourProfile = "clickedCompleteYourProfile",
+  /**
    * Corresponds to {@link ClickedCreateAlert}
    */
   clickedCreateAlert = "clickedCreateAlert",
@@ -1207,6 +1211,10 @@ export enum ActionType {
    * Corresponds to {@link TappedCollectionGroup}
    */
   tappedCollectionGroup = "tappedCollectionGroup",
+  /**
+   * Corresponds to {@link TappedCompleteYourProfile}
+   */
+  tappedCompleteYourProfile = "tappedCompleteYourProfile",
   /**
    * Corresponds to {@link TappedConsign}
    */


### PR DESCRIPTION
Adding tap and click events for interaction with the 'complete your profile' prompt in the activity pannel