### PR TITLE
feat(DIA-1252): add tappedShare event

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -624,6 +624,30 @@ export interface TappedRewind {
 }
 
 /**
+ * A user taps on the share button
+ *
+ * This schema describes events sent to Segment from [[tappedShare]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedShare",
+ *    context_module: "infiniteDiscovery",
+ *    context_screen_owner_id: "artwork-id",
+ *    context_screen_owner_slug: "artwork-slug",
+ *    context_screen_owner_type: "infiniteDiscoveryArtwork"
+ *  }
+ * ```
+ */
+export interface TappedShare {
+  action: ActionType.tappedShare
+  context_module: ContextModule
+  context_screen_owner_id: string
+  context_screen_owner_slug: string
+  context_screen_owner_type: ScreenOwnerType
+}
+
+/**
  * A user taps a button that navigates to the Sell With Artsy home screen (not the 'sell' icon in the tab bar)
  *
  * This schema describes events sent to Segment from [[tappedSell]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -1543,6 +1543,10 @@ export enum ActionType {
    */
   tappedSellArtwork = "tappedSellArtwork",
   /**
+   * Corresponds to {@link TappedShare}
+   */
+  tappedShare = "tappedShare",
+  /**
    * Corresponds to {@link TappedShowGroup}
    */
   tappedShowGroup = "tappedShowGroup",


### PR DESCRIPTION
This PR adds a `tappedShare` event that can be fired from various surfaces when users share artworks, articles, artists, collections, auctions, etc.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
