### PR TITLE
feat: add express checkout viewed event

### DIFF
--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -362,3 +362,29 @@ export interface ShippingEstimateViewed {
   maximum_estimate?: number | null
   estimate_currency: string
 }
+
+/**
+ * A user views express checkout
+ *
+ * This schema describes events sent to Segment from [[ExpressCheckoutViewed]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "expressCheckoutViewed",
+ *    context_page_owner_type: "ordersShipping",
+ *    context_page_owner_slug: "radna-segal-pearl",
+ *    context_page_owner_id: "6164889300d643000db86504",
+ *    flow: "Buy now" | "Make offer" | "Partner offer"
+ *    payment_method: "Apple Pay" | "Google Pay"
+ *  }
+ * ```
+ */
+export interface ExpressCheckoutViewed {
+  action: ActionType.expressCheckoutViewed
+  context_page_owner_type: OwnerType
+  context_page_owner_slug: string
+  context_page_owner_id: string
+  flow: string
+  payment_method: string
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -165,6 +165,7 @@ import {
   CreateAlertReminderMessageViewed,
   EditProfileModalViewed,
   ErrorMessageViewed,
+  ExpressCheckoutViewed,
   ItemViewed,
   ProgressiveOnboardingTooltipViewed,
   RailViewed,
@@ -398,6 +399,7 @@ export type Event =
   | EnterLiveAuction
   | ErrorMessageViewed
   | ExperimentViewed
+  | ExpressCheckoutViewed
   | FocusedOnConversationMessageInput
   | FocusedOnPriceDatabaseSearchInput
   | FocusedOnSearchInput
@@ -1081,6 +1083,10 @@ export enum ActionType {
    * Corresponds to {@link ExperimentViewed}
    */
   experimentViewed = "experiment_viewed", // intentional snake case to match tracked event
+  /**
+   * Corresponds to {@link ExpressCheckoutViewed}
+   */
+  expressCheckoutViewed = "expressCheckoutViewed",
   /**
    * Corresponds to {@link ItemViewed}
    */


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

This adds an `expressCheckoutViewed` event to track when a user views the express checkout in the order flow. 

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
