### PR TITLE
chore: Add graph_data subfield to cms graph

### DIFF
--- a/src/Schema/CMS/Events/AnalyticsPage.ts
+++ b/src/Schema/CMS/Events/AnalyticsPage.ts
@@ -80,7 +80,8 @@ export interface CmsAnalyticsPageClickedMostViewed {
  *   action: "viewedGraph",
  *   context_module: "analyticsMostViewed" | "analyticsPublishedArtworks" | "analyticsViews" | "analyticsInquiries" | "analyticsSales" | "analyticsAudience",
  *   context_page_owner_type: "analytics",
- *   graph_type: "cumulative_line" | "donut" | "horizontal_bar" | "vertical_bar"
+ *   graph_type: "cumulative_line" | "donut" | "horizontal_bar" | "vertical_bar",
+ *   graph_data?: "device" | "medium" | "country" | "landing" | null
  * }
  * ```
  */
@@ -89,6 +90,7 @@ export interface CmsAnalyticsPageViewedGraph {
   context_module: CmsContextModule
   context_page_owner_type: CmsOwnerType.analytics
   graph_type: string
+  graph_data?: string
 }
 
 /**
@@ -101,6 +103,7 @@ export interface CmsAnalyticsPageViewedGraph {
  *   context_module: "analyticsMostViewed" | "analyticsPublishedArtworks" | "analyticsViews" | "analyticsInquiries" | "analyticsSales" | "analyticsAudience",
  *   context_page_owner_type: "analytics",
  *   graph_type: "cumulative_line" | "donut" | "horizontal_bar" | "vertical_bar",
+ *   graph_data?: "device" | "medium" | "country" | "landing" | null,
  *   datapoint_bucket_size?: "daily" | "weekly" | "monthly" | null,
  *   datapoint_is_other?: true | false | null
  * }
@@ -111,6 +114,7 @@ export interface CmsAnalyticsPageViewedGraphDatapoint {
   context_module: CmsContextModule
   context_page_owner_type: CmsOwnerType.analytics
   graph_type: string
+  graph_data?: string
   datapoint_bucket_size?: string
   datapoint_is_other?: boolean
 }


### PR DESCRIPTION
Adds a subfield on the two graph events to differentiate between the two horizontal/donut charts on audience section

The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

Adds a `graph_data` subfield which we can use for those bottom 4 graphs.
- `viewed_graph` and `viewed_graph_datapoint` should have this subfield corresponding to the graph, for those in the audience section
- `graph_data` will be `null` for all of the other graphs (cumulative line, vertical bar) in the other sections

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

