### PR TITLE
feat: share lists tracking events

### DIFF
--- a/src/Schema/Events/ArtworkLists.ts
+++ b/src/Schema/Events/ArtworkLists.ts
@@ -115,3 +115,23 @@ export interface ViewedArtworkList {
   context_owner_type: OwnerType.saves
   owner_id: string
 }
+
+/**
+ * When a user clicks to view a shared artwork list
+ *
+ * This schema describes events sent to Segment from [[viewedSharedArtworkList]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "viewedSharedArtworkList",
+ *    context_owner_type: "saves",
+ *    owner_id: "770fa47d-8cc8-4267-93e7-2808544d2a98"
+ *  }
+ * ```
+ */
+export interface ViewedSharedArtworkList {
+  action: ActionType.viewedSharedArtworkList
+  context_owner_type: OwnerType.saves
+  owner_id: string
+}

--- a/src/Schema/Events/ArtworkLists.ts
+++ b/src/Schema/Events/ArtworkLists.ts
@@ -97,7 +97,7 @@ export interface EditedArtworkList {
 }
 
 /**
- * When a user clicks to view an artwork list
+ * When a user views an artwork list
  *
  * This schema describes events sent to Segment from [[viewedArtworkList]]
  *
@@ -117,7 +117,7 @@ export interface ViewedArtworkList {
 }
 
 /**
- * When a user clicks to view a shared artwork list
+ * When a user views a shared artwork list
  *
  * This schema describes events sent to Segment from [[viewedSharedArtworkList]]
  *

--- a/src/Schema/Events/Share.ts
+++ b/src/Schema/Events/Share.ts
@@ -32,3 +32,53 @@ export interface Share {
   context_owner_slug?: string
   service: CustomService | string
 }
+
+/**
+ * A user clicks the share button on the collection (artwork list) page
+ *
+ * This schema describes events sent to Segment from [[ClickedShareButton]]
+ *
+ * @example
+ * ```
+ * {
+ *    action: "clickedShareButton",
+ *    context_module: "saves" ,
+ *    context_owner_type: "saves",
+ *    context_owner_id: "55ed8ca57261693d930000b8",
+ *    context_owner_slug: "wishlist",
+ * }
+ * ```
+ */
+
+export interface ClickedShareButton {
+  action: ActionType.clickedShareButton
+  context_module: ContextModule
+  context_owner_type: OwnerType
+  context_owner_id: string
+  context_owner_slug?: string
+}
+
+/**
+ * A user clicks the open in new tab button on the collection (artwork list) page
+ *
+ * This schema describes events sent to Segment from [[ClickedOpenInNewTabButton]]
+ *
+ * @example
+ * ```
+ * {
+ *    action: "clickedOpenInNewTabButton",
+ *    context_module: "saves" ,
+ *    context_owner_type: "saves",
+ *    context_owner_id: "55ed8ca57261693d930000b8",
+ *    context_owner_slug: "wishlist",
+ * }
+ * ```
+ */
+
+export interface ClickedOpenInNewTabButton {
+  action: ActionType.clickedOpenInNewTabButton
+  context_module: ContextModule
+  context_owner_type: OwnerType
+  context_owner_id: string
+  context_owner_slug?: string
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -11,6 +11,7 @@ import {
   DeletedArtworkList,
   EditedArtworkList,
   ViewedArtworkList,
+  ViewedSharedArtworkList,
 } from "./ArtworkLists"
 import {
   AuctionPageView,
@@ -211,7 +212,7 @@ import {
   SelectedItemFromSearch,
   SelectedSearchSuggestionQuickNavigationItem,
 } from "./Search"
-import { Share } from "./Share"
+import { ClickedOpenInNewTabButton, ClickedShareButton, Share } from "./Share"
 import { SwipedInfiniteDiscoveryArtwork } from "./Swipe"
 import { SaleScreenLoadComplete, Screen, TimeOnPage } from "./System"
 import {
@@ -347,6 +348,7 @@ export type Event =
   | ClickedOnSubmitOrder
   | ClickedOrderPage
   | ClickedOrderSummary
+  | ClickedOpenInNewTabButton
   | ClickedPartnerCard
   | ClickedPartnerLink
   | ClickedPaymentDetails
@@ -356,6 +358,7 @@ export type Event =
   | ClickedRegisterToBid
   | ClickedSelectShippingOption
   | ClickedSendPartnerOffer
+  | ClickedShareButton
   | ClickedShippingAddress
   | ClickedShowGroup
   | ClickedShowMore
@@ -499,6 +502,7 @@ export type Event =
   | ValidationAddressViewed
   | ViewArtworkMyCollection
   | ViewedArtworkList
+  | ViewedSharedArtworkList
   | ViewedVideo
   | VisitMyCollection
   | VisitMyCollectionOnboardingSlide
@@ -806,6 +810,10 @@ export enum ActionType {
    */
   clickedSave = "clickedSave",
   /**
+   * Corresponds to {@link ClickedShareButton}
+   */
+  clickedShareButton = "clickedShareButton",
+  /**
    * Corresponds to {@link ClickedOnReadMore}
    */
   clickedOnReadMore = "clickedOnReadMore",
@@ -821,6 +829,10 @@ export enum ActionType {
    * Corresponds to {@link ClickedOrderSummary}
    */
   clickedOrderSummary = "clickedOrderSummary",
+  /**
+   * Corresponds to {@link ClickedOpenInNewTabButton}
+   */
+  clickedOpenInNewTabButton = "clickedOpenInNewTabButton",
   /**
    * Corresponds to {@link ClickedPartnerCard}
    */
@@ -1601,6 +1613,10 @@ export enum ActionType {
    * Corresponds to {@link ViewedArtworkList}
    */
   viewedArtworkList = "viewedArtworkList",
+  /**
+   * Corresponds to {@link ViewedSharedArtworkList}
+   */
+  viewedSharedArtworkList = "viewedSharedArtworkList",
   /**
    * Corresponds to {@link ViewedVideo}
    */


### PR DESCRIPTION
The type of this PR is: **Feature**

### Description

Added a few events to track our experimental "share lists" functionality:

<img width="400px" alt="image" src="https://github.com/user-attachments/assets/6e073eab-1768-4f9f-8afd-465c8a3b2eb7" />

We already have a `Share` event which allows us to track when user clicks the "Copy URL" button, but we were missing clicks on the "Share" button itself, and the "Open in the new tab" button.

I've also added an event to track when someone opens shared collections.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
