### PR TITLE
chore: add OwnerType.artworkList to ScreenOwnerType

### DIFF
--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -195,6 +195,7 @@ export type ScreenOwnerType =
   | OwnerType.artistAuctionResults
   | OwnerType.artistSeries
   | OwnerType.artwork
+  | OwnerType.artworkList
   | OwnerType.artworkPriceFilter
   | OwnerType.artworkRecommendations
   | OwnerType.auctionResult


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CO-]

### Description
add OwnerType.artworkList to ScreenOwnerType
addressing comments after QA by data https://artsy.slack.com/archives/C05EQL4R5N0/p1744308674546949?thread_ts=1742927066.401229&cid=C05EQL4R5N0
<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
