### PR TITLE
feat: Add searchBulkEditField event

### DIFF
--- a/src/Schema/CMS/Events/BulkEditFlow.ts
+++ b/src/Schema/CMS/Events/BulkEditFlow.ts
@@ -3,8 +3,8 @@
  * @packageDocumentation
  */
 
-import { CmsContextModule } from "../Values/CmsContextModule"
 import { CmsActionType } from "."
+import { CmsContextModule } from "../Values/CmsContextModule"
 
 /**
  * Generic click event in the bulk edit flow.
@@ -153,6 +153,24 @@ export interface CmsBulkEditFailed {
   artwork_ids: string[]
 }
 
+/**
+ * Search in the bulk edit drawer
+ *
+ * @example
+ * ```
+ * {
+ *   action: "searchBulkEditField",
+ *   context_module: "Artworks - bulk edit",
+ *   value: "search input"
+ * }
+ * ```
+ */
+export interface CmsBulkEditSearch {
+  action: CmsActionType.searchBulkEditField
+  context_module: CmsContextModule.bulkEditFlow
+  value: string
+}
+
 export type CmsBulkEditFlow =
   | CmsBulkEditClickedEvent
   | CmsBulkEditFailedUpdatesPageShown
@@ -162,3 +180,4 @@ export type CmsBulkEditFlow =
   | CmsBulkEditProcessingStarted
   | CmsBulkEditProcessingCompleted
   | CmsBulkEditFailed
+  | CmsBulkEditSearch

--- a/src/Schema/CMS/Events/index.ts
+++ b/src/Schema/CMS/Events/index.ts
@@ -104,6 +104,11 @@ export enum CmsActionType {
   /**
    * Corresponds to {@link CmsBulkEditFlow}
    */
+  searchBulkEditField = "searchBulkEditField",
+
+  /**
+   * Corresponds to {@link CmsBulkEditFlow}
+   */
   shownConflicts = "shownConflicts",
 
   /**


### PR DESCRIPTION
Resolves https://artsy.slack.com/archives/C07UYRFAVPU/p1758555419445629

## Description

This adds the `searchBulkEditField` event to track searches in the batch edits drawer.
```
 * {
 *   action: "searchBulkEditField",
 *   context_module: "Artworks - bulk edit",
 *   value: "search input"
 * }
 ```