### PR TITLE
feat(EMI-2310): add express checkout click events

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -2422,7 +2422,7 @@ export interface ClickedHeroUnitGroup {
  *  ```
  *  {
  *    action: "clickedExpressCheckout",
- *    context_page_owner_type: "ordersExpressCheckout",
+ *    context_page_owner_type: "ordersShipping",
  *    context_page_owner_slug: "radna-segal-pearl",
  *    context_page_owner_id: "6164889300d643000db86504",
  *    flow: "Buy now" | "Make offer" | "Partner offer"
@@ -2448,7 +2448,7 @@ export interface ClickedExpressCheckout {
  *  ```
  *  {
  *    action: "clickedCancelExpressCheckout",
- *    context_page_owner_type: "ordersExpressCheckout",
+ *    context_page_owner_type: "ordersShipping",
  *    context_page_owner_slug: "radna-segal-pearl",
  *    context_page_owner_id: "6164889300d643000db86504",
  *    flow: "Buy now" | "Make offer" | "Partner offer"

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -88,7 +88,6 @@ export enum OwnerType {
   ordersReview = "orders-review",
   ordersShipping = "orders-shipping",
   ordersSubmitted = "orders-submitted",
-  ordersExpressCheckout = "orders-express-checkout",
   partner = "partner",
   partnerShowsArtworks = "partnerShowsArtworks",
   priceDatabase = "priceDatabase",


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [EMI-2310]

### Description

This adds a `clickedExpressCheckout` and `clickedCancelExpressCheckout` events to correspond when a user enters the express checkout flow and exits it. 

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[EMI-2310]: https://artsyproduct.atlassian.net/browse/EMI-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ