### PR TITLE
chore: add tracking schema for OS Multi-Add feature

### DIFF
--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -163,6 +163,8 @@ export enum ContextModule {
   minimalCTABanner = "minimalCTABanner",
   moreFromThisSeries = "moreFromThisSeries",
   moreSeriesByThisArtist = "moreSeriesByThisArtist",
+  multiAdd = "multiAdd",
+  multiAddReview = "multiAddReview",
   myCollection = "myCollection",
   myCollectionAddArtworkAddArtist = "myCollectionAddArtworkAddArtist",
   myCollectionArtwork = "myCollectionArtwork",

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -93,6 +93,7 @@ export enum OwnerType {
   infiniteDiscoveryArtwork = "infiniteDiscoveryArtwork",
   infiniteDiscoveryArtist = "infiniteDiscoveryArtist",
   infiniteDiscoveryOnboarding = "infiniteDiscoveryOnboarding",
+  inventory = "inventory",
   lotsByArtistsYouFollow = "lotsByArtistsYouFollow",
   lotsForYou = "lotsForYou",
   marketNews = "marketNews",

--- a/src/Schema/index.ts
+++ b/src/Schema/index.ts
@@ -50,3 +50,12 @@ export * from "./CMS/Events/QuickReplyFlow"
 export * from "./CMS/Events/SettingsFlow"
 export * from "./CMS/Events/ShowFlow"
 export * from "./CMS/Events/UploadArtworkFlow"
+
+/**
+ * Art OS-specific exports
+ */
+
+export * from "./os/Events"
+export * from "./os/Values/OsContextModule"
+export * from "./os/Values/OsOwnerType"
+export * from "./os/Events/MultiAddFlow"

--- a/src/Schema/os/Events/MultiAddFlow.ts
+++ b/src/Schema/os/Events/MultiAddFlow.ts
@@ -1,0 +1,188 @@
+/**
+ * Schemas describing Art OS Multi-Add Artworks events
+ * @packageDocumentation
+ */
+
+import { OsContextModule } from "../Values/OsContextModule"
+import { OsOwnerType } from "../Values/OsOwnerType"
+import { OsActionType } from "./index"
+
+/**
+ * A partner clicks "Add From File" to enter the Multi-Add flow and open the drop zone.
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedAddFromFile",
+ *   context_module: "multiAdd",
+ *   context_page_owner_type: "inventory"
+ * }
+ * ```
+ */
+export interface ClickedAddFromFile {
+  action: OsActionType.clickedAddFromFile
+  context_module: OsContextModule.multiAdd
+  context_page_owner_type: OsOwnerType.inventory
+}
+
+/**
+ * A partner exits the drop zone without dropping a file (nothing is saved).
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedExitDropZone",
+ *   context_module: "multiAdd",
+ *   context_page_owner_type: "inventory"
+ * }
+ * ```
+ */
+export interface ClickedExitDropZone {
+  action: OsActionType.clickedExitDropZone
+  context_module: OsContextModule.multiAdd
+  context_page_owner_type: OsOwnerType.inventory
+}
+
+/**
+ * A file is accepted by the drop zone and an import session starts (upload to S3,
+ * then createArtworkImport with parseWithAI). One event per started session.
+ *
+ * @example
+ * ```
+ * {
+ *   action: "startedArtworkImport",
+ *   context_module: "multiAdd",
+ *   context_page_owner_type: "inventory",
+ *   file_type: "application/pdf"
+ * }
+ * ```
+ */
+export interface StartedArtworkImport {
+  action: OsActionType.startedArtworkImport
+  context_module: OsContextModule.multiAdd
+  context_page_owner_type: OsOwnerType.inventory
+  file_type: string
+}
+
+/**
+ * A partner confirms the review and creates artworks from the import (skipped rows excluded).
+ *
+ * @example
+ * ```
+ * {
+ *   action: "createdImportedArtworks",
+ *   context_module: "multiAddReview",
+ *   context_page_owner_type: "inventory",
+ *   artwork_import_id: "67b646ecbe87376bfeb3f962",
+ *   row_count: 14,
+ *   selected_count: 12
+ * }
+ * ```
+ */
+export interface CreatedImportedArtworks {
+  action: OsActionType.createdImportedArtworks
+  context_module: OsContextModule.multiAddReview
+  context_page_owner_type: OsOwnerType.inventory
+  artwork_import_id: string
+  row_count: number
+  selected_count: number
+}
+
+/**
+ * A partner cancels the review session, discarding the import.
+ *
+ * @example
+ * ```
+ * {
+ *   action: "cancelledArtworkImport",
+ *   context_module: "multiAddReview",
+ *   context_page_owner_type: "inventory",
+ *   artwork_import_id: "67b646ecbe87376bfeb3f962"
+ * }
+ * ```
+ */
+export interface CancelledArtworkImport {
+  action: OsActionType.cancelledArtworkImport
+  context_module: OsContextModule.multiAddReview
+  context_page_owner_type: OsOwnerType.inventory
+  artwork_import_id: string
+}
+
+/**
+ * A partner is dropped back into a prior import session that is awaiting review.
+ *
+ * @example
+ * ```
+ * {
+ *   action: "resumedArtworkImport",
+ *   context_module: "multiAdd",
+ *   context_page_owner_type: "inventory",
+ *   artwork_import_id: "67b646ecbe87376bfeb3f962"
+ * }
+ * ```
+ */
+export interface ResumedArtworkImport {
+  action: OsActionType.resumedArtworkImport
+  context_module: OsContextModule.multiAdd
+  context_page_owner_type: OsOwnerType.inventory
+  artwork_import_id: string
+}
+
+/**
+ * Artwork creation for the import finishes successfully.
+ *
+ * @example
+ * ```
+ * {
+ *   action: "completedArtworkImport",
+ *   context_module: "multiAdd",
+ *   context_page_owner_type: "inventory",
+ *   artwork_import_id: "67b646ecbe87376bfeb3f962"
+ * }
+ * ```
+ */
+export interface CompletedArtworkImport {
+  action: OsActionType.completedArtworkImport
+  context_module: OsContextModule.multiAdd
+  context_page_owner_type: OsOwnerType.inventory
+  artwork_import_id: string
+}
+
+/**
+ * A partner corrects a cell in the review table (a flagged cell or an unmatched artist).
+ * Carries the import row rather than a saved artwork.
+ *
+ * @example
+ * ```
+ * {
+ *   action: "editedArtworkField",
+ *   context_module: "multiAddReview",
+ *   context_page_owner_type: "inventory",
+ *   artwork_import_id: "67b646ecbe87376bfeb3f962",
+ *   import_row_id: "a1b2c3d4",
+ *   field: "title",
+ *   old_value: "Untitld",
+ *   new_value: "Untitled"
+ * }
+ * ```
+ */
+export interface EditedArtworkField {
+  action: OsActionType.editedArtworkField
+  context_module: OsContextModule.multiAddReview
+  context_page_owner_type: OsOwnerType.inventory
+  artwork_import_id: string
+  import_row_id: string
+  field: string
+  old_value: string
+  new_value: string
+}
+
+export type OsMultiAddFlow =
+  | ClickedAddFromFile
+  | ClickedExitDropZone
+  | StartedArtworkImport
+  | CreatedImportedArtworks
+  | CancelledArtworkImport
+  | ResumedArtworkImport
+  | CompletedArtworkImport
+  | EditedArtworkField

--- a/src/Schema/os/Events/__tests__/MultiAddFlow.test.ts
+++ b/src/Schema/os/Events/__tests__/MultiAddFlow.test.ts
@@ -1,0 +1,151 @@
+import { OsContextModule } from "../../Values/OsContextModule"
+import { OsOwnerType } from "../../Values/OsOwnerType"
+import { OsActionType } from "../index"
+import {
+  CancelledArtworkImport,
+  ClickedAddFromFile,
+  ClickedExitDropZone,
+  CompletedArtworkImport,
+  CreatedImportedArtworks,
+  EditedArtworkField,
+  ResumedArtworkImport,
+  StartedArtworkImport,
+} from "../MultiAddFlow"
+
+describe("Multi-Add flow events", () => {
+  it("ClickedAddFromFile serializes to the expected shape", () => {
+    const event: ClickedAddFromFile = {
+      action: OsActionType.clickedAddFromFile,
+      context_module: OsContextModule.multiAdd,
+      context_page_owner_type: OsOwnerType.inventory,
+    }
+
+    expect(event).toEqual({
+      action: "clickedAddFromFile",
+      context_module: "multiAdd",
+      context_page_owner_type: "inventory",
+    })
+  })
+
+  it("ClickedExitDropZone serializes to the expected shape", () => {
+    const event: ClickedExitDropZone = {
+      action: OsActionType.clickedExitDropZone,
+      context_module: OsContextModule.multiAdd,
+      context_page_owner_type: OsOwnerType.inventory,
+    }
+
+    expect(event).toEqual({
+      action: "clickedExitDropZone",
+      context_module: "multiAdd",
+      context_page_owner_type: "inventory",
+    })
+  })
+
+  it("StartedArtworkImport serializes to the expected shape", () => {
+    const event: StartedArtworkImport = {
+      action: OsActionType.startedArtworkImport,
+      context_module: OsContextModule.multiAdd,
+      context_page_owner_type: OsOwnerType.inventory,
+      file_type: "application/pdf",
+    }
+
+    expect(event).toEqual({
+      action: "startedArtworkImport",
+      context_module: "multiAdd",
+      context_page_owner_type: "inventory",
+      file_type: "application/pdf",
+    })
+  })
+
+  it("CreatedImportedArtworks serializes to the expected shape", () => {
+    const event: CreatedImportedArtworks = {
+      action: OsActionType.createdImportedArtworks,
+      artwork_import_id: "67b646ecbe87376bfeb3f962",
+      context_module: OsContextModule.multiAddReview,
+      context_page_owner_type: OsOwnerType.inventory,
+      row_count: 14,
+      selected_count: 12,
+    }
+
+    expect(event).toEqual({
+      action: "createdImportedArtworks",
+      artwork_import_id: "67b646ecbe87376bfeb3f962",
+      context_module: "multiAddReview",
+      context_page_owner_type: "inventory",
+      row_count: 14,
+      selected_count: 12,
+    })
+  })
+
+  it("CancelledArtworkImport serializes to the expected shape", () => {
+    const event: CancelledArtworkImport = {
+      action: OsActionType.cancelledArtworkImport,
+      artwork_import_id: "67b646ecbe87376bfeb3f962",
+      context_module: OsContextModule.multiAddReview,
+      context_page_owner_type: OsOwnerType.inventory,
+    }
+
+    expect(event).toEqual({
+      action: "cancelledArtworkImport",
+      artwork_import_id: "67b646ecbe87376bfeb3f962",
+      context_module: "multiAddReview",
+      context_page_owner_type: "inventory",
+    })
+  })
+
+  it("ResumedArtworkImport serializes to the expected shape", () => {
+    const event: ResumedArtworkImport = {
+      action: OsActionType.resumedArtworkImport,
+      artwork_import_id: "67b646ecbe87376bfeb3f962",
+      context_module: OsContextModule.multiAdd,
+      context_page_owner_type: OsOwnerType.inventory,
+    }
+
+    expect(event).toEqual({
+      action: "resumedArtworkImport",
+      artwork_import_id: "67b646ecbe87376bfeb3f962",
+      context_module: "multiAdd",
+      context_page_owner_type: "inventory",
+    })
+  })
+
+  it("CompletedArtworkImport serializes to the expected shape", () => {
+    const event: CompletedArtworkImport = {
+      action: OsActionType.completedArtworkImport,
+      artwork_import_id: "67b646ecbe87376bfeb3f962",
+      context_module: OsContextModule.multiAdd,
+      context_page_owner_type: OsOwnerType.inventory,
+    }
+
+    expect(event).toEqual({
+      action: "completedArtworkImport",
+      artwork_import_id: "67b646ecbe87376bfeb3f962",
+      context_module: "multiAdd",
+      context_page_owner_type: "inventory",
+    })
+  })
+
+  it("EditedArtworkField serializes to the expected shape", () => {
+    const event: EditedArtworkField = {
+      action: OsActionType.editedArtworkField,
+      artwork_import_id: "67b646ecbe87376bfeb3f962",
+      context_module: OsContextModule.multiAddReview,
+      context_page_owner_type: OsOwnerType.inventory,
+      field: "title",
+      import_row_id: "a1b2c3d4",
+      new_value: "Untitled",
+      old_value: "Untitld",
+    }
+
+    expect(event).toEqual({
+      action: "editedArtworkField",
+      artwork_import_id: "67b646ecbe87376bfeb3f962",
+      context_module: "multiAddReview",
+      context_page_owner_type: "inventory",
+      field: "title",
+      import_row_id: "a1b2c3d4",
+      new_value: "Untitled",
+      old_value: "Untitld",
+    })
+  })
+})

--- a/src/Schema/os/Events/index.ts
+++ b/src/Schema/os/Events/index.ts
@@ -1,0 +1,55 @@
+import { OsMultiAddFlow } from "./MultiAddFlow"
+
+/**
+ * List of valid schemas for Art OS analytics actions
+ *
+ * Each event describes one ActionType
+ */
+export type OsEvent = OsMultiAddFlow
+
+/**
+ * List of all Art OS actions
+ *
+ * Each OsActionType corresponds with a table in Redshift.
+ */
+export enum OsActionType {
+  /**
+   * Corresponds to {@link CancelledArtworkImport}
+   */
+  cancelledArtworkImport = "cancelledArtworkImport",
+
+  /**
+   * Corresponds to {@link ClickedAddFromFile}
+   */
+  clickedAddFromFile = "clickedAddFromFile",
+
+  /**
+   * Corresponds to {@link ClickedExitDropZone}
+   */
+  clickedExitDropZone = "clickedExitDropZone",
+
+  /**
+   * Corresponds to {@link CompletedArtworkImport}
+   */
+  completedArtworkImport = "completedArtworkImport",
+
+  /**
+   * Corresponds to {@link CreatedImportedArtworks}
+   */
+  createdImportedArtworks = "createdImportedArtworks",
+
+  /**
+   * Corresponds to {@link EditedArtworkField}
+   */
+  editedArtworkField = "editedArtworkField",
+
+  /**
+   * Corresponds to {@link ResumedArtworkImport}
+   */
+  resumedArtworkImport = "resumedArtworkImport",
+
+  /**
+   * Corresponds to {@link StartedArtworkImport}
+   */
+  startedArtworkImport = "startedArtworkImport",
+}

--- a/src/Schema/os/Values/OsContextModule.ts
+++ b/src/Schema/os/Values/OsContextModule.ts
@@ -1,0 +1,10 @@
+/**
+ * All context modules available for Art OS
+ *
+ * A component where an action is triggered
+ * @packageDocumentation
+ */
+export enum OsContextModule {
+  multiAdd = "multiAdd",
+  multiAddReview = "multiAddReview",
+}

--- a/src/Schema/os/Values/OsOwnerType.ts
+++ b/src/Schema/os/Values/OsOwnerType.ts
@@ -1,0 +1,8 @@
+/**
+ * All owner types available for Art OS
+ *
+ * @packageDocumentation
+ */
+export enum OsOwnerType {
+  inventory = "inventory",
+}


### PR DESCRIPTION
cc @artsy/amber-devs 

First Cohesion PR for OS!

Tried to follow conventions, mostly new stuff, but needed to add 'multi add' and 'inventory' in a legacy place in order to reuse some existing events like `BannerViewed` and `ErrorMessageViewed` that need those as context modules/screens.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.363.0--canary.706.14832.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/cohesion@4.363.0--canary.706.14832.0
  # or 
  yarn add @artsy/cohesion@4.363.0--canary.706.14832.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
