### PR TITLE
feat: Migrate SubmittedOffer and SubmittedOrder

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -2423,8 +2423,7 @@ export interface ClickedHeroUnitGroup {
  *  {
  *    action: "clickedExpressCheckout",
  *    context_page_owner_type: "ordersShipping",
- *    context_page_owner_slug: "radna-segal-pearl",
- *    context_page_owner_id: "6164889300d643000db86504",
+ *    context_page_owner_id: "b0ac7b78-ee9b-4fa8-b0ca-b726169db217",
  *    flow: "Buy now" | "Make offer" | "Partner offer"
  *    credit_card_wallet_type: "applePay" | "googlePay"
  *  }
@@ -2433,7 +2432,6 @@ export interface ClickedHeroUnitGroup {
 export interface ClickedExpressCheckout {
   action: ActionType.clickedExpressCheckout
   context_page_owner_type: OwnerType
-  context_page_owner_slug: string
   context_page_owner_id: string
   flow: string
   credit_card_wallet_type: string
@@ -2449,8 +2447,7 @@ export interface ClickedExpressCheckout {
  *  {
  *    action: "clickedCancelExpressCheckout",
  *    context_page_owner_type: "ordersShipping",
- *    context_page_owner_slug: "radna-segal-pearl",
- *    context_page_owner_id: "6164889300d643000db86504",
+ *    context_page_owner_id: "b0ac7b78-ee9b-4fa8-b0ca-b726169db217",
  *    flow: "Buy now" | "Make offer" | "Partner offer"
  *    credit_card_wallet_type: "applePay" | "googlePay"
  *  }
@@ -2459,7 +2456,6 @@ export interface ClickedExpressCheckout {
 export interface ClickedCancelExpressCheckout {
   action: ActionType.clickedCancelExpressCheckout
   context_page_owner_type: OwnerType
-  context_page_owner_slug: string
   context_page_owner_id: string
   flow: string
   credit_card_wallet_type: string

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -2464,3 +2464,51 @@ export interface ClickedCancelExpressCheckout {
   flow: string
   credit_card_wallet_type: string
 }
+
+/**
+ * A user submits an offer. Includes normal and express checkout flows.
+ *
+ * This schema describes events sent to Segment from [[SubmittedOffer]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "submittedOffer",
+ *    context_page_owner_type: "ordersShipping" | "ordersReview",
+ *    order_id: "b0ac7b78-ee9b-4fa8-b0ca-b726169db217",
+ *    flow: "Make offer" | "Partner offer",
+ *    credit_card_wallet_type: "applePay" | "googlePay",
+ *  }
+ * ```
+ */
+export interface SubmittedOffer {
+  action: ActionType.submittedOffer
+  context_page_owner_type: OwnerType
+  order_id: string
+  flow: string
+  credit_card_wallet_type?: string
+}
+
+/**
+ * A user submits an order. Includes normal and express checkout flows.
+ *
+ * This schema describes events sent to Segment from [[SubmittedOrder]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "submittedOrder",
+ *    context_page_owner_type: "ordersShipping" | "ordersReview",
+ *    order_id: "b0ac7b78-ee9b-4fa8-b0ca-b726169db217",
+ *    flow: "Buy now" | "Partner offer",
+ *    credit_card_wallet_type: "applePay" | "googlePay",
+ *  }
+ * ```
+ */
+export interface SubmittedOrder {
+  action: ActionType.submittedOrder
+  context_page_owner_type: OwnerType
+  order_id: string
+  flow: string
+  credit_card_wallet_type?: string
+}

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -896,28 +896,6 @@ export interface ClickedOrderPage {
 }
 
 /**
- *  User clicks on submit order on the orders review page.
- *
- *  This schema describes events sent to Segment from [[clickedOnSubmitOrder]]
- *
- *  @example
- *  ```
- *  {
- *    action: "clickedOnSubmitOrder",
- *    context_module: "OrdersReview",
- *    context_page_owner_type: "orders-review",
- *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
- *  }
- * ```
- */
-export interface ClickedOnSubmitOrder {
-  action: ActionType.clickedOnSubmitOrder
-  context_module: ContextModule
-  context_page_owner_type: string
-  context_page_owner_id: string
-}
-
-/**
  * A user clicks a partner card
  *
  * This schema describes events sent to Segment from [[ClickedPartnerCard]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -118,6 +118,8 @@ import {
   ClickedVerifyIdentity,
   ClickedViewingRoomCard,
   ClickedViewWork,
+  SubmittedOffer,
+  SubmittedOrder,
 } from "./Click"
 import { EditedUserProfile } from "./CollectorProfile"
 import {
@@ -448,6 +450,8 @@ export type Event =
   | ShippingEstimateViewed
   | StartedOnboarding
   | SubmitAnotherArtwork
+  | SubmittedOffer
+  | SubmittedOrder
   | SuccessfullyLoggedIn
   | SwipedInfiniteDiscoveryArtwork
   | SwipedUp
@@ -1309,6 +1313,14 @@ export enum ActionType {
    * Corresponds to {@link SubmitAnotherArtwork}
    */
   submitAnotherArtwork = "submitAnotherArtwork",
+  /**
+   * Corresponds to {@link SubmittedOffer}
+   */
+  submittedOffer = "submittedOffer",
+  /**
+   * Corresponds to {@link SubmittedOrder}
+   */
+  submittedOrder = "submittedOrder",
   /**
    * Corresponds to {@link SuccessfullyLoggedIn}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -96,7 +96,6 @@ import {
   ClickedOnPagination,
   ClickedOnPriceDisplayDropdown,
   ClickedOnReadMore,
-  ClickedOnSubmitOrder,
   ClickedOrderPage,
   ClickedOrderSummary,
   ClickedPartnerCard,
@@ -359,7 +358,6 @@ export type Event =
   | ClickedOnPagination
   | ClickedOnPriceDisplayDropdown
   | ClickedOnReadMore
-  | ClickedOnSubmitOrder
   | ClickedOrderPage
   | ClickedOrderSummary
   | ClickedOpenInNewTabButton
@@ -844,10 +842,6 @@ export enum ActionType {
    * Corresponds to {@link ClickedOnReadMore}
    */
   clickedOnReadMore = "clickedOnReadMore",
-  /**
-   * Corresponds to {@link ClickedOnSubmitOrder}
-   */
-  clickedOnSubmitOrder = "clickedOnSubmitOrder",
   /**
    * Corresponds to {@link ClickedOrderPage}
    */


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

- `clicked_express_checkout` proof on the `slug` `id` comment [here](https://artsy.looker.com/sql/bxyvktf78mj2b9).
- `analytics` tables only require the `order_id` field on the `submitted_order` and `submitted_offer` tables.
- We maintain the same event name as the deprecated event `submitted_order` and `submitted_offer`, which I left in DeprecatedSchema in case things go wrong. 
- Importantly, implementation will fire one of these events when completing Express Checkout, which will restore CVR to CA on the Session level. 

### Description

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
