### PR TITLE
feat: add TappedHeroUnitsGroup

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -93,6 +93,30 @@ export interface TappedArtistSeriesGroup extends TappedEntityGroup {
 }
 
 /**
+ * A user taps a grouping of hero units
+ *
+ *  This schema describes events sent to Segment from [[tappedHeroUnitsGroup]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedHeroUnitsGroup",
+ *    context_module: "home-view-section-hero-units-rail",
+ *    context_screen_owner_type: "home",
+ *    destination_screen_owner_id: "5359794d1a1e86c3740001f7",
+ *    destination_screen_owner_type: Collection,
+ *    destination_screen_owner_url: "fair/fair-name"
+ *    horizontal_slide_position: 1,
+ *    type: "thumbnail"
+ *  }
+ * ```
+ */
+export interface TappedHeroUnitsGroup extends TappedEntityGroup {
+  action: ActionType.tappedHeroUnitsGroup
+  destination_screen_owner_url: string
+}
+
+/**
  * A user taps a grouping of artworks on iOS
  *
  * This schema describes events sent to Segment from [[tappedEntityGroup]]
@@ -280,6 +304,7 @@ export interface TappedEntityGroup {
     | ActionType.tappedExploreGroup
     | ActionType.tappedFairGroup
     | ActionType.tappedViewingRoomGroup
+    | ActionType.tappedHeroUnitsGroup
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id?: string

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -1280,6 +1280,10 @@ export enum ActionType {
    */
   tappedFairGroup = "tappedFairGroup",
   /**
+   * Corresponds to {@link TappedHeroUnitsGroup}
+   */
+  tappedHeroUnitsGroup = "tappedHeroUnitsGroup",
+  /**
    * Corresponds to {@link TappedInboxConversation}
    */
   tappedInboxConversation = "tappedInboxConversation",


### PR DESCRIPTION
This PR resolves [ONYX-1271]

### Description

This PR adds a new event to track taps on the home view hero units rail.

<details><summary>This is the rail 👇 </summary>
<p>

<img width="300" src="https://github.com/user-attachments/assets/60e4c697-d719-4411-a6d6-9fe0039f6954" />

</p>
</details> 



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[ONYX-1271]: https://artsyproduct.atlassian.net/browse/ONYX-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ