### PR TITLE
fix: Adjust bulkEditFailed type to more match error structure

### DIFF
--- a/src/Schema/CMS/Events/BulkEditFlow.ts
+++ b/src/Schema/CMS/Events/BulkEditFlow.ts
@@ -209,13 +209,13 @@ export interface CmsBulkEditProcessingCompleted {
  * {
  *   action: "bulkEditFailed",
  *   context_module: "Artworks - bulk edit",
- *   value: "Network error" // or any error message displayed to user
+ *   value: [ 'availability: must be "for sale", "sold" or "not for sale" for works available for purchase', "error2" ]
  * }
  */
 export interface CmsBulkEditFailed {
   action: CmsActionType.bulkEditFailed
   context_module: CmsContextModule.bulkEditFlow
-  value: string
+  value: string[]
 }
 
 export type CmsBulkEditFlow =


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Small adjustment to the typing to better match how we are formatting errors from websockets over in volt

Ex:
```
[ 'availability: must be "for sale", "sold" or "not for sale" for works available for purchase' ]
```

cc @artsy/amber-devs 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
