### PR TITLE
feat: Add ClickedGraphCTA

### DIFF
--- a/src/Schema/CMS/Events/AnalyticsPage.ts
+++ b/src/Schema/CMS/Events/AnalyticsPage.ts
@@ -30,6 +30,26 @@ export interface CmsAnalyticsPageChangedTimePeriod {
 }
 
 /**
+ * A partner clicks on the CTA below a graph
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedGraphCTA",
+ *   context_module: "publishedArtworks" | "inquiries" | "sales",
+ *   context_page_owner_type: "analytics",
+ *   destination_page_owner_type: "artworks" | "conversations" | "orders"
+ * }
+ * ```
+ */
+export interface CmsAnalyticsPageClickedGraphCTA {
+  action: CmsActionType.clickedGraphCTA
+  context_module: CmsContextModule
+  context_page_owner_type: CmsOwnerType.analytics
+  destination_page_owner_type: string
+}
+
+/**
  * A partner clicks on an entity in the "Most Viewed" section
  *
  * @example
@@ -117,6 +137,7 @@ export interface CmsAnalyticsPageViewedTooltip {
 
 export type CmsAnalyticsPage =
   | CmsAnalyticsPageChangedTimePeriod
+  | CmsAnalyticsPageClickedGraphCTA
   | CmsAnalyticsPageClickedMostViewed
   | CmsAnalyticsPageViewedGraph
   | CmsAnalyticsPageViewedGraphDatapoint

--- a/src/Schema/CMS/Events/index.ts
+++ b/src/Schema/CMS/Events/index.ts
@@ -54,6 +54,11 @@ export enum CmsActionType {
   /**
    * Corresponds to {@link CmsAnalytics}
    */
+  clickedGraphCTA = "clickedGraphCTA",
+
+  /**
+   * Corresponds to {@link CmsAnalytics}
+   */
   clickedMostViewed = "clickedMostViewed",
 
   /**


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CO-]

### Description

<!-- Implementation description -->

We are adding new CTAs to the bottom of a few graphs on the analytics page which will re-direct the partner to artworks, conversations, orders. This PR adds tracking for these using a single event, `clickedGraphCTA`, which will use `ContextModule` to discern which graph the user is interacting with. `Destination_page_owner_type` is also there.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
