### PR TITLE
chore: add `marketNews` as PageOwner type (page+screen)

### DIFF
--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -56,6 +56,7 @@ export enum OwnerType {
   inboxInquiries = "inboxInquiries",
   lotsByArtistsYouFollow = "lotsByArtistsYouFollow",
   lotsForYou = "lotsForYou",
+  marketNews = "marketNews",
   myCollection = "myCollection",
   myCollectionAddArtworkArtist = "myCollectionAddArtworkArtist",
   myCollectionArtwork = "myCollectionArtwork",
@@ -173,6 +174,7 @@ export type ScreenOwnerType =
   | OwnerType.inboxInquiries
   | OwnerType.lotsByArtistsYouFollow
   | OwnerType.lotsForYou
+  | OwnerType.marketNews
   | OwnerType.myCollection
   | OwnerType.myCollectionAddArtworkArtist
   | OwnerType.myCollectionArtwork
@@ -252,6 +254,7 @@ export type PageOwnerType =
   | OwnerType.galleries
   | OwnerType.gene
   | OwnerType.home
+  | OwnerType.marketNews
   | OwnerType.myCollectionArtworkInsights
   | OwnerType.myCollectionInsights
   | OwnerType.onboarding


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

To differentiate between the "Market News" landing page and "Artsy Editorial".

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
