### PR TITLE
chore: EMI-2653 update clickedContactGallery schema

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -367,16 +367,16 @@ export interface ClickedMakeOffer {
 }
 
 /**
- * User clicks "Contact Gallery" on an artwork page (BNMO)
+ * User clicks "Contact Gallery" on an artwork page (BNMO) or Order Details page
  *
  * This schema describes events sent to Segment from [[clickedContactGallery]]
  * @example
  * ```
  *  {
  *    action: "clickedContactGallery",
- *    context_owner_type: "Artwork",
- *    context_owner_slug: "radna-segal-pearl",
+ *    context_owner_type: "Artwork" | "orders-detail"
  *    context_owner_id: "6164889300d643000db86504",
+ *    context_owner_slug: "radna-segal-pearl",
  *    signal_label: "Limited-Time Offer",
  *  }
  * ```
@@ -384,8 +384,8 @@ export interface ClickedMakeOffer {
 export interface ClickedContactGallery {
   action: ActionType.clickedContactGallery
   context_owner_type: OwnerType
-  context_owner_slug: string
   context_owner_id: string
+  context_owner_slug?: string
   signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -375,7 +375,7 @@ export interface ClickedMakeOffer {
  *  {
  *    action: "clickedContactGallery",
  *    context_owner_type: "Artwork" | "orders-detail"
- *    context_owner_id: "6164889300d643000db86504",
+ *    context_owner_id: "6164889300d643000db86504" | "57e60c68-a198-431e-8a02-6ecb01e3a99b",
  *    context_owner_slug: "radna-segal-pearl",
  *    signal_label: "Limited-Time Offer",
  *  }


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [EMI-2653]

### Description

This PR updates the `clickedContactGallery` schema for the new Order Details page. We want to differentiate between clicks on the artwork page, vs. those on the order details page, as they are of different intent.
- Added example events for when it's clicked on Order Details
- Made `slug` optional, because it will be empty for OrderDetails clicks (orders do not have slugs)
- I've attached a screenshot of the old payload. The quote below describes the proposed new payload. Importantly, the new payload calls the [ordersDetail](https://github.com/artsy/cohesion/blob/29cb175c487a0c9988dadd2668a8ffab28cadaba/src/Schema/Values/OwnerType.ts#L112) `OwnerType` and refers to the `order ID`.

![Screenshot 2025-07-08 at 1 52 31 PM](https://github.com/user-attachments/assets/df1edd34-69ce-461b-a63b-d80b9138a646)

> context_owner_type: "orders-detail"
context_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b"



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
