### PR TITLE
feat: add country field to auto complete

### DIFF
--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -290,6 +290,7 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
  *    context_module:"OrdersShipping",
  *    context_owner_type: "orders-shipping",
  *    context_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    country: "US" | "GB" | "DE" | "CH" | "IT" | "FR",
  *    input: "Weserstr."
  *    suggested_addresses_results: 3
  *  }
@@ -300,6 +301,7 @@ export interface AddressAutoCompletionResult {
   context_module: ContextModule
   context_owner_type: PageOwnerType
   context_owner_id?: string
+  country: string
   input: string
   suggested_addresses_results: number
 }
@@ -316,7 +318,8 @@ export interface AddressAutoCompletionResult {
  *    context_module:"OrdersShipping",
  *    context_owner_type: "orders-shipping",
  *    context_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
- *    input: "Wes"
+ *    country: "US" | "GB" | "DE" | "CH" | "IT" | "FR",
+ *    input: "Wes",
  *    item: "Weserstr."
  *  }
  * ```
@@ -326,6 +329,7 @@ export interface SelectedItemFromAddressAutoCompletion {
   context_module: ContextModule
   context_owner_type: PageOwnerType
   context_owner_id?: string
+  country: string
   input: string
   item: string
 }
@@ -342,6 +346,7 @@ export interface SelectedItemFromAddressAutoCompletion {
  *    context_module:"OrdersShipping",
  *    context_owner_type: "orders-shipping",
  *    context_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    country: "US" | "GB" | "DE" | "CH" | "IT" | "FR",
  *    field: "Address line 2"
  *  }
  * ```
@@ -351,5 +356,6 @@ export interface EditedAutocompletedAddress {
   context_module: ContextModule
   context_owner_type: PageOwnerType
   context_owner_id?: string
+  country: string
   field: string
 }


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

Upon QAing async, I realized we don't actually capture the country within the payloads! This makes sense because we launched to US only, but we now must capture the Country we're trying to complete for in order to look at anything and everything!

@artsy/emerald-devs what makes sense here for a string value? I assumed we would just use the Country Code (and that's my preference),  but I am also completely fine with us using the string "United States" or whatever is visible to the user. Those would always be unique and 1:1 right?

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
