### PR TITLE
feat(EMI-2276): adding estimate_available for when widget fails

### DIFF
--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -307,23 +307,24 @@ export interface CreateAlertReminderMessageViewed {
 }
 
 /**
- * User sees a shipping estimate
+ * User sees a shipping estimate. estimate_available = false when artwork is disqualified
+ * from arta (due to size, weight, origin country) and therefore does not show an estimate
  *
  * This schema describes events sent to segment from [[ArtsyShippingEstimateViewed]]
  *
  * @example
  * ```
  * {
- *  "action": "shippingEstimateViewed",
- *  "context_page_owner_type": "artwork",
- *   context_page_owner_id: "58de681f275b2464fcdde097",
- *   context_page_owner_slug: "damien-hirst",
- *  "origin": "New York, NY, US",
- *  "destination": "Chicago, IL, US",
- *  "minimum_estimate": 24
- *  "maximum_estimate": 78
- *  "estimate_currency": "USD"
- *
+ *    action: "shippingEstimateViewed",
+ *    context_page_owner_type: "artwork",
+ *    context_page_owner_id: "58de681f275b2464fcdde097",
+ *    context_page_owner_slug: "damien-hirst",
+ *    origin: "New York, NY, US",
+ *    destination: "Chicago, IL, US",
+ *    estimate_available: true | false
+ *    minimum_estimate: 24 | null
+ *    maximum_estimate: 78 | null
+ *    estimate_currency: "USD"
  * }
  * ```
  */
@@ -334,7 +335,8 @@ export interface ShippingEstimateViewed {
   context_page_owner_slug: string
   origin: string
   destination: string
-  minimum_estimate: number
+  estimate_available: boolean
+  minimum_estimate?: number | null
   maximum_estimate?: number | null
   estimate_currency: string
 }


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [EMI-2276]

### Description

<!-- Implementation description -->

We've implemented some safeguards for artworks that are marked as being able to have an estimate generated, but actually cannot due to their size/weight/price origin country, disqualifying them from receiving an arta shipping price. This commit adds a field to identify when this occurs so that we can identify when this occurs.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[EMI-2276]: https://artsyproduct.atlassian.net/browse/EMI-2276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ