### PR TITLE
chore: Add click event for saving an artwork in CMS edit form AMBER-1268

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1555,6 +1555,29 @@ export interface ClickedPublish {
 }
 
 /**
+ * A partner clicks the save button on the artwork form page in CMS.
+ *
+ * This schema describes events sent to Segment from [[ClickedSave]]
+ *
+ * @example
+ * ```
+ * {
+ *    action: "clickedSave",
+ *    context_module: "artworkDetails" ,
+ *    artwork_id: "60de173a47476c000fd5c4cc"
+ *    label: "Save"
+ * }
+ * ```
+ */
+
+export interface ClickedSave {
+  action: ActionType.clickedSave
+  context_module: ContextModule
+  artwork_id: string
+  label: string
+}
+
+/**
  * A Partner selects a filter on the conversations page in CMS.
  *
  * This schema describes events sent to Segment from [[ClickedConversationsFilter]]

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1540,7 +1540,7 @@ export interface ClickedOnPriceDisplayDropdown {
  * ```
  * {
  *    action: "clickedPublish",
- *    context_module: "artworkDetails" ,
+ *    context_module: "artworkForm" ,
  *    artwork_id: "60de173a47476c000fd5c4cc"
  *    label: "Publish"
  * }
@@ -1563,7 +1563,7 @@ export interface ClickedPublish {
  * ```
  * {
  *    action: "clickedSave",
- *    context_module: "artworkDetails" ,
+ *    context_module: "artworkForm" ,
  *    artwork_id: "60de173a47476c000fd5c4cc"
  *    label: "Save"
  * }

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -766,6 +766,10 @@ export enum ActionType {
    */
   clickedPublish = "clickedPublish",
   /**
+   * Corresponds to {@link ClickedSave}
+   */
+  clickedSave = "clickedSave",
+  /**
    * Corresponds to {@link ClickedOnReadMore}
    */
   clickedOnReadMore = "clickedOnReadMore",

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -37,6 +37,7 @@ export enum ContextModule {
   artistsToFollowRail = "artistsToFollowRail",
   artworkClosedLotHeader = "artworkClosedLotHeader",
   artworkDetails = "artworkDetails",
+  artworkForm = "artworkForm",
   artworkGrid = "artworkGrid",
   artworkImage = "artworkImage",
   artworkMetadata = "artworkMetadata",


### PR DESCRIPTION
There are two buttons in CMS for the Artwork Form:

![sabretooth-000052@2x](https://github.com/user-attachments/assets/e059f616-6a41-4fbb-94ca-f0f48f248fe7)

Neither of these buttons are currently being tracked but I'm working on fixing this! When I came to Cohesion to find a suitable event I found `ClickedPublish`:

```ts
/**
 * A partner clicks the publish button on the artwork form page in CMS.
 *
 * This schema describes events sent to Segment from [[ClickedPublish]]
 *
 * @example
 * ```
 * {
 *    action: "clickedPublish",
 *    context_module: "artworkDetails" ,
 *    artwork_id: "60de173a47476c000fd5c4cc"
 *    label: "Publish"
 * }
 * ```
 */

export interface ClickedPublish {
  action: ActionType.clickedPublish
  context_module: ContextModule
  artwork_id: string
  label: string
}
```

So then I thought I'd add the Save version and that's what's in this PR. This may be good enough but wait a minute - if the publish button in the artwork form is not currently being tracked then how are we even using `ClickedPublish`?

Turns out we use this event on the Artwork show page! Here:

![sabretooth-000053@2x](https://github.com/user-attachments/assets/ac734e58-00a3-4552-9dc0-e652eae924db)

Which.....is not what the description of the event says - that note says that this is used on the artwork form. Is this a problem? I guess we could use the `context_module` to disambiguate. So that's what I did with the second commit - added the `ContextModule.artworkForm` option. Am I missing something or is this cool?

https://artsyproduct.atlassian.net/browse/AMBER-1268

/cc @artsy/amber-devs