### PR TITLE
chore: make address autocomplete Country optional

### DIFF
--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -290,7 +290,7 @@ export interface SelectedSearchSuggestionQuickNavigationItem {
  *    context_module:"OrdersShipping",
  *    context_owner_type: "orders-shipping",
  *    context_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
- *    country: "US" | "GB" | "DE" | "CH" | "IT" | "FR",
+ *    country?: "US" | "GB" | "DE" | "CH" | "IT" | "FR",
  *    input: "Weserstr."
  *    suggested_addresses_results: 3
  *  }
@@ -301,7 +301,7 @@ export interface AddressAutoCompletionResult {
   context_module: ContextModule
   context_owner_type: PageOwnerType
   context_owner_id?: string
-  country: string
+  country?: string
   input: string
   suggested_addresses_results: number
 }
@@ -318,7 +318,7 @@ export interface AddressAutoCompletionResult {
  *    context_module:"OrdersShipping",
  *    context_owner_type: "orders-shipping",
  *    context_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
- *    country: "US" | "GB" | "DE" | "CH" | "IT" | "FR",
+ *    country?: "US" | "GB" | "DE" | "CH" | "IT" | "FR",
  *    input: "Wes",
  *    item: "Weserstr."
  *  }
@@ -329,7 +329,7 @@ export interface SelectedItemFromAddressAutoCompletion {
   context_module: ContextModule
   context_owner_type: PageOwnerType
   context_owner_id?: string
-  country: string
+  country?: string
   input: string
   item: string
 }
@@ -346,7 +346,7 @@ export interface SelectedItemFromAddressAutoCompletion {
  *    context_module:"OrdersShipping",
  *    context_owner_type: "orders-shipping",
  *    context_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
- *    country: "US" | "GB" | "DE" | "CH" | "IT" | "FR",
+ *    country?: "US" | "GB" | "DE" | "CH" | "IT" | "FR",
  *    field: "Address line 2"
  *  }
  * ```
@@ -356,6 +356,6 @@ export interface EditedAutocompletedAddress {
   context_module: ContextModule
   context_owner_type: PageOwnerType
   context_owner_id?: string
-  country: string
+  country?: string
   field: string
 }


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->



### Description

This was blocking a Topaz release because we have not implemented the `country` call in Force yet. [Thread](https://artsy.slack.com/archives/C02BC3HEJ/p1781772094691399).

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
