### PR TITLE
feat: Add submitArtworkStepCompleteYourSubmissionPostApproval owner type

### DIFF
--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -112,6 +112,7 @@ export enum OwnerType {
   submitArtworkStepFrameInformation = "submitArtworkStepFrameInformation",
   submitArtworkStepAddtionalDocuments = "submitArtworkStepAddtionalDocuments",
   submitArtworkStepCondition = "submitArtworkStepCondition",
+  submitArtworkStepCompleteYourSubmissionPostApproval = "submitArtworkStepCompleteYourSubmissionPostApproval",
 
   tag = "tag",
   upcomingAuctions = "upcomingAuctions",
@@ -215,6 +216,7 @@ export type ScreenOwnerType =
   | OwnerType.submitArtworkStepFrameInformation
   | OwnerType.submitArtworkStepAddtionalDocuments
   | OwnerType.submitArtworkStepCondition
+  | OwnerType.submitArtworkStepCompleteYourSubmissionPostApproval
   | OwnerType.similarToRecentlyViewed
   | OwnerType.tag
   | OwnerType.upcomingAuctions
@@ -289,6 +291,7 @@ export type PageOwnerType =
   | OwnerType.submitArtworkStepFrameInformation
   | OwnerType.submitArtworkStepAddtionalDocuments
   | OwnerType.submitArtworkStepCondition
+  | OwnerType.submitArtworkStepCompleteYourSubmissionPostApproval
   | OwnerType.tag
   | OwnerType.user
   | OwnerType.viewingRoom


### PR DESCRIPTION
Addresses [ONYX-1144]

- Related Eigen PR https://github.com/artsy/eigen/pull/10556

## Description

This adds a new `submitArtworkStepCompleteYourSubmissionPostApproval` owner type (similar to `submitArtworkStepCompleteYourSubmission`) for the post appoval "Thank You" step in the Sell flow

[ONYX-1144]: https://artsyproduct.atlassian.net/browse/ONYX-1144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ