### PR TITLE
chore: add new submit artwork form owner types

### DIFF
--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -108,6 +108,10 @@ export enum OwnerType {
   submitArtworkStepCompleteYourSubmission = "submitArtworkStepCompleteYourSubmission",
   submitArtworkStepArtistRejected = "submitArtworkStepArtistRejected",
   submitArtworkStepSelectArtworkMyCollectionArtwork = "submitArtworkStepSelectArtworkMyCollectionArtwork",
+  submitArtworkStepShippingLocation = "submitArtworkStepShippingLocation",
+  submitArtworkStepFrameInformation = "submitArtworkStepFrameInformation",
+  submitArtworkStepAddtionalDocuments = "submitArtworkStepAddtionalDocuments",
+  submitArtworkStepCondition = "submitArtworkStepCondition",
 
   tag = "tag",
   upcomingAuctions = "upcomingAuctions",
@@ -207,6 +211,10 @@ export type ScreenOwnerType =
   | OwnerType.submitArtworkStepCompleteYourSubmission
   | OwnerType.submitArtworkStepArtistRejected
   | OwnerType.submitArtworkStepSelectArtworkMyCollectionArtwork
+  | OwnerType.submitArtworkStepShippingLocation
+  | OwnerType.submitArtworkStepFrameInformation
+  | OwnerType.submitArtworkStepAddtionalDocuments
+  | OwnerType.submitArtworkStepCondition
   | OwnerType.similarToRecentlyViewed
   | OwnerType.tag
   | OwnerType.upcomingAuctions
@@ -277,6 +285,10 @@ export type PageOwnerType =
   | OwnerType.submitArtworkStepCompleteYourSubmission
   | OwnerType.submitArtworkStepArtistRejected
   | OwnerType.submitArtworkStepSelectArtworkMyCollectionArtwork
+  | OwnerType.submitArtworkStepShippingLocation
+  | OwnerType.submitArtworkStepFrameInformation
+  | OwnerType.submitArtworkStepAddtionalDocuments
+  | OwnerType.submitArtworkStepCondition
   | OwnerType.tag
   | OwnerType.user
   | OwnerType.viewingRoom


### PR DESCRIPTION
The type of this PR is: **TYPE**

### Description

Add new submit artwork tier 2 screens owner types.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
