### PR TITLE
feat(DIA-1363): add marketingCollection to ScreenOwnerType

### DIFF
--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -92,6 +92,7 @@ export enum OwnerType {
   lotsByArtistsYouFollow = "lotsByArtistsYouFollow",
   lotsForYou = "lotsForYou",
   marketNews = "marketNews",
+  marketingCollection = "marketingCollection",
   myCollection = "myCollection",
   myCollectionAddArtworkArtist = "myCollectionAddArtworkArtist",
   myCollectionArtwork = "myCollectionArtwork",
@@ -250,6 +251,7 @@ export type ScreenOwnerType =
   | OwnerType.lotsByArtistsYouFollow
   | OwnerType.lotsForYou
   | OwnerType.marketNews
+  | OwnerType.marketingCollection
   | OwnerType.myCollection
   | OwnerType.myCollectionAddArtworkArtist
   | OwnerType.myCollectionArtwork


### PR DESCRIPTION
- The type of this PR is: Feature
- This PR resolves [DIA-1363]

This PR adds `marketingCollection` as a `ScreenOwnerType`. It is needed so that Eigen can pass "MarketingCollection" as the `destination_screen_owner_type` in `tappedCardGroup` events.

Currently that value comes from the Home View section definition in Metaphysics and is typecast `as ScreenOwnerType` to prevent TypeScript errors. This change makes that value an official value.
