### PR TITLE
amending CollectorProfiles for the new flow

### DIFF
--- a/src/Schema/Events/CollectorProfile.ts
+++ b/src/Schema/Events/CollectorProfile.ts
@@ -25,7 +25,7 @@ import { Platform } from "./MyCollection"
  */
 export interface EditedUserProfile {
   action: ActionType.editedUserProfile
-  context_screen: ContextModule.collectorProfile
-  context_screen_owner_type: OwnerType.editProfile
+  context_screen: ContextModule
+  context_screen_owner_type: OwnerType
   platform: Platform
 }


### PR DESCRIPTION
The values for `ContextModule` and `ContextScreenOwnerType` were hard coded in the Collector profile event. 
With the new flow we're adding this event on other surfaces and this change will allow us to track that 