### PR TITLE
feat: Adds failed updates page edit click type

### DIFF
--- a/src/Schema/CMS/Events/BulkEditFlow.ts
+++ b/src/Schema/CMS/Events/BulkEditFlow.ts
@@ -24,6 +24,7 @@ export type CmsBulkEditClickLabel =
   | "cancel"
   | "change availability"
   | "confirm edit"
+  | "failed updates page edit"
   | "publish"
   | "resolve all conflicts"
   | "shortlist"


### PR DESCRIPTION
The type of this PR is: **FEAT**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves a portion of [AMBER-1990](https://artsyproduct.atlassian.net/browse/AMBER-1990)

### Description

feat: Adds failed updates page edit click type

On the client side, this even will fire when button below is clicked

<img width="957" height="740" alt="Screenshot 2025-09-16 at 10 15 27 AM" src="https://github.com/user-attachments/assets/a57526ca-2202-4137-beb1-c2b531d902e2" />



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)

cc @artsy/amber-devs 


[AMBER-1990]: https://artsyproduct.atlassian.net/browse/AMBER-1990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ