### PR TITLE
chore: Update tapped and clicked complete your profile

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -2372,19 +2372,26 @@ export interface ClickedVisitHelpCenter {
 }
 
 /**
- * A user clicks on the complete your profile prompt within the activity pannel
+ * A user clicks on the complete your profile on the order details page (no activity panel)
  *
  * This schema describes events sent to Segment from [[clickedCompleteYourProfile]]
  *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedCompleteYourProfile",
+ *    context_module: "OrdersDetail",
+ *    context_page_owner_type: "orders-detail",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b"
+ *  }
+ *  ```
  */
 
 export interface ClickedCompleteYourProfile {
   action: ActionType.clickedCompleteYourProfile
   context_module: ContextModule
   context_page_owner_type: PageOwnerType
-  context_page_owner_id: string
-  context_page_owner_slug?: string
-  user_id: string
+  context_page_owner_id?: string
 }
 
 /**

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -1467,19 +1467,26 @@ export interface TappedVisitHelpCenter {
 }
 
 /**
- * A user taps on the complete your profile prompt within the activity pannel
+ * A user taps on the complete your profile prompt within the activity panel (not implemented in order details)
  *
  * This schema describes events sent to Segment from [[tappedCompleteYourProfile]]
  *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedCompleteYourProfile",
+ *    context_module: "collectorProfileCard",
+ *    context_screen_owner_type: "profile",
+ *    context_screen_owner_id: ""
+ *  }
+ *  ```
  */
 
 export interface TappedCompleteYourProfile {
   action: ActionType.tappedCompleteYourProfile
   context_module: ContextModule
   context_screen_owner_type: ScreenOwnerType
-  context_screen_owner_id: string
-  context_screen_owner_slug?: string
-  user_id: string
+  context_screen_owner_id?: string
 }
 
 /**

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -59,6 +59,7 @@ import {
   ClickedChangeShippingMethod,
   ClickedCloseValidationAddressModal,
   ClickedCollectionGroup,
+  ClickedCompleteYourProfile,
   ClickedContactGallery,
   ClickedConversationsFilter,
   ClickedCreateAlert,
@@ -258,6 +259,7 @@ import {
   TappedChangePaymentMethod,
   TappedClearTask,
   TappedCollectionGroup,
+  TappedCompleteYourProfile,
   TappedConfirmSeeFewerWorks,
   TappedConsign,
   TappedConsignmentInquiry,
@@ -344,6 +346,7 @@ export type Event =
   | ClickedChangeShippingMethod
   | ClickedCloseValidationAddressModal
   | ClickedCollectionGroup
+  | ClickedCompleteYourProfile
   | ClickedContactGallery
   | ClickedConversationsFilter
   | ClickedCreateAlert
@@ -510,6 +513,7 @@ export type Event =
   | TappedCollectedArtwork
   | TappedCollectedArtworkImages
   | TappedCollectionGroup
+  | TappedCompleteYourProfile
   | TappedConfirmSeeFewerWorks
   | TappedConsign
   | TappedConsignmentInquiry


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

[slack thread](https://artsy.slack.com/archives/C02JHHHKP5K/p1756327122075039)with context.

We recently added a "Complete your profile" link on web for the order details page. We'd like to track interaction with it, reusing the logic from the existing event. 

Upon further investigation, we realized that we don't have any data for these events, potentially because they were not being imported in `index.ts` here. I've added those calls, and also deleted some of the subfields since we didn't see any existing force/eigen implementation that would cause an issue.

Note: This does not solve the fact that `tappedCompleteYourProfile` _is not_ firing when I tap on the "Complete my profile" button on the App on the profile screen. I simply updated it to be the new schema to match `clickedCompleteYourProfile`, and provided an example of what I'd expect it to look like. 

<img width="795" height="340" alt="Screenshot 2025-09-02 at 6 03 12 PM" src="https://github.com/user-attachments/assets/24124ffb-0f28-43a0-a7fa-4ac7137b9917" />

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
