### PR TITLE
chore: use new auth method field rather than expanding triggers

### DIFF
--- a/src/Schema/Events/Authentication.ts
+++ b/src/Schema/Events/Authentication.ts
@@ -64,6 +64,7 @@ export interface CreatedAccount {
   auth_redirect: string
   context_module: AuthContextModule
   intent: AuthIntent
+  method?: AuthMethod
   modal_copy?: string
   onboarding: boolean
   service: AuthService
@@ -131,6 +132,7 @@ export interface SuccessfullyLoggedIn {
   auth_redirect: string
   context_module: AuthContextModule
   intent: AuthIntent
+  method?: AuthMethod
   modal_copy?: string
   service: AuthService
   trigger: AuthTrigger
@@ -156,7 +158,12 @@ export enum AuthModalType {
 /**
  * The type of action that opened the authentication modal
  */
-export type AuthTrigger = "click" | "tap" | "timed" | "scroll" | "one-tap"
+export type AuthTrigger = "click" | "tap" | "timed" | "scroll"
+
+/**
+ * The authentication method or flow used
+ */
+export type AuthMethod = "one-tap"
 
 /**
  * the service the user used to authenticate


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CO-]

### Description

<!-- Implementation description -->

Switch trigger out for a new method field as it does not really fit conceptually with other triggers. 
Analytics pr that is still not merged is only thing passing the modified trigger so should be okay to remove. 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
