### PR TITLE
feat: more single page checkout tracking

### DIFF
--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -424,6 +424,7 @@ export interface ExpressCheckoutViewed {
  *    context_page_owner_id: "6164889300d643000db86504",
  *    flow: "Buy now" | "Make offer" | "Partner offer"
  *    address_ids: ["1234abcd5678efgh9012ijkl"]
+ *    default_address_id: "1234abcd5678efgh9012ijkl"
  *  }
  * ```
  */
@@ -433,6 +434,7 @@ export interface SavedAddressViewed {
   context_page_owner_id: string
   flow: string
   address_ids: string[]
+  default_address_id: string
 }
 
 /**

--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -488,6 +488,32 @@ export interface NewPaymentMethodViewed {
 }
 
 /**
+ * A user views a retrieved shipping quote in checkout
+ *
+ * This schema describes events sent to Segment from [[shippingQuoteViewed]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "shippingQuoteViewed",
+ *    context_page_owner_type: "orders-checkout",
+ *    context_page_owner_id: "6164889300d643000db86504",
+ *    flow: "Buy now" | "Make offer" | "Partner offer"
+ *    shipping_quotes: ["Standard", "Express"]
+ *    shipping_quote_ids: ["abcd1234efgh5678ijkl9012", "mnop3456qrst7890uvwx1234"]
+ *  }
+ * ```
+ */
+export interface ShippingQuoteViewed {
+  action: ActionType.shippingQuoteViewed
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id: string
+  flow: string
+  shipping_quotes: string[]
+  shipping_quote_ids: string[]
+}
+
+/**
  * A user views a step in checkout
  *
  * This schema describes events sent to Segment from [[OrderProgressionViewed]]

--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -501,8 +501,10 @@ export interface NewPaymentMethodViewed {
  *    context_page_owner_type: "orders-checkout",
  *    context_page_owner_id: "6164889300d643000db86504",
  *    flow: "Buy now" | "Make offer" | "Partner offer"
- *    shipping_quotes: ["Standard", "Express"]
- *    shipping_quote_ids: ["abcd1234efgh5678ijkl9012", "mnop3456qrst7890uvwx1234"]
+ *    shipping_quotes: [
+ *      { id: "ABC", type: "standard", price_minor: 123, price_currency: "USD", timeline: "Est. delivery: 3–5 days after shipping" },
+ *      { id: "XYZ", type: "express", price_minor: 456, price_currency: "USD", timeline: "Est. delivery: 2 days after shipping" },
+ *    ]
  *  }
  * ```
  */
@@ -511,8 +513,13 @@ export interface ShippingQuoteViewed {
   context_page_owner_type: PageOwnerType
   context_page_owner_id: string
   flow: "Buy now" | "Make offer" | "Partner offer"
-  shipping_quotes: string[]
-  shipping_quote_ids: string[]
+  shipping_quotes: Array<{
+    id: string
+    type: string
+    price_minor: number
+    price_currency: string
+    timeline: string
+  }>
 }
 
 /**

--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -425,6 +425,7 @@ export interface ExpressCheckoutViewed {
  *    flow: "Buy now" | "Make offer" | "Partner offer"
  *    address_ids: ["1234abcd5678efgh9012ijkl"]
  *    default_address_id: "1234abcd5678efgh9012ijkl"
+ *    default_address_country: "US"
  *  }
  * ```
  */
@@ -435,6 +436,7 @@ export interface SavedAddressViewed {
   flow: string
   address_ids: string[]
   default_address_id: string
+  default_address_country: string
 }
 
 /**

--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -508,7 +508,7 @@ export interface ShippingQuoteViewed {
   action: ActionType.shippingQuoteViewed
   context_page_owner_type: PageOwnerType
   context_page_owner_id: string
-  flow: string
+  flow: "Buy now" | "Make offer" | "Partner offer"
   shipping_quotes: string[]
   shipping_quote_ids: string[]
 }

--- a/src/Schema/Events/ImpressionTracking.ts
+++ b/src/Schema/Events/ImpressionTracking.ts
@@ -502,8 +502,8 @@ export interface NewPaymentMethodViewed {
  *    context_page_owner_id: "6164889300d643000db86504",
  *    flow: "Buy now" | "Make offer" | "Partner offer"
  *    shipping_quotes: [
- *      { id: "ABC", type: "standard", price_minor: 123, price_currency: "USD", timeline: "Est. delivery: 3–5 days after shipping" },
- *      { id: "XYZ", type: "express", price_minor: 456, price_currency: "USD", timeline: "Est. delivery: 2 days after shipping" },
+ *      { id: "ABC", type: "arta", subtype: "standard", price_minor: 123, price_currency: "USD", timeline: "Est. delivery: 3–5 days after shipping" },
+ *      { id: "XYZ", type: "arta", subtype: "express", price_minor: 456, price_currency: "USD", timeline: "Est. delivery: 2 days after shipping" },
  *    ]
  *  }
  * ```
@@ -516,6 +516,7 @@ export interface ShippingQuoteViewed {
   shipping_quotes: Array<{
     id: string
     type: string
+    subtype: string
     price_minor: number
     price_currency: string
     timeline: string

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -204,6 +204,7 @@ import {
   SendOffersErrorMessage,
   SendOffersModalViewed,
   ShippingEstimateViewed,
+  ShippingQuoteViewed,
   TooltipViewed,
   ValidationAddressViewed,
   ViewedToast,
@@ -514,6 +515,7 @@ export type Event =
   | SentRequestPriceEstimate
   | Share
   | ShippingEstimateViewed
+  | ShippingQuoteViewed
   | StartedOnboarding
   | SubmitAnotherArtwork
   | SubmittedOffer
@@ -1473,6 +1475,10 @@ export enum ActionType {
    * Corresponds to {@link ShippingEstimateViewed}
    */
   shippingEstimateViewed = "shippingEstimateViewed",
+  /**
+   * Corresponds to {@link ShippingQuoteViewed}
+   */
+  shippingQuoteViewed = "shippingQuoteViewed",
   /**
    * Corresponds to {@link StartedOnboarding}
    */


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

<!-- Implementation description -->

This does the following:
- adds `default_address_id` and `default_address_country` fields to the `savedAddressViewed`, so that we can know which was the default address saved, and what quotes would've generated upon landing.
- adds `shippingQuoteViewed` which will track impressions on the shipping quotes. We will definitely do this for arta, but I kept the naming open in case we expand providers or want to include flat/free

    - **Decided not to implement tracking when a user completes saving an address. If we fix our firing of the `savedAddressViewed` step, this event would be synonymous with `clickedOrderProgression` when the user navigates from Fulfillment step to the next.**

cc @artsy/emerald-devs 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
