### PR TITLE
fix: add ConfirmYourBid owner type

### DIFF
--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -35,6 +35,7 @@ export enum OwnerType {
   collection = "collection",
   collections = "collections",
   collectionsCategory = "collectionsCategory",
+  confirmYourBid = "confirmYourBid",
   consign = "consign",
   consignmentFlow = "consignmentFlow",
   consignmentInquiry = "consignmentInquiry",
@@ -165,6 +166,7 @@ export type ScreenOwnerType =
   | OwnerType.cityPicker
   | OwnerType.collection
   | OwnerType.collectionsCategory
+  | OwnerType.confirmYourBid
   | OwnerType.consign
   | OwnerType.consignmentFlow
   | OwnerType.consignmentInquiry


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves []

### Description
This PR is a follow-up on #560
This PR adds `confirmYourBid` to cohesion as an owner type, to keep the tracking after the refactoring of the bid flow

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
