### PR TITLE
feat: add interface for TappedMenuItemGroup event

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -1379,3 +1379,27 @@ export interface TappedNavigationPillsGroup extends TappedEntityGroup {
   href: string
   title: string
 }
+
+/**
+ * A user an item within a menu item group
+ *
+ * This schema describes events sent to Segment from [[tappedMenuItemGroup]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedMenuItemGroup",
+ *    context_module: "accountSettings",
+ *    context_screen_owner_type: "artist",
+ *    position: "6",
+ *    subject: "Dark Mode",
+ *  }
+ * ```
+ */
+export interface TappedMenuItemGroup{
+  action: ActionType.tappedMenuItemGroup
+  context_module?: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  position: number,
+  subject: string,
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -244,6 +244,7 @@ import {
   TappedLearnMore,
   TappedLink,
   TappedMainArtworkGrid,
+  TappedMenuItemGroup,
   TappedNavigationPillsGroup,
   TappedNavigationTab,
   TappedPartnerCard,
@@ -469,6 +470,7 @@ export type Event =
   | TappedLink
   | TappedMainArtworkGrid
   | TappedMakeOffer
+  | TappedMenuItemGroup
   | TappedMyCollectionAddArtworkArtist
   | TappedMyCollectionInsightsMedianAuctionPriceChartCareerHighlight
   | TappedMyCollectionInsightsMedianAuctionPriceChartCategory
@@ -1431,6 +1433,10 @@ export enum ActionType {
    * Corresponds to {@link TappedMenuItem}
    */
   tappeMenuItem = "tappeMenuItem",
+  /**
+   * Corresponds to {@link TappedMenuItemGroup}
+   */
+  tappedMenuItemGroup = "tappedMenuItemGroup",
   /**
    * Corresponds to {@link TappedMyCollectionAddArtworkArtist}
    */

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -8,6 +8,8 @@ export enum ContextModule {
   aboutTheWork = "aboutTheWork",
   aboutThisAuction = "aboutThisAuction",
   account = "account",
+  accountSettings = "accountSettings",
+  accountTransactions = "accountTransactions",
   activity = "activity",
   activityRail = "activityRail",
   actNow = "actNow",
@@ -241,6 +243,8 @@ export enum ContextModule {
  */
 export type AuthContextModule =
   | ContextModule.aboutTheWork
+  | ContextModule.accountSettings
+  | ContextModule.accountTransactions
   | ContextModule.activity
   | ContextModule.articleTab
   | ContextModule.artistHeader


### PR DESCRIPTION
### Description

To track a user selecting an item within a menu group, for example the navigation menu in the Account screen.

Will eventually replace the `tappeMenuItem` event only used in a couple places.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
