### PR TITLE
feat(uploads2): Add events

### DIFF
--- a/src/Schema/CMS/Events/UploadArtworkFlow.ts
+++ b/src/Schema/CMS/Events/UploadArtworkFlow.ts
@@ -1,0 +1,64 @@
+import { CmsContextModule } from "../Values/CmsContextModule"
+
+/**
+ * Click "Next" after selecting an existing artist
+ *
+ * @example
+ * ```
+ * {
+ *   action: "click",
+ *   context_module: "Uploads",
+ *   label: "Select existing artist",
+ * }
+ * ```
+ */
+export interface UploadArtworkFlowClickSelectExistingArtist {
+  action: "click"
+  context_module: CmsContextModule.uploads
+  label: "Select existing artist"
+}
+
+/**
+ * Click "Done" after uploading images
+ *
+ * @example
+ * ```
+ * {
+ *   action: "click",
+ *   context_module: "Uploads",
+ *   label: "Finish uploading image",
+ *   artwork_ids: string[]
+ * }
+ * ```
+ */
+export interface UploadArtworkFlowClickFinishUploadingImages {
+  action: "click"
+  context_module: CmsContextModule.uploads
+  label: "Finish uploading image"
+  artwork_ids: string[]
+}
+
+/**
+ * Click "View my artworks" after creating artworks
+ *
+ * @example
+ * ```
+ * {
+ *   action: "click",
+ *   context_module: "Uploads",
+ *   label: "View my artworks",
+ *   artwork_ids: string[]
+ * }
+ * ```
+ */
+export interface UploadArtworkFlowClickViewMyArtworks {
+  action: "click"
+  context_module: CmsContextModule.uploads
+  label: "View my artworks"
+  artwork_ids: string[]
+}
+
+export type UploadArtworkFlow =
+  | UploadArtworkFlowClickSelectExistingArtist
+  | UploadArtworkFlowClickFinishUploadingImages
+  | UploadArtworkFlowClickViewMyArtworks

--- a/src/Schema/CMS/Values/CmsContextModule.ts
+++ b/src/Schema/CMS/Values/CmsContextModule.ts
@@ -9,4 +9,5 @@ export enum CmsContextModule {
   artworkFilterSearch = "Artworks - search",
   artworkFilterQuickEdit = "Artworks - quick edit",
   batchImportFlow = "batchImportFlow",
+  uploads = "Uploads",
 }


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

Adds new tracking events for CMS /uploads2. Based on [this spreadsheet](https://docs.google.com/spreadsheets/d/16aMGgZzCaqAi6TIDSk65oQwd56bliaS1kevwZQiVUWU/edit?gid=0#gid=0).

### PR Checklist (tick all before merging)

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)

cc @artsy/amber-devs 