### PR TITLE
feat: adding a value for the new first step of the signup flow

### DIFF
--- a/src/Schema/Events/Authentication.ts
+++ b/src/Schema/Events/Authentication.ts
@@ -149,6 +149,8 @@ export enum AuthModalType {
   login = "login",
   /** Sign up for a new account */
   signup = "signup",
+  /** Fill out your email to enter the signup or login flow */
+  welcome = "welcome",
 }
 
 /**


### PR DESCRIPTION
The new sign up/log in flow introduces a first step where the user has to fill out their email address first to then be automatically redirected to either the sign up or log in flow. 
This new value allows us to track when that first modal is displayed (called "welcome")

[Figma designs](https://www.figma.com/design/jFcE32eMExDPj0XgmIThML/Sign-up---Improvements?node-id=54-2770&t=aedNNnadwG5wJBlF-0)