### PR TITLE
feat(EMI-2258): add ClickedMakeOffer to events schema for signal tracking

### DIFF
--- a/src/DeprecatedSchema/DeprecatedValues.ts
+++ b/src/DeprecatedSchema/DeprecatedValues.ts
@@ -49,14 +49,7 @@ export enum ActionType {
    * TODO: Check if ‘Tap’ and this can be combined.
    */
   Click = "Click",
-  ClickedBid = 'Clicked "Bid"',
-  /**
-   * A click on 'Buy Now' or 'Make offer' buttons.
-   */
-  ClickedBuyNow = "Clicked buy now",
   ClickedConsign = "Clicked consign",
-  ClickedContactGallery = 'Clicked "Contact Gallery"',
-  ClickedMakeOffer = "Clicked make offer",
 
   /**
    * Triggers a pageview in force, skips segment

--- a/src/DeprecatedSchema/DeprecatedValues.ts
+++ b/src/DeprecatedSchema/DeprecatedValues.ts
@@ -50,6 +50,7 @@ export enum ActionType {
    */
   Click = "Click",
   ClickedConsign = "Clicked consign",
+  ClickedMakeOffer = "Clicked make offer",
 
   /**
    * Triggers a pageview in force, skips segment

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -310,8 +310,6 @@ export interface ClickedBuyNow {
   impulse_conversation_id?: string
   flow?: string
   signal_label?: string
-  signal_lot_watcher_count?: number
-  signal_bid_count?: number
 }
 
 /**
@@ -341,8 +339,6 @@ export interface ClickedMakeOffer {
   impulse_conversation_id?: string
   flow?: string
   signal_label?: string
-  signal_lot_watcher_count?: number
-  signal_bid_count?: number
 }
 
 /**

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -315,6 +315,37 @@ export interface ClickedBuyNow {
 }
 
 /**
+ * User clicks "Make an Offer" on an artwork page (BNMO)
+ *
+ * This schema describes events sent to Segment from [[clickedMakeOffer]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedMakeOffer",
+ *    context_owner_type: "Artwork",
+ *    context_owner_slug: "radna-segal-pearl",
+ *    context_owner_id: "6164889300d643000db86504",
+ *    impulse_conversation_id: "198",
+ *    flow: "Make offer" | "Partner offer"
+ *    signal_label: "Limited-Time Offer",
+ *  }
+ * ```
+ */
+
+export interface ClickedMakeOffer {
+  action: ActionType.clickedMakeOffer
+  context_owner_type: OwnerType
+  context_owner_slug: string
+  context_owner_id: string
+  impulse_conversation_id?: string
+  flow?: string
+  signal_label?: string
+  signal_lot_watcher_count?: number
+  signal_bid_count?: number
+}
+
+/**
  * User clicks "Contact Gallery" on an artwork page (BNMO)
  *
  * This schema describes events sent to Segment from [[clickedContactGallery]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -652,7 +652,7 @@ export enum ActionType {
    */
   clickedCompleteYourProfile = "clickedCompleteYourProfile",
   /**
-   * Corresponds to {@link ClickedCompleteYourProfile}
+   * Corresponds to {@link ClickedContactGallery}
    */
   clickedContactGallery = "clickedContactGallery",
   /**
@@ -711,6 +711,10 @@ export enum ActionType {
    * Corresponds to {@link ClickedMainArtworkGrid}
    */
   clickedMainArtworkGrid = "clickedMainArtworkGrid",
+  /**
+   * Corresponds to {@link ClickedMakeOffer}
+   */
+  clickedMakeOffer = "clickedMakeOffer",
   /**
    * Corresponds to {@link ClickedMyCollectionInsightsMedianAuctionRailItem}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -47,13 +47,16 @@ import {
   ClickedArtworkGroup,
   ClickedAuctionGroup,
   ClickedAuctionResultItem,
+  ClickedBid,
   ClickedBuyerProtection,
+  ClickedBuyNow,
   ClickedChangePage,
   ClickedChangePaymentMethod,
   ClickedChangeShippingAddress,
   ClickedChangeShippingMethod,
   ClickedCloseValidationAddressModal,
   ClickedCollectionGroup,
+  ClickedContactGallery,
   ClickedConversationsFilter,
   ClickedCreateAlert,
   ClickedDeliveryMethod,
@@ -71,6 +74,7 @@ import {
   ClickedHeroUnitGroup,
   ClickedLoadMore,
   ClickedMainArtworkGrid,
+  ClickedMakeOffer,
   ClickedMarketingModal,
   ClickedMarkSold,
   ClickedMarkSpam,
@@ -288,13 +292,16 @@ export type Event =
   | ClickedArtworkGroup
   | ClickedAuctionGroup
   | ClickedAuctionResultItem
+  | ClickedBid
   | ClickedBuyerProtection
+  | ClickedBuyNow
   | ClickedChangePage
   | ClickedChangePaymentMethod
   | ClickedChangeShippingAddress
   | ClickedChangeShippingMethod
   | ClickedCloseValidationAddressModal
   | ClickedCollectionGroup
+  | ClickedContactGallery
   | ClickedConversationsFilter
   | ClickedCreateAlert
   | ClickedDeliveryMethod
@@ -312,6 +319,7 @@ export type Event =
   | ClickedHeroUnitGroup
   | ClickedLoadMore
   | ClickedMainArtworkGrid
+  | ClickedMakeOffer
   | ClickedMarketingModal
   | ClickedMarkSold
   | ClickedMarkSpam
@@ -614,11 +622,11 @@ export enum ActionType {
   /**
    *    * Corresponds to {@link ClickedAuctionResultItem}
    */
+  clickedAuctionResultItem = "clickedAuctionResultItem",
   /**
    * Corresponds to {@link ClickedBid}
    */
   clickedBid = "clickedBid",
-  clickedAuctionResultItem = "clickedAuctionResultItem",
   /**
    * Corresponds to {@link ClickedBuyerProtection}
    */


### PR DESCRIPTION
The type of this PR is: **feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [EMI-2258]

### Description

<!-- Implementation description -->

I copied changes from this [PR](https://github.com/artsy/cohesion/pull/499/files) and the current `clickedBuyNow` schema; not sure if we should remove `flow` `signal_lot_watcher_count` and `signal_bid_count`, for future reasons like making offers on a partner offer, and since the latter two still existed on `clickedBuyNow`. 

Also, do these events not need to be declared in the `export type Event = ` beginning on line 263 in [index.ts](https://github.com/artsy/cohesion/blob/bd9c398c83377b74418a7a2b45b94c0448d52458/src/Schema/Events/index.ts#L263) because they exist in DeprecatedSchema?

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[EMI-2258]: https://artsyproduct.atlassian.net/browse/EMI-2258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ