### PR TITLE
feat: Add new unpublish type to CmsBulkEditClickLabel

### DIFF
--- a/src/Schema/CMS/Events/BulkEditFlow.ts
+++ b/src/Schema/CMS/Events/BulkEditFlow.ts
@@ -28,6 +28,7 @@ export type CmsBulkEditClickLabel =
   | "publish"
   | "resolve all conflicts"
   | "shortlist"
+  | "unpublish"
 
 export interface CmsBulkEditClickedEvent {
   action: "click"


### PR DESCRIPTION
The type of this PR is: **FEAT**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [AMBER-1978](https://artsyproduct.atlassian.net/browse/AMBER-1978)

### Description


feat: Add new unpublish type to CmsBulkEditClickLabel

To track events fired when a partner goes to unpublish via the batch edit system

Ex:

https://github.com/user-attachments/assets/a7625d7f-c49f-4f3d-b04c-8106958978fc

cc @artsy/amber-devs 

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[AMBER-1978]: https://artsyproduct.atlassian.net/browse/AMBER-1978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ