### PR TITLE
feat: add commercialFilterSelectedAll event

### DIFF
--- a/src/Schema/Events/FilterAndSort.ts
+++ b/src/Schema/Events/FilterAndSort.ts
@@ -32,6 +32,34 @@ export interface CommercialFilterParamsChanged {
 }
 
 /**
+ * A user filters an artwork grid facet by keyword, and then selects all resulting options
+ *
+ * This schema describes events sent to Segment from [[commercialFilterSelectedAll]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "commercialFilterSelectedAll",
+ *    context_module: "artworkGrid",
+ *    context_owner_type: "artist",
+ *    context_owner_id: "58ba65b1275b24421f80a102",
+ *    context_owner_slug: "tugo-cheng",
+ *    facet: "locationCities",
+ *    query: "africa",
+ *  }
+ * ```
+ */
+export interface CommercialFilterSelectedAll {
+  action: ActionType.commercialFilterSelectedAll
+  context_module: ContextModule.artworkGrid
+  context_owner_type: OwnerType
+  context_owner_id?: string
+  context_owner_slug?: string
+  facet: string
+  query: string
+}
+
+/**
  * A user applies filters to a filterable/sortable auction results module
  *
  * This schema describes events sent to Segment from [[auctionResultsFilterParamsChanged]]
@@ -107,3 +135,4 @@ export interface SelectedRecentPriceRange {
   context_screen_owner_type: OwnerType.artworkPriceFilter
   collector_profile_sourced: boolean
 }
+

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -133,6 +133,7 @@ import { ExperimentViewed } from "./ExperimentViewed"
 import {
   AuctionResultsFilterParamsChanged,
   CommercialFilterParamsChanged,
+  CommercialFilterSelectedAll,
   PriceDatabaseFilterParamsChanged,
   SelectedRecentPriceRange,
 } from "./FilterAndSort"
@@ -350,6 +351,7 @@ export type Event =
   | ClickedViewingRoomCard
   | ClickedViewWork
   | CommercialFilterParamsChanged
+  | CommercialFilterSelectedAll
   | CompletedOfflineSync
   | CompletedOnboarding
   | ConfirmBid
@@ -915,6 +917,10 @@ export enum ActionType {
    * Corresponds to {@link CommercialFilterParamsChanged}
    */
   commercialFilterParamsChanged = "commercialFilterParamsChanged",
+  /**
+   * Corresponds to {@link CommercialFilterSelectedAll}
+   */
+  commercialFilterSelectedAll = "commercialFilterSelectedAll",
   /**
    * Corresponds to {@link clickedDownloadAppFooter}
    */


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR resolves [ONYX-1504]

### Description

Adds a new event for the "Select all" ability that was added in https://github.com/artsy/palette/pull/1417:

<img width=400 src=https://github.com/user-attachments/assets/d5299adb-0df0-4dee-b2e4-3a96a8b970a8 />

Slack discussion [here](https://artsy.slack.com/archives/C05EQL4R5N0/p1738249164092949).

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[ONYX-1504]: https://artsyproduct.atlassian.net/browse/ONYX-1504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ