### PR TITLE
feat: Adds publish Click label type to BulkEdits flow

### DIFF
--- a/src/Schema/CMS/Events/BulkEditFlow.ts
+++ b/src/Schema/CMS/Events/BulkEditFlow.ts
@@ -19,13 +19,14 @@ import { CmsActionType } from "."
  * }
  */
 export type CmsBulkEditClickLabel =
-  | "change availability"
-  | "bulk edit"
-  | "shortlist"
   | "add to show"
-  | "resolve all conflicts"
-  | "confirm edit"
+  | "bulk edit"
   | "cancel"
+  | "change availability"
+  | "confirm edit"
+  | "publish"
+  | "resolve all conflicts"
+  | "shortlist"
 
 export interface CmsBulkEditClickedEvent {
   action: "click"


### PR DESCRIPTION
The type of this PR is: **FEAT**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [AMBER-1990](https://artsyproduct.atlassian.net/browse/AMBER-1990)

### Description

<!-- Implementation description -->

Adds new label type for batch edits flow

We want to track clicking on this button 👇🏻 and adding the new type to the schema

<img width="1669" height="514" alt="Screenshot 2025-09-15 at 11 06 38 AM" src="https://github.com/user-attachments/assets/64896c92-c361-48af-a58b-524e973ab979" />

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


cc @artsy/amber-devs 

[AMBER-1990]: https://artsyproduct.atlassian.net/browse/AMBER-1990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ