### PR TITLE
chore: add saved price range event

### DIFF
--- a/src/Schema/Events/SavedPriceRange.ts
+++ b/src/Schema/Events/SavedPriceRange.ts
@@ -1,0 +1,24 @@
+import { ScreenOwnerType } from "../Values/OwnerType"
+import { ActionType } from "."
+
+/**
+ * A user saves a price range
+ *
+ * This schema describes events sent to Segment from [[savedPriceRange]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "savedPriceRange",
+ *    context_screen_owner_type: "priceRange",
+ *    context_module: "priceRange"
+ *    value: "100-500"
+ *  }
+ * ```
+ */
+export interface SavedPriceRange {
+  action: ActionType.savedPriceRange
+  context_screen_owner_type: ScreenOwnerType
+  context_module?: string
+  value: string
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -213,6 +213,7 @@ import {
   TappedMyCollectionInsightsMedianAuctionRailItem,
 } from "./MyCollectionInsights"
 import { PromptForReview } from "./PromptForReview"
+import { SavedPriceRange } from "./SavedPriceRange"
 import {
   DeletedSavedSearch,
   EditedAlert,
@@ -456,6 +457,7 @@ export type Event =
   | SavedAddressViewed
   | SavedCookieConsentPreferences
   | SavedPaymentMethodViewed
+  | SavedPriceRange
   | Screen
   | SearchedPriceDatabase
   | SearchedWithNoResults
@@ -1279,6 +1281,10 @@ export enum ActionType {
    * Corresponds to {@link SavedPaymentMethodViewed}
    */
   savedPaymentMethodViewed = "savedPaymentMethodViewed",
+  /**
+   * Corresponds to {@link SavedPriceRange}
+   */
+  savedPriceRange = "savedPriceRange",
   /**
    * Corresponds to {@link Screen}
    */


### PR DESCRIPTION
The type of this PR is: **chore**


This PR adds saved price range event

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [ONYX-1848]

### Description

This PR adds saved price range event

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[ONYX-1848]: https://artsyproduct.atlassian.net/browse/ONYX-1848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ