### PR TITLE
[Do not Merge] Add CMS Browse Galleries tracking events (claude-code walk-through)

### DIFF
--- a/src/Schema/CMS/Events/BrowseGalleries.ts
+++ b/src/Schema/CMS/Events/BrowseGalleries.ts
@@ -1,0 +1,169 @@
+/**
+ * Schemas describing CMS Browse Galleries events
+ * @packageDocumentation
+ */
+
+import { CmsContextModule } from "../Values/CmsContextModule"
+import { CmsOwnerType } from "../Values/CmsOwnerType"
+import { CmsActionType } from "./index"
+
+/**
+ * User clicks on "Partner with Artsy" link
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedPartnerWithArtsy",
+ *   context_module: "browseGalleriesHeader",
+ *   context_page_owner_type: "browseGalleries"
+ * }
+ * ```
+ */
+export interface CmsBrowseGalleriesClickedPartnerWithArtsy {
+  action: CmsActionType.clickedPartnerWithArtsy
+  context_module: CmsContextModule.browseGalleriesHeader
+  context_page_owner_type: CmsOwnerType.browseGalleries
+}
+
+/**
+ * User clicks on "Gallery Insights" link
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedGalleryInsights",
+ *   context_module: "browseGalleriesHeader",
+ *   context_page_owner_type: "browseGalleries"
+ * }
+ * ```
+ */
+export interface CmsBrowseGalleriesClickedGalleryInsights {
+  action: CmsActionType.clickedGalleryInsights
+  context_module: CmsContextModule.browseGalleriesHeader
+  context_page_owner_type: CmsOwnerType.browseGalleries
+}
+
+/**
+ * User clicks on location filter dropdown
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedLocationFilter",
+ *   context_module: "browseGalleriesFilters",
+ *   context_page_owner_type: "browseGalleries",
+ *   filter_type: "location"
+ * }
+ * ```
+ */
+export interface CmsBrowseGalleriesClickedLocationFilter {
+  action: CmsActionType.clickedLocationFilter
+  context_module: CmsContextModule.browseGalleriesFilters
+  context_page_owner_type: CmsOwnerType.browseGalleries
+  filter_type: "location"
+}
+
+/**
+ * User clicks on specialties filter dropdown
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedSpecialtiesFilter",
+ *   context_module: "browseGalleriesFilters",
+ *   context_page_owner_type: "browseGalleries",
+ *   filter_type: "specialties"
+ * }
+ * ```
+ */
+export interface CmsBrowseGalleriesClickedSpecialtiesFilter {
+  action: CmsActionType.clickedSpecialtiesFilter
+  context_module: CmsContextModule.browseGalleriesFilters
+  context_page_owner_type: CmsOwnerType.browseGalleries
+  filter_type: "specialties"
+}
+
+/**
+ * User clicks on galleries filter dropdown
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedGalleriesFilter",
+ *   context_module: "browseGalleriesFilters",
+ *   context_page_owner_type: "browseGalleries",
+ *   filter_type: "galleries"
+ * }
+ * ```
+ */
+export interface CmsBrowseGalleriesClickedGalleriesFilter {
+  action: CmsActionType.clickedGalleriesFilter
+  context_module: CmsContextModule.browseGalleriesFilters
+  context_page_owner_type: CmsOwnerType.browseGalleries
+  filter_type: "galleries"
+}
+
+/**
+ * User clicks on a gallery card to view gallery details
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedGalleryCard",
+ *   context_module: "browseGalleriesGrid",
+ *   context_page_owner_type: "browseGalleries",
+ *   gallery_id: "gallery-internal-id",
+ *   gallery_name: "Friedman Benda",
+ *   gallery_location: "New York, Los Angeles, Paris",
+ *   is_women_owned: true,
+ *   category: "Contemporary Design"
+ * }
+ * ```
+ */
+export interface CmsBrowseGalleriesClickedGalleryCard {
+  action: CmsActionType.clickedGalleryCard
+  context_module: CmsContextModule.browseGalleriesGrid
+  context_page_owner_type: CmsOwnerType.browseGalleries
+  gallery_id: string
+  gallery_name: string
+  gallery_location?: string
+  is_women_owned?: boolean
+  category?: string
+}
+
+/**
+ * User clicks Follow button on gallery card
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedFollowGallery",
+ *   context_module: "browseGalleriesGrid",
+ *   context_page_owner_type: "browseGalleries",
+ *   gallery_id: "gallery-internal-id",
+ *   gallery_name: "Ella West Gallery",
+ *   gallery_location: "Durham",
+ *   is_women_owned: true,
+ *   category: "Contemporary Design"
+ * }
+ * ```
+ */
+export interface CmsBrowseGalleriesClickedFollowGallery {
+  action: CmsActionType.clickedFollowGallery
+  context_module: CmsContextModule.browseGalleriesGrid
+  context_page_owner_type: CmsOwnerType.browseGalleries
+  gallery_id: string
+  gallery_name: string
+  gallery_location?: string
+  is_women_owned?: boolean
+  category?: string
+}
+
+export type CmsBrowseGalleries =
+  | CmsBrowseGalleriesClickedPartnerWithArtsy
+  | CmsBrowseGalleriesClickedGalleryInsights
+  | CmsBrowseGalleriesClickedLocationFilter
+  | CmsBrowseGalleriesClickedSpecialtiesFilter
+  | CmsBrowseGalleriesClickedGalleriesFilter
+  | CmsBrowseGalleriesClickedGalleryCard
+  | CmsBrowseGalleriesClickedFollowGallery

--- a/src/Schema/CMS/Events/index.ts
+++ b/src/Schema/CMS/Events/index.ts
@@ -1,6 +1,7 @@
 import { CmsAnalyticsPage } from "./AnalyticsPage"
 import { CmsArtworkFilter } from "./ArtworkFilter"
 import { CmsBatchImportFlow } from "./BatchImportFlow"
+import { CmsBrowseGalleries } from "./BrowseGalleries"
 import { CmsBulkEditFlow } from "./BulkEditFlow"
 import { CmsSettingsFlow } from "./SettingsFlow"
 import { CmsShowFlow } from "./ShowFlow"
@@ -14,6 +15,7 @@ import { CmsUploadArtworkFlow } from "./UploadArtworkFlow"
 export type CmsEvent =
   | CmsAnalyticsPage
   | CmsArtworkFilter
+  | CmsBrowseGalleries
   | CmsBulkEditFlow
   | CmsBatchImportFlow
   | CmsUploadArtworkFlow
@@ -135,4 +137,39 @@ export enum CmsActionType {
    * Corresponds to {@link CmsAnalytics}
    */
   viewedTooltip = "viewedTooltip",
+
+  /**
+   * Corresponds to {@link CmsBrowseGalleries}
+   */
+  clickedPartnerWithArtsy = "clickedPartnerWithArtsy",
+
+  /**
+   * Corresponds to {@link CmsBrowseGalleries}
+   */
+  clickedGalleryInsights = "clickedGalleryInsights",
+
+  /**
+   * Corresponds to {@link CmsBrowseGalleries}
+   */
+  clickedLocationFilter = "clickedLocationFilter",
+
+  /**
+   * Corresponds to {@link CmsBrowseGalleries}
+   */
+  clickedSpecialtiesFilter = "clickedSpecialtiesFilter",
+
+  /**
+   * Corresponds to {@link CmsBrowseGalleries}
+   */
+  clickedGalleriesFilter = "clickedGalleriesFilter",
+
+  /**
+   * Corresponds to {@link CmsBrowseGalleries}
+   */
+  clickedGalleryCard = "clickedGalleryCard",
+
+  /**
+   * Corresponds to {@link CmsBrowseGalleries}
+   */
+  clickedFollowGallery = "clickedFollowGallery",
 }

--- a/src/Schema/CMS/Values/CmsContextModule.ts
+++ b/src/Schema/CMS/Values/CmsContextModule.ts
@@ -20,4 +20,7 @@ export enum CmsContextModule {
   uploads = "Uploads",
   settings = "Settings",
   showsInstallShots = "Shows - Install shots",
+  browseGalleriesHeader = "browseGalleriesHeader",
+  browseGalleriesFilters = "browseGalleriesFilters",
+  browseGalleriesGrid = "browseGalleriesGrid",
 }

--- a/src/Schema/CMS/Values/CmsOwnerType.ts
+++ b/src/Schema/CMS/Values/CmsOwnerType.ts
@@ -8,4 +8,5 @@ export enum CmsOwnerType {
   bulkEdit = "bulkEdit",
   batchImport = "batchImport",
   batchImportArtistMatching = "batchImportArtistMatching",
+  browseGalleries = "browseGalleries",
 }


### PR DESCRIPTION
## Summary
- Add new tracking events for the CMS Browse Galleries feature
- Implements 7 new tracking interfaces following existing CMS patterns
- Adds support for tracking gallery discovery interactions

## Changes Made
- **New Event Types**: Added `CmsBrowseGalleries` with 7 interface types for different user interactions
- **Context Modules**: Added `browseGalleriesHeader`, `browseGalleriesFilters`, `browseGalleriesGrid` 
- **Owner Type**: Added `browseGalleries` for CMS gallery browsing pages
- **Action Types**: Added 7 new actions including gallery card clicks, follow actions, and filter interactions
- **Metadata Support**: Tracks gallery name, location, women-owned status, and category information

## Events Included
1. `ClickedPartnerWithArtsy` - Navigation to partner signup
2. `ClickedGalleryInsights` - Navigation to gallery insights  
3. `ClickedLocationFilter` - Location filter interaction
4. `ClickedSpecialtiesFilter` - Specialties filter interaction
5. `ClickedGalleriesFilter` - Galleries filter interaction
6. `ClickedGalleryCard` - Gallery profile navigation
7. `ClickedFollowGallery` - Gallery follow action

## Test plan
- [ ] Verify TypeScript compilation passes
- [ ] Test event interfaces can be imported and used
- [ ] Validate event structure matches analytics backend expectations
- [ ] Confirm no breaking changes to existing CMS events

🤖 Generated with [Claude Code](https://claude.ai/code)