### PR TITLE
feat(onyx-1828): add artworkRecommendations as PageOwnerType

### DIFF
--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -325,6 +325,7 @@ export type PageOwnerType =
   | OwnerType.artists
   | OwnerType.artistSeries
   | OwnerType.artwork
+  | OwnerType.artworkRecommendations
   | OwnerType.auctions
   | OwnerType.collect
   | OwnerType.collection


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [ONYX-1828]

### Description

We are adding artwork recommendations rail to the web. `OwnerType.artworkRecommendations` is already a part of a `ScreenOwnerType` union, now making it a part of `PageOwnerType`.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
