### PR TITLE
feat(DIA-1014): add owner type and context module for infinite discovery

### DIFF
--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -116,6 +116,7 @@ export enum ContextModule {
   inboxClosedBids = "inboxClosedBids",
   inboxConversation = "inboxConversation",
   inboxInquiries = "inboxInquiries",
+  infiniteDiscoveryBanner = "infiniteDiscoveryBanner",
   inquiry = "inquiry",
   intextTooltip = "intextTooltip",
   latestViewingRoomsRail = "latestViewingRoomsRail",

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -56,6 +56,7 @@ export enum OwnerType {
   inboxBids = "inboxBids",
   inboxConversation = "inboxConversation",
   inboxInquiries = "inboxInquiries",
+  infiniteDiscovery = "infiniteDiscovery",
   lotsByArtistsYouFollow = "lotsByArtistsYouFollow",
   lotsForYou = "lotsForYou",
   marketNews = "marketNews",


### PR DESCRIPTION
The type of this PR is: Feature
This PR resolves [DIA-1014]

### Description

Added an `infiniteDiscovery` owner type, and an `infiniteDiscoveryBanner` context module to track events on the Infinite Discovery entry-point in Eigen.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[DIA-1014]: https://artsyproduct.atlassian.net/browse/DIA-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ