### PR TITLE
feat: Add Order Details tracking

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -1430,3 +1430,29 @@ export interface TappedMenuItemGroup {
   position: number
   subject: string
 }
+
+/**
+ * A user taps buyer protection on order details page
+ *
+ * This schema describes events sent to Segment from [[tappedBuyerProtection]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedBuyerProtection",
+ *    context_module: "OrdersDetail",
+ *    context_screen_owner_type: "orders-detail",
+ *    context_screen_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    destination_screen_owner_type: "articles",
+ *    destination_screen_owner_slug: "360048946973-How-does-Artsy-protect-me"
+ *  }
+ * ```
+ */
+export interface TappedBuyerProtection {
+  action: ActionType.TappedBuyerProtection
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id: string
+  destination_screen_owner_id: string
+  destination_screen_owner_slug: string
+}

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -1449,7 +1449,7 @@ export interface TappedMenuItemGroup {
  * ```
  */
 export interface TappedBuyerProtection {
-  action: ActionType.TappedBuyerProtection
+  action: ActionType.tappedBuyerProtection
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
   context_screen_owner_id: string

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -239,6 +239,7 @@ import {
   TappedAuctionResultGroup,
   TappedBid,
   TappedBrowseSimilarArtworks,
+  TappedBuyerProtection,
   TappedBuyNow,
   TappedCardGroup,
   TappedChangePaymentMethod,
@@ -468,6 +469,7 @@ export type Event =
   | TappedAuctionResultGroup
   | TappedBid
   | TappedBrowseSimilarArtworks
+  | TappedBuyerProtection
   | TappedBuyNow
   | TappedCardGroup
   | TappedChangePaymentMethod
@@ -1384,6 +1386,10 @@ export enum ActionType {
    * Corresponds to {@link TappedBrowseSimilarArtworks}
    */
   tappedBrowseSimilarArtworks = "tappedBrowseSimilarArtworks",
+  /**
+   * Corresponds to {@link TappedBuyerProtection}
+   */
+  tappedBuyerProtection = "tappedBuyerProtection",
   /**
    * Corresponds to {@link TappedBuyNow}
    */

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -107,6 +107,7 @@ export enum OwnerType {
   onboarding = "onboarding",
   ordersAccept = "orders-accept",
   ordersCounter = "orders-counter",
+  ordersDetail = "orders-detail",
   ordersHistory = "orders-history",
   ordersNewPayment = "orders-new-payment",
   ordersOffer = "orders-offer",
@@ -261,6 +262,7 @@ export type ScreenOwnerType =
   | OwnerType.newWorksFromGalleriesYouFollow
   | OwnerType.notification
   | OwnerType.onboarding
+  | OwnerType.ordersDetail
   | OwnerType.partner
   | OwnerType.priceDatabase
   | OwnerType.profile
@@ -337,6 +339,7 @@ export type PageOwnerType =
   | OwnerType.onboarding
   | OwnerType.ordersAccept
   | OwnerType.ordersCounter
+  | OwnerType.ordersDetail
   | OwnerType.ordersNewPayment
   | OwnerType.ordersOffer
   | OwnerType.ordersPayment


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [EMI-2494] and [EMI-2509]

### Description

Added the new TappedBuyerProtection event as described [here](https://docs.google.com/spreadsheets/d/1t-6TEsFCXI00lBAAgBL8wSMeAigO7fORKPmswHoCF5g/edit?gid=0#gid=0). 

Also added a new OwnerType for the OrdersDetail page, which is a new pagetype we are supporting for app and web in [release](https://artsy.slack.com/archives/C02JHHHKP5K/p1748541224172779).

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
