### PR TITLE
feat: Additional metadata for processingCompleted and click availability bulk edit flow

### DIFF
--- a/src/Schema/CMS/Events/BulkEditFlow.ts
+++ b/src/Schema/CMS/Events/BulkEditFlow.ts
@@ -175,7 +175,7 @@ export interface CmsBulkEditResolvedAllConflictsShown {
 }
 
 /**
- * Bluk edit flow processing started
+ * Bulk edit flow processing started
  *
  * Example:
  * {
@@ -197,14 +197,16 @@ export interface CmsBulkEditProcessingStarted {
  * {
  *   action: "processingCompleted",
  *   context_module: "Artworks - bulk edit",
- *   value: 24  // total number of artworks successfully processed
+ *   label: "change availability",
+ *   value: "on hold", // e.g. "on hold", "available", "not for sale"
  *   artwork_ids: ["artwork1", "artwork2"]
  * }
  */
 export interface CmsBulkEditProcessingCompleted {
   action: CmsActionType.processingCompleted
   context_module: CmsContextModule.bulkEditFlow
-  value: number
+  label: string
+  value: string
   artwork_ids: string[]
 }
 


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [AMBER-1705](https://artsyproduct.atlassian.net/browse/AMBER-1705)

### Description

Adding additional metadata to our bulk edits
- `click change availability`
- `processing completed`

events


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


cc @artsy/amber-devs 

[AMBER-1705]: https://artsyproduct.atlassian.net/browse/AMBER-1705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ