### PR TITLE
chore: Rename wallet type field and correct example values

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -2426,7 +2426,7 @@ export interface ClickedHeroUnitGroup {
  *    context_page_owner_slug: "radna-segal-pearl",
  *    context_page_owner_id: "6164889300d643000db86504",
  *    flow: "Buy now" | "Make offer" | "Partner offer"
- *    payment_method: "Apple Pay" | "Google Pay"
+ *    credit_card_wallet_type: "applePay" | "googlePay"
  *  }
  * ```
  */
@@ -2436,7 +2436,7 @@ export interface ClickedExpressCheckout {
   context_page_owner_slug: string
   context_page_owner_id: string
   flow: string
-  payment_method: string
+  credit_card_wallet_type: string
 }
 
 /**
@@ -2452,7 +2452,7 @@ export interface ClickedExpressCheckout {
  *    context_page_owner_slug: "radna-segal-pearl",
  *    context_page_owner_id: "6164889300d643000db86504",
  *    flow: "Buy now" | "Make offer" | "Partner offer"
- *    payment_method: "Apple Pay" | "Google Pay"
+ *    credit_card_wallet_type: "applePay" | "googlePay"
  *  }
  * ```
  */
@@ -2462,5 +2462,5 @@ export interface ClickedCancelExpressCheckout {
   context_page_owner_slug: string
   context_page_owner_id: string
   flow: string
-  payment_method: string
+  credit_card_wallet_type: string
 }

--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -376,7 +376,7 @@ export interface ShippingEstimateViewed {
  *    context_page_owner_slug: "radna-segal-pearl",
  *    context_page_owner_id: "6164889300d643000db86504",
  *    flow: "Buy now" | "Make offer" | "Partner offer"
- *    payment_methods: ["Apple Pay", "Google Pay"]
+ *    credit_card_wallet_types: ["applePay", "googlePay"]
  *  }
  * ```
  */
@@ -386,5 +386,5 @@ export interface ExpressCheckoutViewed {
   context_page_owner_slug: string
   context_page_owner_id: string
   flow: string
-  payment_methods: string[]
+  credit_card_wallet_types: string[]
 }


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

Exchange will store the `payment_method` as `credit_card` for Express Checkout orders, but created a new field called `credit_card_wallet_type` which will describe the type of Express Checkout used (applePay, googlePay). This renames the field on the event to match.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
