### PR TITLE
feat(DIA-1363): add optional destination_path field to TappedEntityGroup

### DIFF
--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -365,6 +365,7 @@ export interface TappedFairGroup extends TappedEntityGroup {
  *    destination_screen_owner_type: "collectionsCategory",
  *    destination_screen_owner_id: "5359794d1a1e86c3740001f7",
  *    destination_screen_owner_slug: "artworks-under-1000",
+ *    destination_path: "/collection/artworks-under-1000"
  *    horizontal_slide_position: 1,
  *    type: "thumbnail"
  *  }
@@ -407,6 +408,7 @@ export interface TappedEntityGroup {
   destination_screen_owner_type?: ScreenOwnerType
   destination_screen_owner_id?: string
   destination_screen_owner_slug?: string
+  destination_path?: string
   curation_boost?: boolean
   horizontal_slide_position?: number
   module_height?: EntityModuleHeight


### PR DESCRIPTION
- The type of this PR is: Feature
- This PR resolves [DIA-1363]

This PR adds an optional `destination_path` field to the `TappedEntityGroup` interface. This is needed because Eigen is currently sending that field to a `TappedCardGroup` event when users click into marketing collections on the Home View (via _Discover Something New_ and _Explore by Category_).

Currently Eigen is typecasting the event it sends to avoid TypeScript errors, so I want to add the field into the schema to make the field official.

```ts
const payload: TappedCardGroup = {
  action: ActionType.tappedCardGroup,
  context_module: contextModule,
  context_screen_owner_type: OwnerType.home,
  destination_screen_owner_type: entityType,
  destination_path: href,
  destination_screen_owner_id: entityID,
  horizontal_slide_position: index,
  type: "thumbnail",
} as TappedCardGroup
```


[DIA-1363]: https://artsyproduct.atlassian.net/browse/DIA-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ