### PR TITLE
feat: add artworkActions to ContextModule

### DIFF
--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -38,6 +38,7 @@ export enum ContextModule {
   artistSeriesTab = "artistSeriesTab",
   artistsTab = "artistsTab",
   artistsToFollowRail = "artistsToFollowRail",
+  artworkActions = "artworkActions",
   artworkClosedLotHeader = "artworkClosedLotHeader",
   artworkDetails = "artworkDetails",
   artworkForm = "artworkForm",
@@ -258,6 +259,7 @@ export type AuthContextModule =
   | ContextModule.artistSeriesTab
   | ContextModule.artistsTab
   | ContextModule.artistsToFollowRail
+  | ContextModule.artworkActions
   | ContextModule.artworkClosedLotHeader
   | ContextModule.artworkGrid
   | ContextModule.artworkImage


### PR DESCRIPTION
This PR adds `artworkActions` to the `ContextModule` enum so that Eigen can use the Cohesion schema instead of its own (deprecated) schema. These actions are currently being used by saves, view-in-room, and shares.