### PR TITLE
feat: add tappedTaskGroup and tappedClearTask

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -372,6 +372,7 @@ export interface TappedEntityGroup {
     | ActionType.tappedFairGroup
     | ActionType.tappedViewingRoomGroup
     | ActionType.tappedHeroUnitGroup
+    | ActionType.tappedTaskGroup
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id?: string
@@ -1188,12 +1189,12 @@ export interface TappedNewsSection {
 /**
  * A user taps on a task notification in the app
  *
- * This schema describes events sent to Segment from [[tappedNotification]]
+ * This schema describes events sent to Segment from [[tappedTaskGroup]]
  *
  *  @example
  *  ```
  *  {
- *    action: "tappedNotification",
+ *    action: "tappedTaskGroup",
  *    context_module : "Home",
  *    context_screen_owner_type: "Home",
  *    destination_path: "/orders/123",
@@ -1202,10 +1203,8 @@ export interface TappedNewsSection {
  *  }
  * ```
  */
-export interface TappedNotification {
-  action: ActionType.tappedNotification
-  context_module: ContextModule
-  context_screen_owner_type: ScreenOwnerType
+export interface TappedTaskGroup extends TappedEntityGroup {
+  action: ActionType.tappedTaskGroup
   destination_path: string
   notification_id: string
   notification_category: string

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -236,12 +236,12 @@ export interface TappedBrowseSimilarArtworks extends TappedEntityGroup {
 /**
  * A user taps on clear (or swipes away) on a task notification in the app
  *
- * This schema describes events sent to Segment from [[tappedClearNotification]]
+ * This schema describes events sent to Segment from [[tappedClearTask]]
  *
  *  @example
  *  ```
  *  {
- *    action: "tappedClearNotification",
+ *    action: "tappedClearTask",
  *    context_module : "Home",
  *    context_screen_owner_type: "Home",
  *    destination_path: "/orders/123",
@@ -250,8 +250,8 @@ export interface TappedBrowseSimilarArtworks extends TappedEntityGroup {
  *  }
  * ```
  */
-export interface TappedClearNotification {
-  action: ActionType.tappedClearNotification
+export interface TappedClearTask {
+  action: ActionType.tappedClearTask
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
   destination_path: string

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -245,8 +245,8 @@ export interface TappedBrowseSimilarArtworks extends TappedEntityGroup {
  *    context_module : "Home",
  *    context_screen_owner_type: "Home",
  *    destination_path: "/orders/123",
- *    notification_id: "23424132",
- *    notification_category: "send_wire"
+ *    task_id: "23424132",
+ *    task_type: "send_wire"
  *  }
  * ```
  */
@@ -255,8 +255,8 @@ export interface TappedClearTask {
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
   destination_path: string
-  notification_id: string
-  notification_category: string
+  task_id: string
+  task_type: string
 }
 
 /**
@@ -1198,16 +1198,16 @@ export interface TappedNewsSection {
  *    context_module : "Home",
  *    context_screen_owner_type: "Home",
  *    destination_path: "/orders/123",
- *    notification_id: "23424132",
- *    notification_category: "send_wire"
+ *    task_id: "23424132",
+ *    task_type: "send_wire"
  *  }
  * ```
  */
 export interface TappedTaskGroup extends TappedEntityGroup {
   action: ActionType.tappedTaskGroup
   destination_path: string
-  notification_id: string
-  notification_category: string
+  task_id: string
+  task_type: string
 }
 
 /**

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -213,8 +213,8 @@ import {
   TappedBid,
   TappedBrowseSimilarArtworks,
   TappedBuyNow,
-  TappedChangePaymentMethod,
   TappedCardGroup,
+  TappedChangePaymentMethod,
   TappedClearNotification,
   TappedCollectionGroup,
   TappedConsign,
@@ -229,7 +229,6 @@ import {
   TappedLink,
   TappedMainArtworkGrid,
   TappedNavigationTab,
-  TappedNotification,
   TappedPartnerCard,
   TappedPromoSpace,
   TappedSell,
@@ -237,6 +236,7 @@ import {
   TappedShowMore,
   TappedSkip,
   TappedTabBar,
+  TappedTaskGroup,
   TappedVerifyIdentity,
   TappedViewingRoomCard,
   TappedViewingRoomGroup,
@@ -436,7 +436,6 @@ export type Event =
   | TappedInfoBubble
   | TappedLink
   | TappedNavigationTab
-  | TappedNotification
   | TappedNotificationsBell
   | TappedMainArtworkGrid
   | TappedMakeOffer
@@ -455,6 +454,7 @@ export type Event =
   | TappedLearnMore
   | TappedSkip
   | TappedTabBar
+  | TappedTaskGroup
   | TappedVerifyIdentity
   | TappedViewingRoomCard
   | TappedViewingRoomGroup
@@ -1364,10 +1364,6 @@ export enum ActionType {
    */
   tappedNavigationTab = "tappedNavigationTab",
   /**
-   * Corresponds to {@link TappedNotification}
-   */
-  tappedNotification = "tappedNotification",
-  /**
    * Corresponds to {@link TappedNotificationsBell}
    */
   tappedNotificationsBell = "tappedNotificationsBell",
@@ -1415,6 +1411,10 @@ export enum ActionType {
    * Corresponds to {@link TappedTabBar}
    */
   tappedTabBar = "tappedTabBar",
+  /**
+   * Corresponds to {@link TappedTaskGroup}
+   */
+  tappedTaskGroup = "tappedTaskGroup",
   /**
    * Corresponds to {@link TappedUploadAnotherArtwork}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -215,7 +215,7 @@ import {
   TappedBuyNow,
   TappedCardGroup,
   TappedChangePaymentMethod,
-  TappedClearNotification,
+  TappedClearTask,
   TappedCollectionGroup,
   TappedConsign,
   TappedConsignmentInquiry,
@@ -420,7 +420,7 @@ export type Event =
   | TappedBuyNow
   | TappedChangePaymentMethod
   | TappedCardGroup
-  | TappedClearNotification
+  | TappedClearTask
   | TappedCollectedArtwork
   | TappedCollectedArtworkImages
   | TappedCollectionGroup
@@ -1248,9 +1248,9 @@ export enum ActionType {
    */
   tappedCardGroup = "tappedCardGroup",
   /**
-   * Corresponds to {@link TappedClearNotification}
+   * Corresponds to {@link TappedClearTask}
    */
-  tappedClearNotification = "tappedClearNotification",
+  tappedClearTask = "tappedClearTask",
   /**
    * Corresponds to {@link TappedCollectedArtwork}
    */


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [EMI-2167] and [AS-4701]

### Description

Renaming the tappedNotification to tappedTaskGroup and tappedClearNotification to tappedClearTask (to match former naming). This matches the naming schema on the homeview; for the Emerald negotiation zone. 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[EMI-2167]: https://artsyproduct.atlassian.net/browse/EMI-2167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AS-4701]: https://artsyproduct.atlassian.net/browse/AS-4701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ