### PR TITLE
feat(DIA-1283): add swipedUp event

### DIFF
--- a/src/Schema/Events/Swipe.ts
+++ b/src/Schema/Events/Swipe.ts
@@ -30,3 +30,11 @@ export interface SwipedInfiniteDiscoveryArtwork {
   context_screen_owner_slug: string
   context_screen_owner_type: ScreenOwnerType
 }
+
+export interface SwipedUp {
+  action: ActionType.swipedUp
+  context_module: ContextModule
+  context_screen_owner_id: string
+  context_screen_owner_slug: string
+  context_screen_owner_type: ScreenOwnerType
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -223,7 +223,7 @@ import {
   SelectedSearchSuggestionQuickNavigationItem,
 } from "./Search"
 import { ClickedOpenInNewTabButton, ClickedShareButton, Share } from "./Share"
-import { SwipedInfiniteDiscoveryArtwork } from "./Swipe"
+import { SwipedInfiniteDiscoveryArtwork, SwipedUp } from "./Swipe"
 import { SaleScreenLoadComplete, Screen, TimeOnPage } from "./System"
 import {
   TappedActivityGroup,
@@ -260,6 +260,7 @@ import {
   TappedPromoSpace,
   TappedSell,
   TappedSellArtwork,
+  TappedShare,
   TappedShowMore,
   TappedSkip,
   TappedTabBar,
@@ -449,6 +450,7 @@ export type Event =
   | SubmitAnotherArtwork
   | SuccessfullyLoggedIn
   | SwipedInfiniteDiscoveryArtwork
+  | SwipedUp
   | TappedActivityGroup
   | TappedAlertsGroup
   | TappedArticleGroup
@@ -501,6 +503,7 @@ export type Event =
   | TappedRequestPriceEstimate
   | TappedSell
   | TappedSellArtwork
+  | TappedShare
   | TappedShowMore
   | TappedSkip
   | TappedTabBar
@@ -1314,6 +1317,10 @@ export enum ActionType {
    * Corresponds to {@link SwipedInfiniteDiscoveryArtwork}
    */
   swipedInfiniteDiscoveryArtwork = "swipedInfiniteDiscoveryArtwork",
+  /**
+   * Corresponds to {@link SwipedUp}
+   */
+  swipedUp = "swipedUp",
   /**
    * Corresponds to {@link TappedActivityGroup}
    */


### PR DESCRIPTION
This PR adds a `swipedUp` event that can be used when users open bottom sheets, such as the artwork details bottom sheet in Discover Daily.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
