### PR TITLE
feat: Implement clickedEditShippingAddress

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1125,8 +1125,8 @@ export interface ClickedShippingAddress {
  *  ```
  *  {
  *    action: "clickedEditShippingAddress",
- *    context_module: "ordersShipping",
- *    context_page_owner_type: "orders-shipping",
+ *    context_module: "ordersFulfillment",
+ *    context_page_owner_type: "orders-checkout",
  *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b"
  *  }
  * ```

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -1117,6 +1117,28 @@ export interface ClickedShippingAddress {
 }
 
 /**
+ *  User clicks to edit a shipping address in the checkout flow.
+ *
+ *  This schema describes events sent to Segment from [[clickedEditShippingAddress]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedEditShippingAddress",
+ *    context_module: "ordersShipping",
+ *    context_page_owner_type: "orders-shipping",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b"
+ *  }
+ * ```
+ */
+export interface ClickedEditShippingAddress {
+  action: ActionType.clickedEditShippingAddress
+  context_module: ContextModule
+  context_page_owner_type: string
+  context_page_owner_id: string
+}
+
+/**
  *  User chooses shipping option.
  *
  *  This schema describes events sent to Segment from [[clickedSelectShippingOption]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -72,6 +72,7 @@ import {
   ClickedDownloadAppHeader,
   ClickedEditAlert,
   ClickedEditArtwork,
+  ClickedEditShippingAddress,
   ClickedEstimateShippingCost,
   ClickedExpandFilterPanel,
   ClickedExpansionToggle,
@@ -376,6 +377,7 @@ export type Event =
   | ClickedDownloadAppHeader
   | ClickedEditArtwork
   | ClickedEditAlert
+  | ClickedEditShippingAddress
   | ClickedEstimateShippingCost
   | ClickedExpandFilterPanel
   | ClickedExpansionToggle
@@ -814,6 +816,10 @@ export enum ActionType {
    * Corresponds to {@link ClickedEditAlert}
    */
   clickedEditAlert = "clickedEditAlert",
+  /**
+   * Corresponds to {@link ClickedEditShippingAddress}
+   */
+  clickedEditShippingAddress = "clickedEditShippingAddress",
   /**
    * Corresponds to {@link ClickedEstimateShippingCost}
    */


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

From this [QA item](https://www.notion.so/artsy/I-know-this-intended-but-seems-a-lil-funky-to-have-two-active-CTAs-if-I-edit-my-address-359cab0764a080e29f4fe7ca040be983?source=copy_link) about having multiple CTAs open at once, we implement this event to track when a user clicks the "Edit" button on an address in the new checkout flow. **This is not the button to re-enter the section.** This can fire `onClick`.

<img width="833" height="498" alt="Screenshot 2026-05-07 at 2 55 35 PM" src="https://github.com/user-attachments/assets/53386fcf-eb95-4a08-83bc-4949abe380e2" />

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
