### PR TITLE
feat: add one-tap auth trigger #trivial

### DIFF
--- a/src/Schema/Events/Authentication.ts
+++ b/src/Schema/Events/Authentication.ts
@@ -48,7 +48,6 @@ export interface AuthImpression {
  *    action: "createdAccount",
  *    auth_redirect: "https://artsy.net/artist/andy-warhol",
  *    context_module: "popUpModal",
- *    context_page_path: "/artist/andy-warhol",
  *    intent: "viewArtist",
  *    modal_copy: "Sign up to follow artists",
  *    onboarding: true,
@@ -64,7 +63,6 @@ export interface CreatedAccount {
   action: ActionType.createdAccount
   auth_redirect: string
   context_module: AuthContextModule
-  context_page_path?: string
   intent: AuthIntent
   modal_copy?: string
   onboarding: boolean
@@ -118,7 +116,6 @@ export interface ResetYourPassword {
  *    action: "successfullyLoggedIn",
  *    auth_redirect: "https://artsy.net/artist/andy-warhol",
  *    context_module: "popUpModal",
- *    context_page_path: "/artist/andy-warhol",
  *    intent: "viewArtist",
  *    modal_copy: "Sign up to follow artists",
  *    service: "email",
@@ -133,7 +130,6 @@ export interface SuccessfullyLoggedIn {
   action: ActionType.successfullyLoggedIn
   auth_redirect: string
   context_module: AuthContextModule
-  context_page_path?: string
   intent: AuthIntent
   modal_copy?: string
   service: AuthService

--- a/src/Schema/Events/Authentication.ts
+++ b/src/Schema/Events/Authentication.ts
@@ -48,6 +48,7 @@ export interface AuthImpression {
  *    action: "createdAccount",
  *    auth_redirect: "https://artsy.net/artist/andy-warhol",
  *    context_module: "popUpModal",
+ *    context_page_path: "/artist/andy-warhol",
  *    intent: "viewArtist",
  *    modal_copy: "Sign up to follow artists",
  *    onboarding: true,
@@ -63,6 +64,7 @@ export interface CreatedAccount {
   action: ActionType.createdAccount
   auth_redirect: string
   context_module: AuthContextModule
+  context_page_path?: string
   intent: AuthIntent
   modal_copy?: string
   onboarding: boolean
@@ -116,6 +118,7 @@ export interface ResetYourPassword {
  *    action: "successfullyLoggedIn",
  *    auth_redirect: "https://artsy.net/artist/andy-warhol",
  *    context_module: "popUpModal",
+ *    context_page_path: "/artist/andy-warhol",
  *    intent: "viewArtist",
  *    modal_copy: "Sign up to follow artists",
  *    service: "email",
@@ -130,6 +133,7 @@ export interface SuccessfullyLoggedIn {
   action: ActionType.successfullyLoggedIn
   auth_redirect: string
   context_module: AuthContextModule
+  context_page_path?: string
   intent: AuthIntent
   modal_copy?: string
   service: AuthService
@@ -156,7 +160,7 @@ export enum AuthModalType {
 /**
  * The type of action that opened the authentication modal
  */
-export type AuthTrigger = "click" | "tap" | "timed" | "scroll"
+export type AuthTrigger = "click" | "tap" | "timed" | "scroll" | "one-tap"
 
 /**
  * the service the user used to authenticate


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [DI-291](https://www.notion.so/artsy/6-Force-One-Tap-Basic-Analytics-361cab0764a0804c9a28d989f4c950fe?v=310cab0764a08151b558000cc3bc6840&source=copy_link)

### Description

<!-- Implementation description -->

- adds one-tap as an AuthTrigger to differentiate from regular google sign in 
- ~~adds context_page_path in auth events to capture page auth started on~~

https://artsy.slack.com/archives/C05EEBNEF71/p1778881199224469?thread_ts=1778874112.044779&cid=C05EEBNEF71

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events) - maybe?
