### PR TITLE
feat: Adds artwork_ids metadata to processing and shortlist bulk edit events

### DIFF
--- a/src/Schema/CMS/Events/BulkEditFlow.ts
+++ b/src/Schema/CMS/Events/BulkEditFlow.ts
@@ -55,7 +55,8 @@ export interface CmsBulkEditClickedEditPill {
  *   action: "click",
  *   context_module: "Artworks - bulk edit",
  *   label: "shortlist",
- *   value: 5, // how many artworks selected
+ *   value: 3, // how many artworks selected
+ *   artwork_ids: ["artwork1", "artwork2", "artwork3"]
  * }
  * ```
  */
@@ -64,6 +65,7 @@ export interface CmsBulkEditClickedShortlistPill {
   context_module: CmsContextModule.bulkEditFlow
   label: "shortlist"
   value: number
+  artwork_ids: string[]
 }
 
 /**
@@ -194,12 +196,14 @@ export interface CmsBulkEditProcessingStarted {
  *   action: "processingCompleted",
  *   context_module: "Artworks - bulk edit",
  *   value: 24  // total number of artworks successfully processed
+ *   artwork_ids: ["artwork1", "artwork2"]
  * }
  */
 export interface CmsBulkEditProcessingCompleted {
   action: CmsActionType.processingCompleted
   context_module: CmsContextModule.bulkEditFlow
   value: number
+  artwork_ids: string[]
 }
 
 /**
@@ -209,13 +213,15 @@ export interface CmsBulkEditProcessingCompleted {
  * {
  *   action: "bulkEditFailed",
  *   context_module: "Artworks - bulk edit",
- *   value: [ 'availability: must be "for sale", "sold" or "not for sale" for works available for purchase', "error2" ]
+ *   value: [ 'availability: must be "for sale", "sold" or "not for sale" for works available for purchase', "error2" ],
+ *   artwork_ids: [ "artwork1", "artwork2" ]
  * }
  */
 export interface CmsBulkEditFailed {
   action: CmsActionType.bulkEditFailed
   context_module: CmsContextModule.bulkEditFlow
   value: string[]
+  artwork_ids: string[]
 }
 
 export type CmsBulkEditFlow =


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves Feedback from QA with @leodmz 

### Description

Adds `artwork_ids` metadata to processing and shortlist bulk edit events

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
-  [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
