### PR TITLE
fix: prefer 'type' for distinguishing immersive view clicks

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -664,6 +664,8 @@ export interface ClickedFairCard {
  * Currently, this event only fires on our new artwork grids on the following pages: Collect, Collection, Artist works-for-sale, and Search Results.
  * Note: This event is separate from [[clickedArtworkGroup]] because it is an important and frequent event. Separating it out will make it easier for analysts to access.
  *
+ * This event is also used for the immersive view on artwork grids, distinguished by the `type` field.
+ *
  * This schema describes events sent to Segment from [[clickedMainArtworkGrid]]
  *
  *  @example
@@ -691,7 +693,7 @@ export interface ClickedMainArtworkGrid {
   destination_page_owner_type: PageOwnerType
   destination_page_owner_id: string
   destination_page_owner_slug: string
-  type: "thumbnail"
+  type: "thumbnail" | "immersive"
   position?: number
   sort?: string
   signal_label?: string


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR resolves [ONYX-1807]

### Description

Follow-up to [this review comment](https://github.com/artsy/force/pull/16177#discussion_r2394435061) in Force
### PR Checklist (tick all before merging)

Let's use `type`, instead of `label` which is intended for a different purpose.


[ONYX-1807]: https://artsyproduct.atlassian.net/browse/ONYX-1807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.307.0--canary.642.13276.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/cohesion@4.307.0--canary.642.13276.0
  # or 
  yarn add @artsy/cohesion@4.307.0--canary.642.13276.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
