### PR TITLE
feat(batch-edits-v3): Adds shownFailedUpdatesPage to bulk edit tracking schema

### DIFF
--- a/src/Schema/CMS/Events/BulkEditFlow.ts
+++ b/src/Schema/CMS/Events/BulkEditFlow.ts
@@ -37,6 +37,21 @@ export interface CmsBulkEditClickedEvent {
 }
 
 /**
+ * A partner has seen the failed updates screen.
+ * 
+ * @example
+ * ```
+ * {
+ *   action: "shownFailedUpdatesPage",
+ *   context_module: "Artworks - bulk edit",
+ * }
+ */
+export interface CmsBulkEditFailedUpdatesPageShown {
+  action: CmsActionType.shownFailedUpdatesPage
+  context_module: CmsContextModule.bulkEditFlow
+}
+
+/**
  * A partner has seen the max edit limit reached tool tip.
  *
  * @example
@@ -139,6 +154,7 @@ export interface CmsBulkEditFailed {
 
 export type CmsBulkEditFlow =
   | CmsBulkEditClickedEvent
+  | CmsBulkEditFailedUpdatesPageShown
   | CmsBulkEditMaxEditLimitReachedShown
   | CmsBulkEditConflictsShown
   | CmsBulkEditResolvedAllConflictsShown

--- a/src/Schema/CMS/Events/index.ts
+++ b/src/Schema/CMS/Events/index.ts
@@ -109,6 +109,12 @@ export enum CmsActionType {
   /**
    * Corresponds to {@link CmsBulkEditFlow}
    */
+  shownFailedUpdatesPage = "shownFailedUpdatesPage",
+
+
+  /**
+   * Corresponds to {@link CmsBulkEditFlow}
+   */
   shownMaxEditLimitReached = "shownMaxEditLimitReached",
 
   /**


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves part of [AMBER-1990](https://artsyproduct.atlassian.net/browse/AMBER-1990)

### Description

Adds `shownFailedUpdatesPage` to bulk edit tracking schema

⚠️ Additional metadata may be required but just want to get the general event structure into Volt, will work with Leo when hes online tomorrow ⚠️ 

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[AMBER-1990]: https://artsyproduct.atlassian.net/browse/AMBER-1990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ