### PR TITLE
feat: Orders Detail native app tracking

### DIFF
--- a/src/Schema/CMS/Events/BatchImportFlow.ts
+++ b/src/Schema/CMS/Events/BatchImportFlow.ts
@@ -233,9 +233,11 @@ export interface CmsBatchImportTableContentSummary {
   context_module: CmsContextModule.batchImportFlow
   context_page_owner_type: CmsOwnerType.batchImport
   context_page_owner_id: string
-  values: Record<string, { optional: boolean; valid: number; missing: number; invalid: number }>
+  values: Record<
+    string,
+    { optional: boolean; valid: number; missing: number; invalid: number }
+  >
 }
-
 
 export type CmsBatchImportFlow =
   | CmsBatchImportFlowClickImport

--- a/src/Schema/CMS/Events/BulkEditFlow.ts
+++ b/src/Schema/CMS/Events/BulkEditFlow.ts
@@ -3,8 +3,8 @@
  * @packageDocumentation
  */
 
-import { CmsActionType } from "."
 import { CmsContextModule } from "../Values/CmsContextModule"
+import { CmsActionType } from "."
 
 /**
  * Partners clicked change availability pill
@@ -187,7 +187,7 @@ export interface CmsBulkEditResolvedAllConflictsShown {
 export interface CmsBulkEditProcessingStarted {
   action: CmsActionType.processingStarted
   context_module: CmsContextModule.bulkEditFlow
-  value: number 
+  value: number
 }
 
 /**

--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -469,8 +469,8 @@ export interface OrderProgressionViewed {
  *  {
  *    action: "orderDetailsViewed",
  *    context_module: "ordersDetail"
- *    context_page_owner_type: "orders-detail",
- *    context_page_owner_id: "b0ac7b78-ee9b-4fa8-b0ca-b726169db217",
+ *    context_owner_type: "orders-detail",
+ *    context_owner_id: "b0ac7b78-ee9b-4fa8-b0ca-b726169db217",
  *    message_type: "CANCELLED" | "SHIPPING_EXPRESS" | ...
  *  }
  * ```
@@ -478,7 +478,7 @@ export interface OrderProgressionViewed {
 export interface OrderDetailsViewed {
   action: ActionType.orderDetailsViewed
   context_module: ContextModule
-  context_page_owner_type: OwnerType
-  context_page_owner_id: string
+  context_owner_type: OwnerType
+  context_owner_id: string
   message_type: string
 }

--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -458,3 +458,27 @@ export interface OrderProgressionViewed {
   context_page_owner_id: string
   flow: string
 }
+
+/**
+ * A user views the order details page. Event used to track the displayed message
+ *
+ * This schema describes events sent to Segment from [[orderDetailsViewed]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "orderDetailsViewed",
+ *    context_module: "ordersDetail"
+ *    context_page_owner_type: "orders-detail",
+ *    context_page_owner_id: "b0ac7b78-ee9b-4fa8-b0ca-b726169db217",
+ *    message_type: "CANCELLED" | "SHIPPING_EXPRESS" | ...
+ *  }
+ * ```
+ */
+export interface OrderDetailsViewed {
+  action: ActionType.orderDetailsViewed
+  context_module: ContextModule
+  context_page_owner_type: OwnerType
+  context_page_owner_id: string
+  message_type: string
+}

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -1525,6 +1525,7 @@ export interface TappedBuyerProtection {
  *    context_screen_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
  *    destination_screen_owner_type: "articles",
  *    destination_screen_owner_slug: "How-are-taxes-and-customs-fees-calculated"
+ *    flow: "Buy now" | "Make offer" | "Partner offer"
  *  }
  * ```
  */
@@ -1535,4 +1536,5 @@ export interface TappedImportFees {
   context_screen_owner_id: string
   destination_screen_owner_type: ScreenOwnerType
   destination_screen_owner_slug: string
+  flow: string
 }

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -1510,3 +1510,29 @@ export interface TappedBuyerProtection {
   destination_screen_owner_type: ScreenOwnerType
   destination_screen_owner_slug: string
 }
+
+/**
+ * User clicks on additional duties and taxes may apply at import
+ *
+ *  This schema describes events sent to Segment from [[tappedImportFees]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedImportFees",
+ *    context_module: "OrdersDetail",
+ *    context_page_owner_type: "orders-detail",
+ *     context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    destination_page_owner_type: "articles",
+ *    destination_page_owner_slug: "How-are-taxes-and-customs-fees-calculated"
+ *  }
+ * ```
+ */
+export interface TappedImportFees {
+  action: ActionType.tappedImportFees
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id: string
+  destination_screen_owner_type: ScreenOwnerType
+  destination_screen_owner_slug: string
+}

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -1522,7 +1522,7 @@ export interface TappedBuyerProtection {
  *    action: "tappedImportFees",
  *    context_module: "OrdersDetail",
  *    context_page_owner_type: "orders-detail",
- *     context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
  *    destination_page_owner_type: "articles",
  *    destination_page_owner_slug: "How-are-taxes-and-customs-fees-calculated"
  *  }

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -1521,10 +1521,10 @@ export interface TappedBuyerProtection {
  *  {
  *    action: "tappedImportFees",
  *    context_module: "OrdersDetail",
- *    context_page_owner_type: "orders-detail",
- *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
- *    destination_page_owner_type: "articles",
- *    destination_page_owner_slug: "How-are-taxes-and-customs-fees-calculated"
+ *    context_screen_owner_type: "orders-detail",
+ *    context_screen_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    destination_screen_owner_type: "articles",
+ *    destination_screen_owner_slug: "How-are-taxes-and-customs-fees-calculated"
  *  }
  * ```
  */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -262,6 +262,7 @@ import {
   TappedFairCard,
   TappedFairGroup,
   TappedGlobalSearchBar,
+  TappedImportFees,
   TappedInfoBubble,
   TappedLearnMore,
   TappedLink,
@@ -511,6 +512,7 @@ export type Event =
   | TappedFairGroup
   | TappedFollowsGroup
   | TappedGlobalSearchBar
+  | TappedImportFees
   | TappedInboxConversation
   | TappedInfoBubble
   | TappedLearnMore
@@ -1535,6 +1537,10 @@ export enum ActionType {
    * Corresponds to {@link TappedHeroUnitGroup}
    */
   tappedHeroUnitGroup = "tappedHeroUnitGroup",
+  /**
+   * Corresponds to {@link TappedImportFees}
+   */
+  tappedImportFees = "tappedImportFees",
   /**
    * Corresponds to {@link TappedInboxConversation}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -181,6 +181,7 @@ import {
   ErrorMessageViewed,
   ExpressCheckoutViewed,
   ItemViewed,
+  OrderDetailsViewed,
   OrderProgressionViewed,
   ProgressiveOnboardingTooltipViewed,
   RailViewed,
@@ -442,6 +443,7 @@ export type Event =
   | MaxBidSelected
   | MyCollectionOnboardingCompleted
   | OnboardingUserInputData
+  | OrderDetailsViewed
   | OrderProgressionViewed
   | PriceDatabaseFilterParamsChanged
   | PromptForReview
@@ -1221,6 +1223,10 @@ export enum ActionType {
    * Corresponds to {@link OnboardingUserInputData}
    */
   onboardingUserInputData = "onboardingUserInputData",
+  /**
+   * Corresponds to {@link OrderDetailsViewed}
+   */
+  orderDetailsViewed = "orderDetailsViewed",
   /**
    * Corresponds to {@link OrderProgressionViewed}
    */


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->



### Description

This PR adds two new events: `TappedImportFees` and `OrderDetailsViewed`. The former is extending `ClickedImportFees` to app, and the second is a new impression event to track the displayed content to the user. We could not add this to the pageview event.

Some notes:
- Because `OrderDetailsViewed` will fire on web and app, I use `OwnerType` and therefore do not specify the screen/page within the field or OwnerType.
- We believe `message_type`, which corresponds to the displayed content, is sufficient to describe the message displayed to the user. I thought about recording the delivery (shipping/pickup), arta vs. flat/free, and payment method here, but we have the `order_id` and can join that info easily. The message may change, but those order components should stay static.
- @MrSltun ClickedImportFees has a `flow` field, so I've added that to the Tapped version as well. Comparing this to Tapped/Clicked`BuyerProtection`, that does not have a `flow`. For simplicity I'm mirroring the Click event so that the web/app versions have the same fields. `ClickedVisitHelpCenter` and `clickedAskSpecialist` also have `flow`, and so does `TappedAskSpecialist`.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
