### PR TITLE
fix: clickedContactGallery wrongly said tapped

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -330,7 +330,7 @@ export interface ClickedBuyNow {
  * ```
  */
 export interface ClickedContactGallery {
-  action: ActionType.tappedContactGallery
+  action: ActionType.clickedContactGallery
   context_owner_type: OwnerType
   context_owner_slug: string
   context_owner_id: string
@@ -339,9 +339,9 @@ export interface ClickedContactGallery {
   signal_bid_count?: number
 }
 
-/** A user taps "Bid" on an artwork page inside an Auction
+/** A user clicks "Bid" on an artwork page inside an Auction
  *
- * This schema describes events sent to Segment from [[tappedBid]]
+ * This schema describes events sent to Segment from [[clickedBid]]
  *
  *  @example
  *  ```


### PR DESCRIPTION
The type of this PR is: **fix**

### Description

One event I migrated from the old schema had incorrect types. Some docs also mentioned 'tapped' in t click.ts file so I fixed those too.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
