### PR TITLE
chore(EMI-2035): update collector signals schema - one label max.

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -176,13 +176,13 @@ export interface ClickedArtistSeriesGroup extends ClickedEntityGroup {
  *    destination_page_owner_slug: "romain-jacquet-lagreze-makeshift-garden-hong-kong",
  *    horizontal_slide_position: 1,
  *    type: "thumbnail"
- *    signal_labels: ["Limited-Time Offer"],
+ *    signal_label: "Limited-Time Offer",
  *  }
  * ```
  */
 export interface ClickedArtworkGroup extends ClickedEntityGroup {
   action: ActionType.clickedArtworkGroup
-  signal_labels?: string[]
+  signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
 }
@@ -210,7 +210,7 @@ export interface ClickedArtworkGroup extends ClickedEntityGroup {
  */
 export interface ClickedAuctionGroup extends ClickedEntityGroup {
   action: ActionType.clickedAuctionGroup
-  signal_labels?: string[]
+  signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
 }
@@ -297,7 +297,7 @@ export interface ClickedBuyerProtection {
  *    context_owner_id: "6164889300d643000db86504",
  *    impulse_conversation_id: "198",
  *    flow: "Buy now" | "Partner offer"
- *    signal_labels: ["Limited-Time Offer"],
+ *    signal_label: "Limited-Time Offer",
  *  }
  * ```
  */
@@ -309,7 +309,7 @@ export interface ClickedBuyNow {
   context_owner_id: string
   impulse_conversation_id?: string
   flow?: string
-  signal_labels?: string[]
+  signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
 }
@@ -325,7 +325,7 @@ export interface ClickedBuyNow {
  *    context_owner_type: "Artwork",
  *    context_owner_slug: "radna-segal-pearl",
  *    context_owner_id: "6164889300d643000db86504",
- *    signal_labels: ["Limited-Time Offer"],
+ *    signal_label: "Limited-Time Offer",
  *  }
  * ```
  */
@@ -334,7 +334,7 @@ export interface ClickedContactGallery {
   context_owner_type: OwnerType
   context_owner_slug: string
   context_owner_id: string
-  signal_labels?: string[]
+  signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
 }
@@ -359,7 +359,7 @@ export interface ClickedBid {
   context_owner_type: OwnerType
   context_owner_id: string
   context_owner_slug: string
-  signal_labels?: string[]
+  signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
 }
@@ -606,7 +606,7 @@ export interface ClickedFairCard {
  *    destination_page_owner_id: "53188b0d8b3b8192bb0005ae",
  *    destination_page_owner_slug: "damien-hirst-anatomy-of-an-angel",
  *    type: "thumbnail"
- *    signal_labels: ["Limited-Time Offer"],
+ *    signal_label: "Limited-Time Offer",
  *  }
  * ```
  */
@@ -622,7 +622,7 @@ export interface ClickedMainArtworkGrid {
   type: "thumbnail"
   position?: number
   sort?: string
-  signal_labels?: string[]
+  signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
 }

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -109,13 +109,13 @@ export interface TappedArtistSeriesGroup extends TappedEntityGroup {
  *    horizontal_slide_position: 1,
  *    module_height: "single",
  *    type: "thumbnail"
- *    signal_labels: ["Limited-Time Offer"],
+ *    signal_label: "Limited-Time Offer",
  *  }
  * ```
  */
 export interface TappedArtworkGroup extends TappedEntityGroup {
   action: ActionType.tappedArtworkGroup
-  signal_labels?: string[]
+  signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
 }
@@ -144,7 +144,7 @@ export interface TappedArtworkGroup extends TappedEntityGroup {
  */
 export interface TappedAuctionGroup extends TappedEntityGroup {
   action: ActionType.tappedAuctionGroup
-  signal_labels?: string[]
+  signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
 }
@@ -423,7 +423,7 @@ export interface TappedInfoBubble {
  *    destination_screen_owner_id: "53188b0d8b3b8192bb0005ae",
  *    destination_screen_owner_slug: "damien-hirst-anatomy-of-an-angel",
  *    type: "thumbnail"
- *    signal_labels: ["Limited-Time Offer"],
+ *    signal_label: "Limited-Time Offer",
  *  }
  * ```
  */
@@ -441,7 +441,7 @@ export interface TappedMainArtworkGrid {
   sort?: string
   type: "thumbnail"
   query?: string
-  signal_labels?: string[]
+  signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
 }
@@ -787,7 +787,7 @@ export interface TappedBid {
   context_owner_type: ScreenOwnerType
   context_owner_id: string
   context_owner_slug: string
-  signal_labels?: string[]
+  signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
 }
@@ -806,7 +806,7 @@ export interface TappedBid {
  *    context_owner_id: "6164889300d643000db86504",
  *    impulse_conversation_id: "198",
  *    flow: "Buy now" | "Partner offer"
- *    signal_labels: ["Limited-Time Offer"],
+ *    signal_label: "Limited-Time Offer",
  *  }
  * ```
  */
@@ -818,7 +818,7 @@ export interface TappedBuyNow {
   context_owner_slug: string
   impulse_conversation_id?: string
   flow?: "Buy now" | "Partner offer"
-  signal_labels?: string[]
+  signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
 }
@@ -835,7 +835,7 @@ export interface TappedBuyNow {
  *    context_owner_type: "Artwork",
  *    context_owner_slug: "radna-segal-pearl",
  *    context_owner_id: "6164889300d643000db86504",
- *    signal_labels: ["Limited-Time Offer"],
+ *    signal_label: "Limited-Time Offer",
  *  }
  * ```
  */
@@ -845,7 +845,7 @@ export interface TappedContactGallery {
   context_owner_type: OwnerType
   context_owner_slug: string
   context_owner_id: string
-  signal_labels?: string[]
+  signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
 }


### PR DESCRIPTION
The type of this PR is: **chore**

This PR resolves [EMI-2035].

### Description

This PR updates the cohesion schema for collector signals interactions to allow only 0-1 labels, not a list, following clarification with design.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[EMI-2035]: https://artsyproduct.atlassian.net/browse/EMI-2035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ