### PR TITLE
feat: Adding events for App upsell tracking

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -2191,3 +2191,33 @@ export interface ClickedCompleteYourProfile {
   context_page_owner_slug?: string
   user_id: string
 }
+
+/**
+ * A user clicks on the header taking them to the app store 
+ *
+ * This schema describes events sent to Segment from [[clickedDownloadAppHeader]]
+ *
+ */
+
+export interface ClickedDownloadAppHeader {
+  action: ActionType.clickedDownloadAppHeader
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id: string
+  context_page_owner_slug?: string
+  user_id: string
+}
+
+/**
+ * A user clicks on the footer taking them to the app store 
+ *
+ * This schema describes events sent to Segment from [[clickedDownloadAppFooter]]
+ *
+ */
+
+export interface ClickedDownloadAppFooter {
+  action: ActionType.clickedDownloadAppFooter
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id: string
+  context_page_owner_slug?: string
+  user_id: string
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -105,6 +105,8 @@ import {
   ClickedVerifyIdentity,
   ClickedViewingRoomCard,
   ClickedViewWork,
+  ClickedDownloadAppHeader,
+  ClickedDownloadAppFooter
 } from "./Click"
 import { EditedUserProfile } from "./CollectorProfile"
 import {
@@ -333,6 +335,8 @@ export type Event =
   | ClickedValidationAddressOptions
   | ClickedCloseValidationAddressModal
   | ClickedViewWork
+  | ClickedDownloadAppFooter
+  | ClickedDownloadAppHeader
   | CommercialFilterParamsChanged
   | CompletedOfflineSync
   | CompletedOnboarding
@@ -869,6 +873,14 @@ export enum ActionType {
    * Corresponds to {@link CommercialFilterParamsChanged}
    */
   commercialFilterParamsChanged = "commercialFilterParamsChanged",
+    /**
+   * Corresponds to {@link clickedDownloadAppFooter}
+   */
+  clickedDownloadAppFooter = "clickedDownloadAppFooter",
+    /**
+   * Corresponds to {@link clickedDownloadAppHeader}
+   */
+    clickedDownloadAppHeader = "clickedDownloadAppHeader",
   /**
    * Corresponds to {@link CompletedOfflineSync}
    */


### PR DESCRIPTION
adding two events for the app upsell tracking 
both events are click events fired when a user clicks on either of the modals taking them to the app store 
the first one is the header present on all mweb pages and the second one is the footer present after the second page view. 