### PR TITLE
chore: add `tappedNotificationsBell` event

### DIFF
--- a/src/Schema/Events/ActivityPanel.ts
+++ b/src/Schema/Events/ActivityPanel.ts
@@ -22,6 +22,22 @@ export interface ClickedNotificationsBell {
 }
 
 /**
+ * A user tapped on a notifications bell.
+ *
+ * This schema describes events sent to Segment from [[tappedNotificationsBell]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedNotificationsBell"
+ *  }
+ * ```
+ */
+export interface TappedNotificationsBell {
+  action: ActionType.tappedNotificationsBell
+}
+
+/**
  * A user clicked on a notification in Activity Panel.
  *
  * This schema describes events sent to Segment from [[clickedActivityPanelNotificationItem]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -2,6 +2,7 @@ import {
   ClickedActivityPanelNotificationItem,
   ClickedActivityPanelTab,
   ClickedNotificationsBell,
+  TappedNotificationsBell
 } from "./ActivityPanel"
 import { AddToCalendar } from "./AddToCalendar"
 import {
@@ -426,6 +427,7 @@ export type Event =
   | TappedInfoBubble
   | TappedLink
   | TappedNavigationTab
+  | TappedNotificationsBell
   | TappedMainArtworkGrid
   | TappedMakeOffer
   | TappedMyCollectionInsightsMedianAuctionRailItem
@@ -1335,6 +1337,10 @@ export enum ActionType {
    * Corresponds to {@link TappedNavigationTab}
    */
   tappedNavigationTab = "tappedNavigationTab",
+  /**
+   * Corresponds to {@link TappedNotificationsBell}
+   */
+  tappedNotificationsBell = "tappedNotificationsBell",
   /**
    * Corresponds to {@link TappedPartnerCard}
    */


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

App counterpart for `clickedNotificationsBell` on web.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
