### PR TITLE
feat: Adding tracking for User prompting flow

### DIFF
--- a/src/Schema/Events/CollectorProfile.ts
+++ b/src/Schema/Events/CollectorProfile.ts
@@ -25,7 +25,8 @@ import { Platform } from "./MyCollection"
  */
 export interface EditedUserProfile {
   action: ActionType.editedUserProfile
-  context_screen: ContextModule
+  context_module: ContextModule
+  context_screen: OwnerType
   context_screen_owner_type: OwnerType
   platform: Platform
 }

--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -1,6 +1,7 @@
 import { ContextModule } from "../Values/ContextModule"
 import { OwnerType, PageOwnerType } from "../Values/OwnerType"
 import { ActionType } from "."
+import { Platform } from "./MyCollection"
 
 /**
  * Schemas describing rail_viewed events
@@ -230,4 +231,29 @@ export interface SendOffersErrorMessage {
   price: number
   collectors: number
   message: string
+}
+
+/**
+ * User sees the edit profile modal after sending an inquiry
+ *
+ * This schema describes events sent to Segment from [[EditProfileModalViewed]].
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "editProfileModalViewed",
+ *    context_module: "add artwork" or "add profession/location"
+ *    context_page_owner_type: "home"
+ *    partner_id: "61bcda16515b038ce5000104"
+ *  }
+ * ```
+ *
+ */
+export interface EditProfileModalViewed {
+  action: ActionType.editProfileModalViewed
+  context_module: string
+  context_page_owner_type: PageOwnerType
+  user_id: string
+  inquiry_id: string
+  platform: Platform
 }

--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -244,7 +244,9 @@ export interface SendOffersErrorMessage {
  *    action: "editProfileModalViewed",
  *    context_module: "add artwork" or "add profession/location"
  *    context_page_owner_type: "home"
- *    partner_id: "61bcda16515b038ce5000104"
+ *    user_id: "61bcda16515b038ce5000104"
+ *    inquiry_id: "61bcda16515b038ce5000104"
+ *    platform: "web" 
  *  }
  * ```
  *

--- a/src/Schema/Events/MyCollection.ts
+++ b/src/Schema/Events/MyCollection.ts
@@ -201,6 +201,7 @@ export interface TappedMyCollectionAddArtworkArtist {
   context_module: ContextModule.myCollectionAddArtworkAddArtist
   context_screen_owner_id?: string
   context_screen_owner_slug?: string
+  platform: Platform
 }
 
 /**

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -1123,6 +1123,10 @@ export enum ActionType {
    * Corresponds to {@link SendOffersModalViewed}
    */
   sendOffersModalViewed = "sendOffersModalViewed",
+    /**
+   * Corresponds to {@link EditProfileModalViewed}
+   */
+    editProfileModalViewed = "editProfileModalViewed",
   /**
    * Corresponds to {@link sentArtworkInquiry}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -155,6 +155,7 @@ import {
   SendOffersModalViewed,
   TooltipViewed,
   ValidationAddressViewed,
+  EditProfileModalViewed,
 } from "./ImpressionTracking"
 import {
   AddCollectedArtwork,
@@ -353,6 +354,7 @@ export type Event =
   | EnterLiveAuction
   | ErrorMessageViewed
   | ExperimentViewed
+  | EditProfileModalViewed
   | ItemViewed
   | UploadSizeLimitExceeded
   | FocusedOnConversationMessageInput


### PR DESCRIPTION
[here](https://www.notion.so/artsy/Second-launch-tracking-and-impact-e5a4199344424c9e98a2d973183af4cf) is the tracking plan

for the different flows we want to track
1. when a user entered the flow (either with an impression tracking or a click)
2. when a user finished the flow by clicking save and exit

We cannot have just 2 events because the flows described [here](https://www.figma.com/design/yugauriWRATcpu6knETvRY/Collector-Profile---User-Facing?node-id=1702-17470&t=g0QCAtLx2xbpmsnp-0) and [here](https://www.figma.com/design/y68lismoyIR69mTYtEcmrD/Collector-Prompting?node-id=1-324&t=vmgsKZwz2iiBRec1-0) behave differently

This PR adds: 
* `editprofileModalviewed` event to track when the modal was displayed after an inquiry
* capabilities to track if the event was fired on app or web in `EditedUserProfile` and `TappedMyCollectionAddArtworkArtist`