### PR TITLE
feat: added tappedNewsGroup

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -44,12 +44,11 @@ export interface TappedArticleGroup extends TappedEntityGroup {
  *    action: "tappedNewsGroup",
  *    context_module: "articleRail",
  *    context_screen_owner_type: "home",
- *    context_screen_owner_id: "5e726bd22524980012caafb0",
- *    context_screen_owner_slug: "arteba-special-edition",
  *    destination_screen_owner_type: "article",
  *    destination_screen_owner_id: "542f1ccc7261694847410400",
  *    destination_screen_owner_slug: "acaw-acaw-presenter-charwei-tsai",
  *    type: "thumbnail"
+ *    vertical_slide_position: 1
  *  }
  * ```
  */

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -34,6 +34,30 @@ export interface TappedArticleGroup extends TappedEntityGroup {
 }
 
 /**
+ * A user taps a grouping of news on App
+ *
+ *  This schema describes events sent to Segment from [[tappedNewsGroup]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedNewsGroup",
+ *    context_module: "articleRail",
+ *    context_screen_owner_type: "home",
+ *    context_screen_owner_id: "5e726bd22524980012caafb0",
+ *    context_screen_owner_slug: "arteba-special-edition",
+ *    destination_screen_owner_type: "article",
+ *    destination_screen_owner_id: "542f1ccc7261694847410400",
+ *    destination_screen_owner_slug: "acaw-acaw-presenter-charwei-tsai",
+ *    type: "thumbnail"
+ *  }
+ * ```
+ */
+export interface TappedNewsGroup extends TappedEntityGroup {
+  action: ActionType.tappedNewsGroup
+}
+
+/**
  * A user taps a grouping of activity items
  *
  *  This schema describes events sent to Segment from [[tappedActivityGroup]]
@@ -310,7 +334,6 @@ export interface TappedEntityGroup {
   action:
     | ActionType.tappedActivityGroup
     | ActionType.tappedArticleGroup
-    | ActionType.tappedShowGroup
     | ActionType.tappedArtistGroup
     | ActionType.tappedArtistSeriesGroup
     | ActionType.tappedArtworkGroup
@@ -320,8 +343,10 @@ export interface TappedEntityGroup {
     | ActionType.tappedCollectionGroup
     | ActionType.tappedExploreGroup
     | ActionType.tappedFairGroup
-    | ActionType.tappedViewingRoomGroup
     | ActionType.tappedHeroUnitGroup
+    | ActionType.tappedNewsGroup
+    | ActionType.tappedShowGroup
+    | ActionType.tappedViewingRoomGroup
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id?: string
@@ -331,6 +356,7 @@ export interface TappedEntityGroup {
   destination_screen_owner_slug?: string
   curation_boost?: boolean
   horizontal_slide_position?: number
+  vertical_slide_position?: number
   module_height?: EntityModuleHeight
   type: EntityModuleType
 }

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -224,6 +224,7 @@ import {
   TappedLink,
   TappedMainArtworkGrid,
   TappedNavigationTab,
+  TappedNewsGroup,
   TappedPartnerCard,
   TappedPromoSpace,
   TappedSell,
@@ -247,18 +248,17 @@ import { ViewedVideo } from "./Video"
  * Each event describes one ActionType
  */
 export type Event =
+  | AddCollectedArtwork
   | AddedArtworkToArtworkList
   | AddedToAlbum
-  | AddToCalendar
-  | AddCollectedArtwork
   | AddressAutoCompletionResult
+  | AddToCalendar
   | ArtworkDetailsCompleted
   | AuctionPageView
   | AuctionResultsFilterParamsChanged
   | AuthImpression
   | BidPageView
-  | CreatedAccount
-  | CreatedArtworkList
+  | CheckedAccountBalance
   | ClickedActiveBid
   | ClickedActivityPanelNotificationItem
   | ClickedActivityPanelTab
@@ -279,9 +279,14 @@ export type Event =
   | ClickedChangePaymentMethod
   | ClickedChangeShippingAddress
   | ClickedChangeShippingMethod
+  | ClickedCloseValidationAddressModal
   | ClickedCollectionGroup
+  | ClickedConversationsFilter
   | ClickedCreateAlert
   | ClickedDeliveryMethod
+  | ClickedDismissInquiry
+  | ClickedDownloadAppFooter
+  | ClickedDownloadAppHeader
   | ClickedEditArtwork
   | ClickedExpandFilterPanel
   | ClickedExpansionToggle
@@ -291,12 +296,15 @@ export type Event =
   | ClickedLoadMore
   | ClickedMainArtworkGrid
   | ClickedMarketingModal
-  | ClickedNavigationTab
+  | ClickedMarkSold
+  | ClickedMarkSpam
   | ClickedNavBar
+  | ClickedNavigationTab
   | ClickedNotificationsBell
+  | ClickedOfferActions
   | ClickedOfferOption
-  | ClickedOnArtworkShippingWeight
   | ClickedOnArtworkShippingUnitsDropdown
+  | ClickedOnArtworkShippingWeight
   | ClickedOnBuyNowCheckbox
   | ClickedOnDuplicateArtwork
   | ClickedOnFramedMeasurements
@@ -306,38 +314,29 @@ export type Event =
   | ClickedOnPagination
   | ClickedOnPriceDisplayDropdown
   | ClickedOnReadMore
-  | ClickedPublish
   | ClickedOnSubmitOrder
-  | ClickedSnooze
-  | ClickedUploadArtwork
+  | ClickedOrderPage
+  | ClickedOrderSummary
   | ClickedPartnerCard
   | ClickedPartnerLink
-  | ClickedPaymentMethod
   | ClickedPaymentDetails
-  | CheckedAccountBalance
+  | ClickedPaymentMethod
   | ClickedPromoSpace
+  | ClickedPublish
   | ClickedRegisterToBid
   | ClickedSelectShippingOption
   | ClickedSendPartnerOffer
   | ClickedShippingAddress
   | ClickedShowGroup
   | ClickedShowMore
+  | ClickedSnooze
   | ClickedStartPartnerOffer
+  | ClickedUpdateArtwork
+  | ClickedUploadArtwork
+  | ClickedValidationAddressOptions
   | ClickedVerifyIdentity
   | ClickedViewingRoomCard
-  | ClickedOfferActions
-  | ClickedOrderPage
-  | ClickedOrderSummary
-  | ClickedDismissInquiry
-  | ClickedMarkSpam
-  | ClickedMarkSold
-  | ClickedConversationsFilter
-  | ClickedUpdateArtwork
-  | ClickedValidationAddressOptions
-  | ClickedCloseValidationAddressModal
   | ClickedViewWork
-  | ClickedDownloadAppFooter
-  | ClickedDownloadAppHeader
   | CommercialFilterParamsChanged
   | CompletedOfflineSync
   | CompletedOnboarding
@@ -346,34 +345,34 @@ export type Event =
   | ConsignmentArtistFailed
   | ConsignmentSubmitted
   | ContactInformationCompleted
+  | CreatedAccount
   | CreatedAlbum
+  | CreatedArtworkList
   | DeleteCollectedArtwork
-  | EditedAlert
   | DeletedArtworkList
   | DeletedSavedSearch
   | EditCollectedArtwork
+  | EditedAlert
   | EditedArtworkList
   | EditedAutocompletedAddress
   | EditedSavedSearch
   | EditedUserProfile
+  | EditProfileModalViewed
   | EnterLiveAuction
   | ErrorMessageViewed
   | ExperimentViewed
-  | EditProfileModalViewed
-  | ItemViewed
-  | UploadSizeLimitExceeded
   | FocusedOnConversationMessageInput
-  | FocusedOnSearchInput
   | FocusedOnPriceDatabaseSearchInput
+  | FocusedOnSearchInput
   | FollowEvents
   | Impression
+  | ItemViewed
   | MaxBidSelected
   | MyCollectionOnboardingCompleted
   | OnboardingUserInputData
   | PriceDatabaseFilterParamsChanged
   | PromptForReview
   | RailViewed
-  | ValidationAddressViewed
   | RegistrationPageView
   | RegistrationSubmitted
   | ResetYourPassword
@@ -384,16 +383,16 @@ export type Event =
   | SearchedPriceDatabase
   | SearchedWithNoResults
   | SearchedWithResults
-  | SelectedItemFromSearch
-  | SelectedItemFromPriceDatabaseSearch
   | SelectedItemFromAddressAutoCompletion
+  | SelectedItemFromPriceDatabaseSearch
+  | SelectedItemFromSearch
   | SelectedRecentPriceRange
   | SelectedSearchSuggestionQuickNavigationItem
   | SendOffersBannerViewed
   | SendOffersErrorMessage
   | SendOffersModalViewed
-  | SentContent
   | SentConsignmentInquiry
+  | SentContent
   | SentConversationMessage
   | SentRequestPriceEstimate
   | Share
@@ -415,8 +414,8 @@ export type Event =
   | TappedCollectedArtworkImages
   | TappedCollectionGroup
   | TappedConsign
-  | TappedContactGallery
   | TappedConsignmentInquiry
+  | TappedContactGallery
   | TappedCreateAlert
   | TappedExploreGroup
   | TappedExploreMyCollection
@@ -424,15 +423,17 @@ export type Event =
   | TappedFairGroup
   | TappedInboxConversation
   | TappedInfoBubble
+  | TappedLearnMore
   | TappedLink
-  | TappedNavigationTab
   | TappedMainArtworkGrid
   | TappedMakeOffer
-  | TappedMyCollectionInsightsMedianAuctionRailItem
+  | TappedMyCollectionAddArtworkArtist
   | TappedMyCollectionInsightsMedianAuctionPriceChartCareerHighlight
   | TappedMyCollectionInsightsMedianAuctionPriceChartCategory
   | TappedMyCollectionInsightsMedianAuctionPriceChartTimeframe
-  | TappedMyCollectionAddArtworkArtist
+  | TappedMyCollectionInsightsMedianAuctionRailItem
+  | TappedNavigationTab
+  | TappedNewsGroup
   | TappedPartnerCard
   | TappedProductCapabilitiesGroup
   | TappedPromoSpace
@@ -440,7 +441,6 @@ export type Event =
   | TappedSell
   | TappedSellArtwork
   | TappedShowMore
-  | TappedLearnMore
   | TappedSkip
   | TappedTabBar
   | TappedVerifyIdentity
@@ -455,6 +455,8 @@ export type Event =
   | ToggledSavedSearch
   | TooltipViewed
   | UploadPhotosCompleted
+  | UploadSizeLimitExceeded
+  | ValidationAddressViewed
   | ViewArtworkMyCollection
   | ViewedArtworkList
   | ViewedVideo
@@ -1335,6 +1337,10 @@ export enum ActionType {
    * Corresponds to {@link TappedNavigationTab}
    */
   tappedNavigationTab = "tappedNavigationTab",
+  /**
+   * Corresponds to {@link TappedNewsGroup}
+   */
+  tappedNewsGroup = "tappedNewsGroup",
   /**
    * Corresponds to {@link TappedPartnerCard}
    */


### PR DESCRIPTION
The type of this PR is: **Feature**



<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [ONYX-1288]

### Description

This PR adds `TappedNewsGroup` as an event. This is required for the news section in Home. 

**Note:** 
- In the existing home view, we are not tracking taps on the news articles.
- I did some alphabetical sorting to make additions easier in the past

<img src="https://github.com/user-attachments/assets/3f1c2050-808b-45ac-bd28-63e4027bb52e" width="300" />



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[ONYX-1288]: https://artsyproduct.atlassian.net/browse/ONYX-1288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ