### PR TITLE
chore: Add new type to track publish learn more help doc clicks

### DIFF
--- a/src/Schema/CMS/Events/BulkEditFlow.ts
+++ b/src/Schema/CMS/Events/BulkEditFlow.ts
@@ -26,6 +26,7 @@ export type CmsBulkEditClickLabel =
   | "confirm edit"
   | "failed updates page edit"
   | "publish"
+  | "publish learn more"
   | "resolve all conflicts"
   | "shortlist"
   | "unpublish"


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [AMBER-2004](https://artsyproduct.atlassian.net/browse/AMBER-2004)

### Description


Adding new click type to track clicks to the help center documentation for batch publishing

Implementation example: https://github.com/artsy/volt/pull/10018
<!-- Implementation description -->

cc @artsy/amber-devs 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
