### PR TITLE
feat: Adds more custom events for BulkEdits

### DIFF
--- a/src/Schema/CMS/Events/BulkEditFlow.ts
+++ b/src/Schema/CMS/Events/BulkEditFlow.ts
@@ -88,9 +88,25 @@ export interface CmsBulkEditProcessingCompleted {
   value: number // total number of artworks successfully processed
 }
 
+/**
+ * Bulk edit failed
+ *
+ * Example:
+ * {
+ *   action: "bulkEditFailed",
+ *   context_module: "Artworks - bulk edit",
+ *   value: "Network error" // or any error message displayed to user
+ * }
+ */
+export interface CmsBulkEditFailed {
+  action: CmsActionType.bulkEditFailed
+  context_module: CmsContextModule.bulkEditFlow
+  value: string
+}
 
 export type CmsBulkEditFlow =
   | CmsBulkEditConflictsShown
+  | CmsBulkEditFailed
   | CmsBulkEditMaxEditLimitReachedShown
   | CmsBulkEditProcessingCompleted
   | CmsBulkEditProcessingStarted

--- a/src/Schema/CMS/Events/BulkEditFlow.ts
+++ b/src/Schema/CMS/Events/BulkEditFlow.ts
@@ -56,7 +56,42 @@ export interface CmsBulkEditResolvedAllConflictsShown {
   context_module: CmsContextModule.bulkEditFlow
 }
 
+/**
+ * Bluk edit flow processing started
+ *
+ * Example:
+ * {
+ *   action: "processingStarted",
+ *   context_module: "Artworks - bulk edit",
+ *   value: 25
+ * }
+ */
+export interface CmsBulkEditProcessingStarted {
+  action: CmsActionType.processingStarted
+  context_module: CmsContextModule.bulkEditFlow
+  value: number // total number of artworks being processed
+}
+
+/**
+ * Bulk Edit flow processing completed
+ *
+ * Example:
+ * {
+ *   action: "processingCompleted",
+ *   context_module: "Artworks - bulk edit",
+ *   value: 24
+ * }
+ */
+export interface CmsBulkEditProcessingCompleted {
+  action: CmsActionType.processingCompleted
+  context_module: CmsContextModule.bulkEditFlow
+  value: number // total number of artworks successfully processed
+}
+
+
 export type CmsBulkEditFlow =
   | CmsBulkEditConflictsShown
   | CmsBulkEditMaxEditLimitReachedShown
+  | CmsBulkEditProcessingCompleted
+  | CmsBulkEditProcessingStarted
   | CmsBulkEditResolvedAllConflictsShown

--- a/src/Schema/CMS/Events/index.ts
+++ b/src/Schema/CMS/Events/index.ts
@@ -56,6 +56,16 @@ export enum CmsActionType {
   editedLocation = "editedLocation",
 
   /**
+   * Corresponds to {@link BulkEditFlow}
+   */
+  processingStarted = "processingStarted",
+
+   /**
+   * Corresponds to {@link BulkEditFlow}
+   */
+   processingCompleted = "processingCompleted",
+
+  /**
    * Corresponds to {@link CmsArtworkFilter}
    */
   searchedArtwork = "searched artwork",

--- a/src/Schema/CMS/Events/index.ts
+++ b/src/Schema/CMS/Events/index.ts
@@ -36,6 +36,11 @@ export enum CmsActionType {
   artistNeedsMatching = "artistNeedsMatching",
 
   /**
+   * Corresponds to {@link CmsBulkEditFlow}
+   */
+  bulkEditFailed = "bulkEditFailed",
+
+  /**
    * Corresponds to {@link CmsArtworkFilter}
    */
   clickedOnDuplicateArtwork = "clickedonduplicateartwork",
@@ -56,14 +61,14 @@ export enum CmsActionType {
   editedLocation = "editedLocation",
 
   /**
-   * Corresponds to {@link BulkEditFlow}
+   * Corresponds to {@link CmsBulkEditFlow}
    */
   processingStarted = "processingStarted",
 
-   /**
-   * Corresponds to {@link BulkEditFlow}
+  /**
+   * Corresponds to {@link CmsBulkEditFlow}
    */
-   processingCompleted = "processingCompleted",
+  processingCompleted = "processingCompleted",
 
   /**
    * Corresponds to {@link CmsArtworkFilter}
@@ -71,17 +76,17 @@ export enum CmsActionType {
   searchedArtwork = "searched artwork",
 
   /**
-   * Corresponds to {@link BulkEditFlow}
+   * Corresponds to {@link CmsBulkEditFlow}
    */
   shownConflicts = "shownConflicts",
 
   /**
-   * Corresponds to {@link BulkEditFlow}
+   * Corresponds to {@link CmsBulkEditFlow}
    */
   shownMaxEditLimitReached = "shownMaxEditLimitReached",
 
   /**
-   * Corresponds to {@link BulkEditFlow}
+   * Corresponds to {@link CmsBulkEditFlow}
    */
   shownResolvedAllConflicts = "shownResolvedAllConflicts",
 


### PR DESCRIPTION
The type of this PR is: **FEAT**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [Leo's data events needed for bulk edits](https://docs.google.com/spreadsheets/d/15AcrQTjuXA2ee0RC5AZHjD7H2cQ1x9d-AraeBql2Z-Q/edit?gid=0#gid=0)
### Description

Wiring up the last few events needed for bulk edits launch, see doc from Léo [here](https://docs.google.com/spreadsheets/d/15AcrQTjuXA2ee0RC5AZHjD7H2cQ1x9d-AraeBql2Z-Q/edit?gid=0#gid=0)


Events in this PR include:
- `CmsBulkEditFailed`
- `CmsBulkEditProcessingCompleted`
- `CmsBulkEditProcessingStarted`

I think this is the last of them!

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


cc @artsy/amber-devs 