### PR TITLE
fix: reverting EditedUserProfile event

### DIFF
--- a/src/Schema/Events/CollectorProfile.ts
+++ b/src/Schema/Events/CollectorProfile.ts
@@ -25,8 +25,7 @@ import { Platform } from "./MyCollection"
  */
 export interface EditedUserProfile {
   action: ActionType.editedUserProfile
-  context_module: ContextModule
-  context_screen: OwnerType
+  context_screen: ContextModule
   context_screen_owner_type: OwnerType
   platform: Platform
 }


### PR DESCRIPTION
- [ ] reverting the structure of the event to `context_screen: ContextModule` due to backward compatibility issues introduced in [this PR](https://github.com/artsy/cohesion/pull/510/files)