### PR TITLE
feat(imports): Add CmsBatchImport events

### DIFF
--- a/src/Schema/CMS/Events/BatchImportFlow.ts
+++ b/src/Schema/CMS/Events/BatchImportFlow.ts
@@ -25,7 +25,7 @@ export interface CmsBatchImportFlowClickImport {
   context_module: CmsContextModule.batchImportFlow
   context_page_owner_type: CmsOwnerType.batchImport
   context_page_owner_id: string
-  label: "click import"
+  label: "click import works"
   referrer: ""
 }
 
@@ -70,49 +70,6 @@ export interface CmsBatchImportFlowClickDownloadTemplate {
 }
 
 /**
- * Import process was completed.
- *
- * @example
- * ```
- * {
- *   event: "importComplete",
- *   context_page_owner_type: "batchImport",
- *   context_page_owner_id: "67b646ecbe87376bfeb3f962",
- *   // original_csv_size = number of lines in csv
- *   // outcome = number of lines successfuly imported
- *   value: { original_csv_size: number, outcome: number }
- * }
- * ```
- */
-export interface CmsBatchImportFlowImportComplete {
-  event: CmsActionType.importComplete
-  context_page_owner_type: CmsOwnerType.batchImport
-  context_page_owner_id: string
-  value: { original_csv_size: number; outcome: number }
-}
-
-/**
- * An error occurred during CSV import.
- *
- * @example
- * ```
- * {
- *   event: "csvImportError",
- *   context_page_owner_type: "batchImport",
- *   context_page_owner_id: "67b646ecbe87376bfeb3f962",
- *   // list of errors
- *   value: [ "error1", "error2" ]
- * }
- * ```
- */
-export interface CmsBatchImportFlowImportError {
-  event: CmsActionType.csvImportError
-  context_page_owner_type: CmsOwnerType.batchImport
-  context_page_owner_id: string
-  value: string[]
-}
-
-/**
  * Some artworks have missing information warnings.
  *
  * @example
@@ -154,11 +111,30 @@ export interface CmsBatchImportFlowArtistNeedsMatching {
   value: number
 }
 
+/**
+ * Partners click to exit the batch import flow 
+ *
+ * @example
+ * ```
+ * {
+*   context_module: "batchImportFlow",
+ *   context_page_owner_type: "batchImport",
+ *   context_page_owner_id: "67b646ecbe87376bfeb3f962",
+ *   label: "click import"
+ * }
+ * ```
+ */
+export interface CmsBatchImportClickExit {
+  context_module: CmsContextModule.batchImportFlow
+  context_page_owner_type: CmsOwnerType.batchImport
+  context_page_owner_id: string
+  label: "click exit"
+}
+
 export type CmsBatchImportFlow =
   | CmsBatchImportFlowClickImport
   | CmsBatchImportFlowClickAddCSV
   | CmsBatchImportFlowClickDownloadTemplate
-  | CmsBatchImportFlowImportComplete
-  | CmsBatchImportFlowImportError
   | CmsBatchImportFlowShownMissingInformation
   | CmsBatchImportFlowArtistNeedsMatching
+  | CmsBatchImportClickExit

--- a/src/Schema/CMS/Events/BatchImportFlow.ts
+++ b/src/Schema/CMS/Events/BatchImportFlow.ts
@@ -1,0 +1,164 @@
+/**
+ * Schemas describing CMS BatchImportFlow events
+ * @packageDocumentation
+ */
+
+import { CmsContextModule } from "../Values/CmsContextModule"
+import { CmsOwnerType } from "../Values/CmsOwnerType"
+import { CmsActionType } from "./index"
+
+/**
+ * A partner has clicked the import button and started the flow.
+ *
+ * @example
+ * ```
+ * {
+ *   context_module: "batchImportFlow",
+ *   context_page_owner_type: "batchImport",
+ *   context_page_owner_id: "67b646ecbe87376bfeb3f962",
+ *   label: "click import",
+ *   referrer: ""
+ * }
+ * ```
+ */
+export interface CmsBatchImportFlowClickImport {
+  context_module: CmsContextModule.batchImportFlow
+  context_page_owner_type: CmsOwnerType.batchImport
+  context_page_owner_id: string
+  label: "click import"
+  referrer: ""
+}
+
+/**
+ * A partner has clicked to add a CSV file.
+ *
+ * @example
+ * ```
+ * {
+ *   context_module: "batchImportFlow",
+ *   context_page_owner_type: "batchImport",
+ *   context_page_owner_id: "67b646ecbe87376bfeb3f962",
+ *   label: "click add CSV"
+ * }
+ * ```
+ */
+export interface CmsBatchImportFlowClickAddCSV {
+  context_module: CmsContextModule.batchImportFlow
+  context_page_owner_type: CmsOwnerType.batchImport
+  context_page_owner_id: string
+  label: "click add CSV"
+}
+
+/**
+ * A partner has clicked to download the template.
+ *
+ * @example
+ * ```
+ * {
+ *   context_module: "batchImportFlow",
+ *   context_page_owner_type: "batchImport",
+ *   context_page_owner_id: "67b646ecbe87376bfeb3f962",
+ *   label: "click download template"
+ * }
+ * ```
+ */
+export interface CmsBatchImportFlowClickDownloadTemplate {
+  context_module: CmsContextModule.batchImportFlow
+  context_page_owner_type: CmsOwnerType.batchImport
+  context_page_owner_id: string
+  label: "click download template"
+}
+
+/**
+ * Import process was completed.
+ *
+ * @example
+ * ```
+ * {
+ *   event: "importComplete",
+ *   context_page_owner_type: "batchImport",
+ *   context_page_owner_id: "67b646ecbe87376bfeb3f962",
+ *   // original_csv_size = number of lines in csv
+ *   // outcome = number of lines successfuly imported
+ *   value: { original_csv_size: number, outcome: number }
+ * }
+ * ```
+ */
+export interface CmsBatchImportFlowImportComplete {
+  event: CmsActionType.importComplete
+  context_page_owner_type: CmsOwnerType.batchImport
+  context_page_owner_id: string
+  value: { original_csv_size: number; outcome: number }
+}
+
+/**
+ * An error occurred during CSV import.
+ *
+ * @example
+ * ```
+ * {
+ *   event: "csvImportError",
+ *   context_page_owner_type: "batchImport",
+ *   context_page_owner_id: "67b646ecbe87376bfeb3f962",
+ *   // list of errors
+ *   value: [ "error1", "error2" ]
+ * }
+ * ```
+ */
+export interface CmsBatchImportFlowImportError {
+  event: CmsActionType.csvImportError
+  context_page_owner_type: CmsOwnerType.batchImport
+  context_page_owner_id: string
+  value: string[]
+}
+
+/**
+ * Some artworks have missing information warnings.
+ *
+ * @example
+ * ```
+ * {
+ *   event: "shownMissingInformation",
+ *   context_page_owner_type: "batchImport",
+ *   context_page_owner_id: "67b646ecbe87376bfeb3f962",
+ *   // number of artworks with warnings
+ *   value: 5
+ * }
+ * ```
+ */
+export interface CmsBatchImportFlowShownMissingInformation {
+  event: CmsActionType.shownMissingInformation
+  context_page_owner_type: CmsOwnerType.batchImport
+  context_page_owner_id: string
+  value: number
+}
+
+/**
+ * Artists need matching during the batch import.
+ *
+ * @example
+ * ```
+ * {
+ *   event: "artistNeedsMatching",
+ *   context_page_owner_type: "batchImportArtistMatching",
+ *   context_page_owner_id: "67b646ecbe87376bfeb3f962",
+ *   // number of artists with missing matching
+ *   value: 3
+ * }
+ * ```
+ */
+export interface CmsBatchImportFlowArtistNeedsMatching {
+  event: CmsActionType.artistNeedsMatching
+  context_page_owner_type: CmsOwnerType.batchImportArtistMatching
+  context_page_owner_id: string
+  value: number
+}
+
+export type CmsBatchImportFlow =
+  | CmsBatchImportFlowClickImport
+  | CmsBatchImportFlowClickAddCSV
+  | CmsBatchImportFlowClickDownloadTemplate
+  | CmsBatchImportFlowImportComplete
+  | CmsBatchImportFlowImportError
+  | CmsBatchImportFlowShownMissingInformation
+  | CmsBatchImportFlowArtistNeedsMatching

--- a/src/Schema/CMS/Events/index.ts
+++ b/src/Schema/CMS/Events/index.ts
@@ -1,0 +1,34 @@
+import { CmsBatchImportFlow } from "./BatchImportFlow"
+
+/**
+ * List of valid schemas for CMS analytics actions
+ *
+ * Each event describes one ActionType
+ */
+export type CmsEvent = CmsBatchImportFlow
+
+/**
+ * List of all CMS actions
+ *
+ * Each CmsActionType corresponds with a table in Redshift.
+ */
+export enum CmsActionType {
+  /**
+   * Corresponds to {@link CmsBatchImportFlow}
+   */
+  artistNeedsMatching = "artistNeedsMatching",
+
+  /**
+   * Corresponds to {@link BatchImportFlow}
+   */
+  csvImportError = "csvImportError",
+
+  /**
+   * Corresponds to {@link BatchImportFlow}
+   */
+  importComplete = "importComplete",
+  /**
+   * Corresponds to {@link BatchImportFlow}
+   */
+  shownMissingInformation = "shownMissingInformation",
+}

--- a/src/Schema/CMS/Events/index.ts
+++ b/src/Schema/CMS/Events/index.ts
@@ -21,14 +21,5 @@ export enum CmsActionType {
   /**
    * Corresponds to {@link BatchImportFlow}
    */
-  csvImportError = "csvImportError",
-
-  /**
-   * Corresponds to {@link BatchImportFlow}
-   */
-  importComplete = "importComplete",
-  /**
-   * Corresponds to {@link BatchImportFlow}
-   */
   shownMissingInformation = "shownMissingInformation",
 }

--- a/src/Schema/CMS/Values/CmsContextModule.ts
+++ b/src/Schema/CMS/Values/CmsContextModule.ts
@@ -1,0 +1,9 @@
+/**
+ * All context modules available for CMS
+ *
+ * A component where an action is triggered
+ * @packageDocumentation
+ */
+export enum CmsContextModule {
+  batchImportFlow = "batchImportFlow",
+}

--- a/src/Schema/CMS/Values/CmsOwnerType.ts
+++ b/src/Schema/CMS/Values/CmsOwnerType.ts
@@ -1,0 +1,9 @@
+/**
+ * All owner types available for CMS
+ *
+ * @packageDocumentation
+ */
+export enum CmsOwnerType {
+  batchImport = "batchImport",
+  batchImportArtistMatching = "batchImportArtistMatching",
+}

--- a/src/Schema/index.ts
+++ b/src/Schema/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Web and iOS exports
+ */
+
 export * from "./Events"
 export * from "./Events/ActivityPanel"
 export * from "./Events/AddToCalendar"
@@ -29,3 +33,11 @@ export * from "./Values/Intent"
 export * from "./Values/OwnerType"
 export * from "./Values/PushNotificationType"
 export * from "./Values/Tab"
+
+/**
+ * CMS-specific exports
+ */
+
+export * from "./CMS/Events"
+export * from "./CMS/Values/CmsContextModule"
+export * from "./CMS/Values/CmsOwnerType"


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

This updates cohesion with the new BatchImports events. 

Additionally (per our discussion @leodmz) starts organizing our CMS-specific events inside of an `src/Schema/CMS` folder, mirroring how things are structured in web / ios folders:

```
├── Schema
│   ├── CMS
│   │   ├── Events
│   │   └── Values
```

An updated organization like this will become imperative as we continue migrating CMS pages to our modern patterns and moving legacy CMS events over to cohesion.  

Note that CMS interfaces/events/values have been prefixed with a `CMS` identifier. This shouldn't preclude mixing in events from other parts of the schema in an event (like `Event.click`), only that now we can go directly to the `CMS` folder not get lost in collector-specific events, and avoid type clashes. 

cc @artsy/amber-devs 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.238.1--canary.562.11138.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/cohesion@4.238.1--canary.562.11138.0
  # or 
  yarn add @artsy/cohesion@4.238.1--canary.562.11138.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
