### PR TITLE
feat: CMS Analytics Page tracking

### DIFF
--- a/src/Schema/CMS/Events/AnalyticsPage.ts
+++ b/src/Schema/CMS/Events/AnalyticsPage.ts
@@ -1,0 +1,123 @@
+/**
+ * Schemas describing CMS Analytics events
+ * @packageDocumentation
+ */
+
+import { CmsContextModule } from "../Values/CmsContextModule"
+import { CmsOwnerType } from "../Values/CmsOwnerType"
+import { CmsActionType } from "./index"
+
+/**
+ * A partner has changed the time period for a graph.
+ *
+ * @example
+ * ```
+ * {
+ *   action: "changedTimePeriod",
+ *   context_module: "mostViewed" | "publishedArtworks" | "views" | "inquiries" | "sales" | "audience",
+ *   context_page_owner_type: "analytics",
+ *   time_period_start: -28 | -112 | -365,
+ *   time_period_end: 0
+ * }
+ * ```
+ */
+export interface CmsAnalyticsPageChangedTimePeriod {
+  action: CmsActionType.changedTimePeriod
+  context_module: CmsContextModule
+  context_page_owner_type: CmsOwnerType.analytics
+  time_period_start: number
+  time_period_end: number
+}
+
+/**
+ * A partner clicks on an entity in the "Most Viewed" section
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedMostViewed",
+ *   context_module: "mostViewed"
+ *   context_page_owner_type: "analytics",
+ *   destination_page_owner_type: "artworks" | "show" | "artist" | "viewing-room",
+ *   position: 0 | 1 | ... | 9
+ * }
+ * ```
+ */
+export interface CmsAnalyticsPageClickedMostViewed {
+  action: CmsActionType.clickedMostViewed
+  context_module: CmsContextModule
+  context_page_owner_type: CmsOwnerType.analytics
+  destination_page_owner_type: string
+  position: number
+}
+
+/**
+ * A partner views a graph on the analytics page
+ *
+ * @example
+ * ```
+ * {
+ *   action: "viewedGraph",
+ *   context_module: "mostViewed" | "publishedArtworks" | "views" | "inquiries" | "sales" | "audience",
+ *   context_page_owner_type: "analytics",
+ *   graph_type: "cumulative_line" | "donut"
+ * }
+ * ```
+ */
+export interface CmsAnalyticsPageViewedGraph {
+  action: CmsActionType.viewedGraph
+  context_module: CmsContextModule
+  context_page_owner_type: CmsOwnerType.analytics
+  graph_type: string
+}
+
+/**
+ * A partner views a datapoint on a graph on the analytics page
+ *
+ * @example
+ * ```
+ * {
+ *   action: "viewedGraphDatapoint",
+ *   context_module: "mostViewed" | "publishedArtworks" | "views" | "inquiries" | "sales" | "audience",
+ *   context_page_owner_type: "analytics",
+ *   graph_type: "cumulative_line" | "donut"
+ *   datapoint_bucket_size?: "daily" | "weekly" | "monthly" | null
+ *   datapoint_is_other?: true | false | null
+ * }
+ * ```
+ */
+export interface CmsAnalyticsPageViewedGraphDatapoint {
+  action: CmsActionType.viewedGraphDatapoint
+  context_module: CmsContextModule
+  context_page_owner_type: CmsOwnerType.analytics
+  graph_type: string
+  datapoint_bucket_size?: string
+  datapoint_is_other?: boolean
+}
+
+/**
+ * A partner views a tooltip on the analytics page
+ *
+ * @example
+ * ```
+ * {
+ *   action: "viewedTooltip",
+ *   context_module: "mostViewed"
+ *   context_page_owner_type: "analytics",
+ *   type: "explanatory" | "response-time" | "response-time-score"
+ * }
+ * ```
+ */
+export interface CmsAnalyticsPageViewedTooltip {
+  action: CmsActionType.viewedTooltip
+  context_module: CmsContextModule.analyticsMostViewed
+  context_page_owner_type: CmsOwnerType.analytics
+  type: string
+}
+
+export type CmsAnalyticsPage =
+  | CmsAnalyticsPageChangedTimePeriod
+  | CmsAnalyticsPageClickedMostViewed
+  | CmsAnalyticsPageViewedGraph
+  | CmsAnalyticsPageViewedGraphDatapoint
+  | CmsAnalyticsPageViewedTooltip

--- a/src/Schema/CMS/Events/index.ts
+++ b/src/Schema/CMS/Events/index.ts
@@ -1,3 +1,4 @@
+import { CmsAnalyticsPage } from "./AnalyticsPage"
 import { CmsArtworkFilter } from "./ArtworkFilter"
 import { CmsBatchImportFlow } from "./BatchImportFlow"
 import { CmsBulkEditFlow } from "./BulkEditFlow"
@@ -11,6 +12,7 @@ import { CmsUploadArtworkFlow } from "./UploadArtworkFlow"
  * Each event describes one ActionType
  */
 export type CmsEvent =
+  | CmsAnalyticsPage
   | CmsArtworkFilter
   | CmsBulkEditFlow
   | CmsBatchImportFlow
@@ -43,6 +45,16 @@ export enum CmsActionType {
    * Corresponds to {@link CmsBulkEditFlow}
    */
   bulkEditFailed = "bulkEditFailed",
+
+  /**
+   * Corresponds to {@link CmsAnalyticsPage}
+   */
+  changedTimePeriod = "changedTimePeriod",
+
+  /**
+   * Corresponds to {@link CmsAnalytics}
+   */
+  clickedMostViewed = "clickedMostViewed",
 
   /**
    * Corresponds to {@link CmsArtworkFilter}
@@ -103,4 +115,19 @@ export enum CmsActionType {
    * Corresponds to {@link BatchImportFlow}
    */
   shownMissingInformation = "shownMissingInformation",
+
+  /**
+   * Corresponds to {@link CmsAnalytics}
+   */
+  viewedGraph = "viewedGraph",
+
+  /**
+   * Corresponds to {@link CmsAnalytics}
+   */
+  viewedGraphDatapoint = "viewedGraphDatapoint",
+
+  /**
+   * Corresponds to {@link CmsAnalytics}
+   */
+  viewedTooltip = "viewedTooltip",
 }

--- a/src/Schema/CMS/Values/CmsContextModule.ts
+++ b/src/Schema/CMS/Values/CmsContextModule.ts
@@ -6,6 +6,12 @@
  */
 export enum CmsContextModule {
   addArtworkToShow = "Add artwork to show",
+  analyticsAudience = "analyticsAudience",
+  analyticsInquiries = "analyticsInquiries",
+  analyticsMostViewed = "analyticsMostViewed",
+  analyticsPublishedArtworks = "analyticsPublishedArtworks",
+  analyticsSales = "analyticsSales",
+  analyticsViews = "analyticsViews",
   artworkFilterFilterArtworks = "Artworks - filter artworks",
   artworkFilterSearch = "Artworks - search",
   artworkFilterQuickEdit = "Artworks - quick edit",

--- a/src/Schema/CMS/Values/CmsOwnerType.ts
+++ b/src/Schema/CMS/Values/CmsOwnerType.ts
@@ -4,6 +4,7 @@
  * @packageDocumentation
  */
 export enum CmsOwnerType {
+  analytics = "analytics",
   bulkEdit = "bulkEdit",
   batchImport = "batchImport",
   batchImportArtistMatching = "batchImportArtistMatching",


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->

Spreadsheet with the tracking schema [here](https://docs.google.com/spreadsheets/d/1KPwzjTQDk0rNCqBMUK-2NopS6ZOsKmmlYOGBXcJTrZA/edit?gid=0#gid=0)

- I've left comments in the spreadsheet with some explanation for event subfields. Please leave feedback on if there's any expected issue with implementation
- I maintained the `CmsAnalyticsPage` naming prefix because specifying `Page` seemed worthwhile. Within `ContextModule`, I only specify `analytics` as a prefix, because otherwise "Sales" "Views" etc. seem far too general, when I am in fact referring to that specific component on the analytics page. Open to renaming it to `analyticsPageSales` for example, if needed

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

