### PR TITLE
feat(artwork-filter): Add CmsArtworkFilter events

### DIFF
--- a/src/Schema/CMS/Events/ArtworkFilter.ts
+++ b/src/Schema/CMS/Events/ArtworkFilter.ts
@@ -1,0 +1,169 @@
+/**
+ * Schemas describing CMS ArtworkFilter events
+ * @packageDocumentation
+ */
+
+import { CmsContextModule } from "../Values/CmsContextModule"
+import { CmsActionType } from "."
+
+/**
+ * Click on the duplicate artwork button
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedonduplicateartwork",
+ * }
+ * ```
+ */
+export interface CmsArtworkFilterClickDuplicateArtwork {
+  action: CmsActionType.clickedOnDuplicateArtwork
+}
+
+/**
+ * Click on the sort at the top right of the sreen
+ *
+ * @example
+ * ```
+ * {
+ *   action: "click",
+ *   context_module: "Artworks - filter artworks",
+ *   label: "change sorting method",
+ *   title: "Sort by",
+ * }
+ * ```
+ */
+export interface CmsArtworkFilterClickSort {
+  action: "click"
+  context_module: CmsContextModule.artworkFilterFilterArtworks
+  label: "change sorting method"
+  title: string
+}
+
+/**
+ * Filter through one of the filters at the top
+ *
+ * @example
+ * ```
+ * {
+ *   action: "click",
+ *   context_module: "Artworks - filter artworks",
+ *   label: Filter by <some filter>",
+ *   value: "true",
+ * }
+ * ```
+ */
+export interface CmsArtworkFilterQuickEditClickFilter {
+  action: "click"
+  context_module: CmsContextModule.artworkFilterFilterArtworks
+  label: string
+  title: string
+}
+
+/**
+ * Quick edit - change price
+ *
+ * @example
+ * ```
+ * {
+ *   action: "click",
+ *   context_module: "Artworks - quick edit",
+ *   label: "save price",
+ *   artwork_id: "artwork_id",
+ * }
+ * ```
+ */
+export interface CmsArtworkFilterQuickEditSavePrice {
+  action: "click"
+  context_module: CmsContextModule.artworkFilterQuickEdit
+  label: "save price"
+  artwork_id: string
+}
+
+/**
+ * Quick edit - change availability
+ *
+ * @example
+ * ```
+ * {
+ *   action: "click",
+ *   context_module: "Artworks - quick edit",
+ *   label: "change availability",
+ *   artwork_id: "artwork_id",
+ *   value: "for sale"
+ * }
+ * ```
+ */
+export interface CmsArtworkFilterQuickEditChangeAvailability {
+  action: "click"
+  context_module: CmsContextModule.artworkFilterQuickEdit
+  label: "change availability"
+  artwork_id: string
+  value: string
+}
+
+/**
+ * Quick edit - publish
+ *
+ * @example
+ * ```
+ * {
+ *   action: "click",
+ *   context_module: "Artworks - quick edit",
+ *   label: "publish",
+ *   artwork_id: "artwork_id",
+ * }
+ * ```
+ */
+export interface CmsArtworkFilterQuickEditPublish {
+  action: "click"
+  context_module: CmsContextModule.artworkFilterQuickEdit
+  label: "publish"
+  artwork_id: string
+}
+
+/**
+ * Click "import work " to enter the batch import flow
+ *
+ * @example
+ * ```
+ * {
+ *   action: "click",
+ *   context_module: 'batchImportFlow',
+ *   label: "click import works",
+ * }
+ * ```
+ */
+export interface CmsArtworkFilterQuickEditClickImport {
+  action: "click"
+  context_module: CmsContextModule.batchImportFlow
+  label: "click import works"
+}
+
+/**
+ * Search something using the search bar
+ *
+ * @example
+ * ```
+ * {
+ *   action: "searched artwork",
+ *   context_module: 'Artworks - search',
+ *   value: "search input",
+ * }
+ * ```
+ */
+export interface CmsArtworkFilterSearch {
+  action: CmsActionType.searchedArtwork
+  context_module: CmsContextModule.artworkFilterSearch
+  value: string
+}
+
+export type CmsArtworkFilter =
+  | CmsArtworkFilterClickDuplicateArtwork
+  | CmsArtworkFilterClickSort
+  | CmsArtworkFilterQuickEditClickFilter
+  | CmsArtworkFilterQuickEditSavePrice
+  | CmsArtworkFilterQuickEditChangeAvailability
+  | CmsArtworkFilterQuickEditPublish
+  | CmsArtworkFilterQuickEditClickImport
+  | CmsArtworkFilterSearch

--- a/src/Schema/CMS/Events/index.ts
+++ b/src/Schema/CMS/Events/index.ts
@@ -1,3 +1,4 @@
+import { CmsArtworkFilter } from "./ArtworkFilter"
 import { CmsBatchImportFlow } from "./BatchImportFlow"
 
 /**
@@ -5,7 +6,7 @@ import { CmsBatchImportFlow } from "./BatchImportFlow"
  *
  * Each event describes one ActionType
  */
-export type CmsEvent = CmsBatchImportFlow
+export type CmsEvent = CmsBatchImportFlow | CmsArtworkFilter
 
 /**
  * List of all CMS actions
@@ -19,9 +20,19 @@ export enum CmsActionType {
   artistNeedsMatching = "artistNeedsMatching",
 
   /**
+   * Corresponds to {@link CmsArtworkFilter}
+   */
+  clickedOnDuplicateArtwork = "clickedonduplicateartwork",
+
+  /**
    * Corresponds to {@link CmsBatchImportFlow}
    */
   csvImportError = "csvImportError",
+
+  /**
+   * Corresponds to {@link CmsArtworkFilter}
+   */
+  searchedArtwork = "searched artwork",
 
   /**
    * Corresponds to {@link BatchImportFlow}

--- a/src/Schema/CMS/Values/CmsContextModule.ts
+++ b/src/Schema/CMS/Values/CmsContextModule.ts
@@ -5,5 +5,8 @@
  * @packageDocumentation
  */
 export enum CmsContextModule {
+  artworkFilterFilterArtworks = "Artworks - filter artworks",
+  artworkFilterSearch = "Artworks - search",
+  artworkFilterQuickEdit = "Artworks - quick edit",
   batchImportFlow = "batchImportFlow",
 }


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR resolves [AMBER-1536]

### Description

This moves the CMS artwork filter events over to cohesion, as listed in [this spreadsheet](https://docs.google.com/spreadsheets/d/1X_Mi-rB16bC3vczl7Orz6JuhCTq0KQ8YlRRIVFjgU2s/edit?gid=0#gid=0). 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[AMBER-1536]: https://artsyproduct.atlassian.net/browse/AMBER-1536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ