### PR TITLE
feat(EMI-2098): Add tappedNotification and tappedClearNotification to the schema

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -244,7 +244,6 @@ export interface TappedBrowseSimilarArtworks extends TappedEntityGroup {
  *    action: "tappedClearNotification",
  *    context_module : "Home",
  *    context_screen_owner_type: "Home",
- *    context_screen_owner_id: "58de681f275b2464fcdde097",
  *    notification_id: "23424132",
  *    notification_category: "send_wire"
  *  }
@@ -254,7 +253,6 @@ export interface TappedClearNotification {
   action: ActionType.tappedClearNotification
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
-  context_screen_owner_id: string
   notification_id: string
   notification_category: string
 }
@@ -1172,7 +1170,6 @@ export interface TappedNewsSection {
  *    action: "tappedNotification",
  *    context_module : "Home",
  *    context_screen_owner_type: "Home",
- *    context_screen_owner_id: "58de681f275b2464fcdde097",
  *    notification_id: "23424132",
  *    notification_category: "send_wire"
  *  }
@@ -1182,7 +1179,6 @@ export interface TappedNotification {
   action: ActionType.tappedNotification
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
-  context_screen_owner_id: string
   notification_id: string
   notification_category: string
 }

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -244,6 +244,7 @@ export interface TappedBrowseSimilarArtworks extends TappedEntityGroup {
  *    action: "tappedClearNotification",
  *    context_module : "Home",
  *    context_screen_owner_type: "Home",
+ *    destination_path: "/orders/123",
  *    notification_id: "23424132",
  *    notification_category: "send_wire"
  *  }
@@ -253,6 +254,7 @@ export interface TappedClearNotification {
   action: ActionType.tappedClearNotification
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
+  destination_path: string
   notification_id: string
   notification_category: string
 }
@@ -1170,6 +1172,7 @@ export interface TappedNewsSection {
  *    action: "tappedNotification",
  *    context_module : "Home",
  *    context_screen_owner_type: "Home",
+ *    destination_path: "/orders/123",
  *    notification_id: "23424132",
  *    notification_category: "send_wire"
  *  }
@@ -1179,6 +1182,7 @@ export interface TappedNotification {
   action: ActionType.tappedNotification
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
+  destination_path: string
   notification_id: string
   notification_category: string
 }

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -234,6 +234,32 @@ export interface TappedBrowseSimilarArtworks extends TappedEntityGroup {
 }
 
 /**
+ * A user taps on clear (or swipes away) on a task notification in the app
+ *
+ * This schema describes events sent to Segment from [[tappedClearNotification]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedClearNotification",
+ *    context_module : "Home",
+ *    context_screen_owner_type: "Home",
+ *    context_screen_owner_id: "58de681f275b2464fcdde097",
+ *    notification_id: "23424132",
+ *    notification_category: "send_wire"
+ *  }
+ * ```
+ */
+export interface TappedClearNotification {
+  action: ActionType.tappedClearNotification
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id: string
+  notification_id: string
+  notification_category: string
+}
+
+/**
  * A user taps a grouping of collections on iOS
  *
  * This schema describes events sent to Segment from [[tappedEntityGroup]]
@@ -1133,6 +1159,32 @@ export interface TappedNewsSection {
   context_screen_owner_id: string
   destination_screen_owner_type: ScreenOwnerType
   destination_screen_owner_id: string
+}
+
+/**
+ * A user taps on a task notification in the app
+ *
+ * This schema describes events sent to Segment from [[tappedNotification]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedNotification",
+ *    context_module : "Home",
+ *    context_screen_owner_type: "Home",
+ *    context_screen_owner_id: "58de681f275b2464fcdde097",
+ *    notification_id: "23424132",
+ *    notification_category: "send_wire"
+ *  }
+ * ```
+ */
+export interface TappedNotification {
+  action: ActionType.tappedNotification
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id: string
+  notification_id: string
+  notification_category: string
 }
 
 /**

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -2,7 +2,7 @@ import {
   ClickedActivityPanelNotificationItem,
   ClickedActivityPanelTab,
   ClickedNotificationsBell,
-  TappedNotificationsBell
+  TappedNotificationsBell,
 } from "./ActivityPanel"
 import { AddToCalendar } from "./AddToCalendar"
 import {
@@ -212,6 +212,7 @@ import {
   TappedBid,
   TappedBrowseSimilarArtworks,
   TappedBuyNow,
+  TappedClearNotification,
   TappedCollectionGroup,
   TappedConsign,
   TappedConsignmentInquiry,
@@ -225,6 +226,7 @@ import {
   TappedLink,
   TappedMainArtworkGrid,
   TappedNavigationTab,
+  TappedNotification,
   TappedPartnerCard,
   TappedPromoSpace,
   TappedSell,
@@ -412,6 +414,7 @@ export type Event =
   | TappedBid
   | TappedBrowseSimilarArtworks
   | TappedBuyNow
+  | TappedClearNotification
   | TappedCollectedArtwork
   | TappedCollectedArtworkImages
   | TappedCollectionGroup
@@ -427,6 +430,7 @@ export type Event =
   | TappedInfoBubble
   | TappedLink
   | TappedNavigationTab
+  | TappedNotification
   | TappedNotificationsBell
   | TappedMainArtworkGrid
   | TappedMakeOffer
@@ -1230,6 +1234,10 @@ export enum ActionType {
    */
   tappedBuyNow = "tappedBuyNow",
   /**
+   * Corresponds to {@link TappedClearNotification}
+   */
+  tappedClearNotification = "tappedClearNotification",
+  /**
    * Corresponds to {@link TappedCollectedArtwork}
    */
   tappedCollectedArtwork = "tappedCollectedArtwork",
@@ -1337,6 +1345,10 @@ export enum ActionType {
    * Corresponds to {@link TappedNavigationTab}
    */
   tappedNavigationTab = "tappedNavigationTab",
+  /**
+   * Corresponds to {@link TappedNotification}
+   */
+  tappedNotification = "tappedNotification",
   /**
    * Corresponds to {@link TappedNotificationsBell}
    */

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -11,6 +11,7 @@ export enum ContextModule {
   adServer = "adServer",
   activity = "activity",
   activityRail = "activityRail",
+  actNow = "actNow",
   alertsAll = "alertsAll",
   alertConfirmation = "alertConfirmation",
   alertDetails = "alertDetails",


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [EMI-2098]

### Description
This PR adds `TappedNotification` and `TappedClearNotification` events to `Tap.ts`

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[EMI-2098]: https://artsyproduct.atlassian.net/browse/EMI-2098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ