### PR TITLE
chore: Add more data to event when publishing matching work from demand AMBER-1090

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1812,21 +1812,25 @@ export interface ClickedNavBar {
  *  ```
  *  {
  *    action: "clickedUploadArtwork",
- *    context_module: "alerts-price"
- *    context_page_owner_type: "demand",
- *    context_page_owner_id: "",
+ *    alert_page_rank: 1,
  *    artist_id: "4212691337420",
- *    search_criteria_id: "4212691337420"
+ *    context_module: "alerts-price",
+ *    context_page_owner_id: "",
+ *    context_page_owner_type: "demand",
+ *    partner_search_criteria_id: "123abc",
+ *    search_criteria_id: "4212691337420",
  *    subject: "Upload Artworks"
  *  }
  * ```
  */
 export interface ClickedUploadArtwork {
   action: ActionType.clickedUploadArtwork
-  context_module: ContextModule
-  context_page_owner_type: PageOwnerType
-  context_page_owner_id?: string
+  alert_page_rank?: number
   artist_id?: string
+  context_module: ContextModule
+  context_page_owner_id?: string
+  context_page_owner_type: PageOwnerType
+  partner_search_criteria_id?: string
   search_criteria_id?: string
   subject: string
 }


### PR DESCRIPTION
This PR updates our event for when a partner publishes a matching artwork in CMS. It now includes a the `PartnerSearchCriteria` id and the page rank of the alert that's being published against.

https://artsyproduct.atlassian.net/browse/AMBER-1090

/cc @artsy/amber-devs @leodmz 