### PR TITLE
chore: Add tracking schema for OS Instagram Editor

### DIFF
--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -148,6 +148,7 @@ export enum OwnerType {
   shows = "shows",
   signup = "signup",
   similarToRecentlyViewed = "similarToRecentlyViewed",
+  studioInstagram = "studioInstagram",
   studioMaterials = "studioMaterials",
   submitArtworkStepAddDetails = "submitArtworkStepAddDetails",
   submitArtworkStepAddDimensions = "submitArtworkStepAddDimensions",

--- a/src/Schema/index.ts
+++ b/src/Schema/index.ts
@@ -39,8 +39,6 @@ export * from "./Values/Tab"
  */
 
 export * from "./CMS/Events"
-export * from "./CMS/Values/CmsContextModule"
-export * from "./CMS/Values/CmsOwnerType"
 export * from "./CMS/Events/AnalyticsPage"
 export * from "./CMS/Events/ArtworkFilter"
 export * from "./CMS/Events/BatchImportFlow"
@@ -50,18 +48,20 @@ export * from "./CMS/Events/QuickReplyFlow"
 export * from "./CMS/Events/SettingsFlow"
 export * from "./CMS/Events/ShowFlow"
 export * from "./CMS/Events/UploadArtworkFlow"
+export * from "./CMS/Values/CmsContextModule"
+export * from "./CMS/Values/CmsOwnerType"
 
 /**
  * Art OS-specific exports
  */
 
 export * from "./os/Events"
-export * from "./os/Values/OsContextModule"
-export * from "./os/Values/OsOwnerType"
 export * from "./os/Events/BrandKit"
 export * from "./os/Events/Click"
 export * from "./os/Events/ConnectedAppsFlow"
+export * from "./os/Events/InstagramEditor"
 export * from "./os/Events/InventoryTable"
-export * from "./os/Events/MaterialsEditor"
 export * from "./os/Events/MultiAddFlow"
 export * from "./os/Events/Submit"
+export * from "./os/Values/OsContextModule"
+export * from "./os/Values/OsOwnerType"

--- a/src/Schema/os/Events/InstagramEditor.ts
+++ b/src/Schema/os/Events/InstagramEditor.ts
@@ -1,0 +1,260 @@
+import { OsContextModule } from "../Values/OsContextModule"
+import { OsOwnerType } from "../Values/OsOwnerType"
+import { OsActionType } from "."
+
+/**
+ * Schemas describing Art OS Instagram Editor events
+ * @packageDocumentation
+ */
+
+/**
+ * A partner clicks "Connect" or "Cancel" in the Instagram account connection modal.
+ * The same modal is also used for Mailchimp; `label` identifies which service it is.
+ *
+ * This schema describes events sent to Segment from [[OsClickedConnectModal]]
+ *
+ * @example Connect
+ * ```
+ * {
+ *   action: "clickedConnectModal",
+ *   context_module: "connectModal",
+ *   context_page_owner_type: "studioInstagram",
+ *   label: "instagram",
+ *   value: "connect"
+ * }
+ * ```
+ *
+ * @example Cancel
+ * ```
+ * {
+ *   action: "clickedConnectModal",
+ *   context_module: "connectModal",
+ *   context_page_owner_type: "studioInstagram",
+ *   label: "instagram",
+ *   value: "cancel"
+ * }
+ * ```
+ */
+export interface OsClickedConnectModal {
+  action: OsActionType.clickedConnectModal
+  context_module: OsContextModule.connectModal
+  context_page_owner_type: OsOwnerType.studioInstagram
+  label: "instagram" | "mailchimp"
+  value: "connect" | "cancel"
+}
+
+/**
+ * A partner selects or deselects an image from the Image Bank in the Instagram editor.
+ *
+ * This schema describes events sent to Segment from [[OsClickedImageBankImage]]
+ *
+ * @example Select
+ * ```
+ * {
+ *   action: "clickedImageBankImage",
+ *   context_module: "imageBank",
+ *   context_page_owner_type: "studioInstagram",
+ *   value: "selected"
+ * }
+ * ```
+ *
+ * @example Deselect
+ * ```
+ * {
+ *   action: "clickedImageBankImage",
+ *   context_module: "imageBank",
+ *   context_page_owner_type: "studioInstagram",
+ *   value: "deselected"
+ * }
+ * ```
+ */
+export interface OsClickedImageBankImage {
+  action: OsActionType.clickedImageBankImage
+  context_module: OsContextModule.imageBank
+  context_page_owner_type: OsOwnerType.studioInstagram
+  value: "selected" | "deselected"
+}
+
+/**
+ * A partner uploads an image into the Image Bank.
+ * Fires when the upload is initiated (file selected).
+ *
+ * This schema describes events sent to Segment from [[OsClickedUploadImageBank]]
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedUploadImageBank",
+ *   context_module: "imageBank",
+ *   context_page_owner_type: "studioInstagram",
+ *   field: "file",
+ *   value: "filename.png"
+ * }
+ * ```
+ */
+export interface OsClickedUploadImageBank {
+  action: OsActionType.clickedUploadImageBank
+  context_module: OsContextModule.imageBank
+  context_page_owner_type: OsOwnerType.studioInstagram
+  field: "file"
+  value: string
+}
+
+/**
+ * A partner reorders or removes an image in the Image Bank management view.
+ *
+ * This schema describes events sent to Segment from [[OsClickedImageBankManagement]]
+ *
+ * @example Reorder
+ * ```
+ * {
+ *   action: "clickedImageBankManagement",
+ *   context_module: "imageBank",
+ *   context_page_owner_type: "studioInstagram",
+ *   value: "reorder"
+ * }
+ * ```
+ *
+ * @example Remove
+ * ```
+ * {
+ *   action: "clickedImageBankManagement",
+ *   context_module: "imageBank",
+ *   context_page_owner_type: "studioInstagram",
+ *   value: "remove"
+ * }
+ * ```
+ */
+export interface OsClickedImageBankManagement {
+  action: OsActionType.clickedImageBankManagement
+  context_module: OsContextModule.imageBank
+  context_page_owner_type: OsOwnerType.studioInstagram
+  value: "reorder" | "remove"
+}
+
+/**
+ * A partner interacts with the aspect-ratio toggle or zoom crop control in the image editor.
+ * `label` identifies which control was used.
+ *
+ * This schema describes events sent to Segment from [[OsClickedAspectRatio]]
+ *
+ * @example Aspect ratio toggle
+ * ```
+ * {
+ *   action: "clickedAspectRatio",
+ *   context_module: "imageEditor",
+ *   context_page_owner_type: "studioInstagram",
+ *   label: "image aspect ratio"
+ * }
+ * ```
+ *
+ * @example Zoom/crop
+ * ```
+ * {
+ *   action: "clickedAspectRatio",
+ *   context_module: "imageEditor",
+ *   context_page_owner_type: "studioInstagram",
+ *   label: "image zoom"
+ * }
+ * ```
+ */
+export interface OsClickedAspectRatio {
+  action: OsActionType.clickedAspectRatio
+  context_module: OsContextModule.imageEditor
+  context_page_owner_type: OsOwnerType.studioInstagram
+  label: "image aspect ratio" | "image zoom"
+}
+
+/**
+ * A partner clicks "Cancel" or "Continue" in the Instagram post publish confirmation modal.
+ *
+ * This schema describes events sent to Segment from [[OsClickedPublishConfirmation]]
+ *
+ * @example Continue
+ * ```
+ * {
+ *   action: "clickedPublishConfirmation",
+ *   context_module: "publishConfirmationModal",
+ *   context_page_owner_type: "studioInstagram",
+ *   value: "continue"
+ * }
+ * ```
+ *
+ * @example Cancel
+ * ```
+ * {
+ *   action: "clickedPublishConfirmation",
+ *   context_module: "publishConfirmationModal",
+ *   context_page_owner_type: "studioInstagram",
+ *   value: "cancel"
+ * }
+ * ```
+ */
+export interface OsClickedPublishConfirmation {
+  action: OsActionType.clickedPublishConfirmation
+  context_module: OsContextModule.publishConfirmationModal
+  context_page_owner_type: OsOwnerType.studioInstagram
+  value: "cancel" | "continue"
+}
+
+/**
+ * A partner publishes an Instagram post or downloads a PNG from the Instagram editor.
+ *
+ * `content` is a generic catch-all (same pattern as {@link OsCreatedStudioContent}) holding
+ * post metadata fields: artworkTitle, artistNames, postCaption, collaborators, aspectRatio,
+ * imageCount, etc. It is kept generic so the same event can serve multiple studio surfaces.
+ *
+ * This schema describes events sent to Segment from [[OsCreatedInstagramContent]]
+ *
+ * @example Publish
+ * ```
+ * {
+ *   action: "createdStudioContent",
+ *   context_module: "instagramEditor",
+ *   context_page_owner_type: "studioInstagram",
+ *   value: "instagram post",
+ *   brand_kit: true,
+ *   content: {
+ *     artworkTitle: "Xpto",
+ *     artistNames: ["Jane Doe", "John Doe"],
+ *     postCaption: "FooBar",
+ *     collaborators: ["bonnie", "clyde"],
+ *     aspectRatio: "4:5",
+ *     imageCount: 3
+ *   }
+ * }
+ * ```
+ *
+ * @example PNG download
+ * ```
+ * {
+ *   action: "createdStudioContent",
+ *   context_module: "instagramEditor",
+ *   context_page_owner_type: "studioInstagram",
+ *   value: "instagram png download",
+ *   brand_kit: false,
+ *   content: {
+ *     aspectRatio: "1:1",
+ *     imageCount: 2
+ *   }
+ * }
+ * ```
+ */
+export interface OsCreatedInstagramContent {
+  action: OsActionType.createdStudioContent
+  context_module: OsContextModule.instagramEditor
+  context_page_owner_type: OsOwnerType.studioInstagram
+  value: "instagram post" | "instagram png download"
+  brand_kit: boolean
+  /** Generic catch-all for post metadata included in the created content */
+  content: Record<string, unknown>
+}
+
+export type OsInstagramEditor =
+  | OsClickedAspectRatio
+  | OsClickedConnectModal
+  | OsClickedImageBankImage
+  | OsClickedImageBankManagement
+  | OsClickedPublishConfirmation
+  | OsClickedUploadImageBank
+  | OsCreatedInstagramContent

--- a/src/Schema/os/Events/MaterialsEditor.ts
+++ b/src/Schema/os/Events/MaterialsEditor.ts
@@ -8,6 +8,30 @@ import { OsActionType } from "."
  */
 
 /**
+ * A partner selects "Tearsheet" or "Checklist" from the inventory actions dropdown
+ * to open the Materials editor. The dropdown is surfaced three ways: the artwork's
+ * actions, bulk actions, and the right-click context menu.
+ *
+ * This schema describes events sent to Segment from [[OsClickedActionsDropdown]]
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedActionsDropdown",
+ *   context_module: "actionsDropdown",
+ *   context_page_owner_type: "inventory",
+ *   value: "Tearsheet"
+ * }
+ * ```
+ */
+export interface OsClickedActionsDropdown {
+  action: OsActionType.clickedActionsDropdown
+  context_module: OsContextModule.actionsDropdown
+  context_page_owner_type: OsOwnerType
+  value: "Tearsheet" | "Checklist"
+}
+
+/**
  * A partner clicks "Exit" in the Materials editor header to leave the editor.
  *
  * This schema describes events sent to Segment from [[OsClickedExitEditor]]
@@ -91,6 +115,7 @@ export interface OsCreatedStudioContent {
 }
 
 export type OsMaterialsEditor =
+  | OsClickedActionsDropdown
   | OsClickedBrandKitModal
   | OsClickedExitEditor
   | OsCreatedStudioContent

--- a/src/Schema/os/Events/MaterialsEditor.ts
+++ b/src/Schema/os/Events/MaterialsEditor.ts
@@ -28,7 +28,7 @@ export interface OsClickedActionsDropdown {
   action: OsActionType.clickedActionsDropdown
   context_module: OsContextModule.actionsDropdown
   context_page_owner_type: OsOwnerType
-  value: "Tearsheet" | "Checklist"
+  value: "Tearsheet" | "Checklist" | "Instagram Post"
 }
 
 /**
@@ -49,7 +49,7 @@ export interface OsClickedActionsDropdown {
 export interface OsClickedExitEditor {
   action: OsActionType.clickedExitEditor
   context_module: OsContextModule.editorHeader
-  context_page_owner_type: OsOwnerType.studioMaterials
+  context_page_owner_type: OsOwnerType
   label: string
 }
 
@@ -73,7 +73,7 @@ export interface OsClickedExitEditor {
 export interface OsClickedBrandKitModal {
   action: OsActionType.clickedBrandKitModal
   context_module: OsContextModule.brandKitPromptModal
-  context_page_owner_type: OsOwnerType.studioMaterials
+  context_page_owner_type: OsOwnerType
   label: string
   value: "cancel" | "create"
 }

--- a/src/Schema/os/Events/index.ts
+++ b/src/Schema/os/Events/index.ts
@@ -6,6 +6,7 @@ import {
 } from "./BrandKit"
 import { OsClickEvent } from "./Click"
 import { OsConnectedAppsFlow } from "./ConnectedAppsFlow"
+import { OsInstagramEditor } from "./InstagramEditor"
 import { OsInventoryTable } from "./InventoryTable"
 import { OsMaterialsEditor } from "./MaterialsEditor"
 import { OsMultiAddFlow } from "./MultiAddFlow"
@@ -24,6 +25,7 @@ export type OsEvent =
   | ClickedSaveBrandKit
   | OsConnectedAppsFlow
   | OsClickEvent
+  | OsInstagramEditor
   | OsInventoryTable
   | OsMaterialsEditor
   | OsSubmitEvent
@@ -75,14 +77,19 @@ export enum OsActionType {
   clickedArtworkRow = "clickedArtworkRow",
 
   /**
+   * Corresponds to {@link OsInstagramEditor}
+   */
+  clickedAspectRatio = "clickedAspectRatio",
+
+  /**
+   * Corresponds to {@link OsClickedBrandKitModal}
+   */
+  clickedBrandKitModal = "clickedBrandKitModal",
+
+  /**
    * Corresponds to {@link ClickedCancelBulkEdit}
    */
   clickedCancelBulkEdit = "clickedCancelBulkEdit",
-
-  /**
-   * Corresponds to {@link OsInventoryTable}
-   */
-  clickedEditionSetRow = "clickedEditionSetRow",
 
   /**
    * Corresponds to {@link ClickedConnectAccount}
@@ -95,9 +102,14 @@ export enum OsActionType {
   clickedConnectAccountModal = "clickedConnectAccountModal",
 
   /**
-   * Corresponds to {@link OsClickedBrandKitModal}
+   * Corresponds to {@link OsInstagramEditor}
    */
-  clickedBrandKitModal = "clickedBrandKitModal",
+  clickedConnectModal = "clickedConnectModal",
+
+  /**
+   * Corresponds to {@link OsInventoryTable}
+   */
+  clickedEditionSetRow = "clickedEditionSetRow",
 
   /**
    * Corresponds to {@link ClickedExitDropZone}
@@ -110,9 +122,29 @@ export enum OsActionType {
   clickedExitEditor = "clickedExitEditor",
 
   /**
+   * Corresponds to {@link OsInstagramEditor}
+   */
+  clickedImageBankImage = "clickedImageBankImage",
+
+  /**
+   * Corresponds to {@link OsInstagramEditor}
+   */
+  clickedImageBankManagement = "clickedImageBankManagement",
+
+  /**
    * Corresponds to {@link OsInventoryTable}
    */
   clickedImagesModal = "clickedImagesModal",
+
+  /**
+   * Corresponds to {@link OsInstagramEditor}
+   */
+  clickedPublishConfirmation = "clickedPublishConfirmation",
+
+  /**
+   * Corresponds to {@link OsInstagramEditor}
+   */
+  clickedUploadImageBank = "clickedUploadImageBank",
 
   /**
    * Corresponds to {@link CompletedArtworkImport}
@@ -125,7 +157,7 @@ export enum OsActionType {
   createdImportedArtworks = "createdImportedArtworks",
 
   /**
-   * Corresponds to {@link OsCreatedStudioContent}
+   * Corresponds to {@link OsMaterialsEditor} and {@link OsInstagramEditor}
    */
   createdStudioContent = "createdStudioContent",
 

--- a/src/Schema/os/Values/OsContextModule.ts
+++ b/src/Schema/os/Values/OsContextModule.ts
@@ -18,8 +18,12 @@ export enum OsContextModule {
   distributeModal = "distributeModal",
   documentsModal = "documentsModal",
   editorHeader = "editorHeader",
+  imageBank = "imageBank",
+  imageEditor = "imageEditor",
   imagesModal = "imagesModal",
+  instagramEditor = "instagramEditor",
   materialsEditor = "materialsEditor",
   multiAdd = "multiAdd",
   multiAddReview = "multiAddReview",
+  publishConfirmationModal = "publishConfirmationModal",
 }

--- a/src/Schema/os/Values/OsOwnerType.ts
+++ b/src/Schema/os/Values/OsOwnerType.ts
@@ -9,5 +9,6 @@ export enum OsOwnerType {
   inventory = "inventory",
   list = "list",
   studio = "studio",
+  studioInstagram = "studioInstagram",
   studioMaterials = "studioMaterials",
 }

--- a/src/Schema/os/Values/OsOwnerType.ts
+++ b/src/Schema/os/Values/OsOwnerType.ts
@@ -4,6 +4,7 @@
  * @packageDocumentation
  */
 export enum OsOwnerType {
+  collection = "collection",
   connectedApps = "connectedApps",
   inventory = "inventory",
   list = "list",


### PR DESCRIPTION
Resolves [Analytics / Tracking for Instagram Editor](https://app.notion.com/p/artsy/Analytics-Tracking-for-Instagram-Editor-373cab0764a080859a1ceaa352dc2e08)

## Description

Adds the cohesion tracking schema for the Art OS Instagram Editor feature (Instagram post publishing and PNG download). Built on top of the Materials Editor PR — shares `OsClickedExitEditor` and `OsClickedBrandKitModal` (widened to accept any `OsOwnerType`) and the `OsClickedActionsDropdown` dropdown entry point.

## Changes
- New file `src/Schema/os/Events/InstagramEditor.ts` with the `OsInstagramEditor` union and 7 interfaces:
  - `OsClickedConnectModal` — clicks in the Instagram account connection modal
  - `OsClickedImageBankImage` — selecting/deselecting an image from the Image Bank
  - `OsClickedUploadImageBank` — uploading an image into the Image Bank
  - `OsClickedImageBankManagement` — reordering or removing images from the bank
  - `OsClickedAspectRatio` — aspect-ratio toggle or zoom crop interaction
  - `OsClickedPublishConfirmation` — cancel/continue in the publish confirmation modal
  - `OsCreatedInstagramContent` — post published or PNG downloaded (reuses `createdStudioContent` action)
- `OsActionType` extended with: `clickedAspectRatio`, `clickedConnectModal`, `clickedImageBankImage`, `clickedImageBankManagement`, `clickedPublishConfirmation`, `clickedUploadImageBank`
- `OsContextModule` extended with: `connectModal`, `imageBank`, `imageEditor`, `instagramEditor`, `publishConfirmationModal`
- `OsOwnerType` extended with: `studioInstagram`
- Generic `OwnerType` += `studioInstagram` (for type-safe reuse of `BannerViewed`, `ViewedToast`, `ErrorMessageViewed`)
- `OsClickedActionsDropdown.value` widened to include `"Instagram Post"`
- `OsClickedExitEditor.context_page_owner_type` and `OsClickedBrandKitModal.context_page_owner_type` widened from `studioMaterials` to `OsOwnerType` (shared across editor types)

## Events

**`OsClickedActionsDropdown`** — partner opens Instagram editor from the inventory dropdown
```json
{
  "action": "clickedActionsDropdown",
  "context_module": "actionsDropdown",
  "context_page_owner_type": "inventory",
  "value": "Instagram Post"
}
```

**`OsClickedConnectModal`** — partner clicks connect or cancel in the Instagram account connection modal
```json
{ "action": "clickedConnectModal", "context_module": "connectModal", "context_page_owner_type": "studioInstagram", "label": "instagram", "value": "connect" }
```
```json
{ "action": "clickedConnectModal", "context_module": "connectModal", "context_page_owner_type": "studioInstagram", "label": "instagram", "value": "cancel" }
```

**`OsClickedExitEditor`** — partner clicks Exit in the Instagram editor header
```json
{
  "action": "clickedExitEditor",
  "context_module": "editorHeader",
  "context_page_owner_type": "studioInstagram",
  "label": "instagram editor"
}
```

**`OsClickedBrandKitModal`** — partner clicks cancel or create in the Brand Kit prompt modal
```json
{ "action": "clickedBrandKitModal", "context_module": "brandKitPromptModal", "context_page_owner_type": "studioInstagram", "label": "instagram brand kit modal", "value": "create" }
```
```json
{ "action": "clickedBrandKitModal", "context_module": "brandKitPromptModal", "context_page_owner_type": "studioInstagram", "label": "instagram brand kit modal", "value": "cancel" }
```

**`OsClickedImageBankImage`** — partner selects or deselects an image from the Image Bank
```json
{ "action": "clickedImageBankImage", "context_module": "imageBank", "context_page_owner_type": "studioInstagram", "value": "selected" }
```
```json
{ "action": "clickedImageBankImage", "context_module": "imageBank", "context_page_owner_type": "studioInstagram", "value": "deselected" }
```

**`OsClickedUploadImageBank`** — partner uploads an image into the Image Bank
```json
{
  "action": "clickedUploadImageBank",
  "context_module": "imageBank",
  "context_page_owner_type": "studioInstagram",
  "field": "file",
  "value": "filename.png"
}
```

**`OsClickedImageBankManagement`** — partner reorders or removes an image in the bank management view
```json
{ "action": "clickedImageBankManagement", "context_module": "imageBank", "context_page_owner_type": "studioInstagram", "value": "reorder" }
```
```json
{ "action": "clickedImageBankManagement", "context_module": "imageBank", "context_page_owner_type": "studioInstagram", "value": "remove" }
```

**`OsClickedAspectRatio`** — partner uses the aspect-ratio toggle or zoom crop control
```json
{ "action": "clickedAspectRatio", "context_module": "imageEditor", "context_page_owner_type": "studioInstagram", "label": "image aspect ratio" }
```
```json
{ "action": "clickedAspectRatio", "context_module": "imageEditor", "context_page_owner_type": "studioInstagram", "label": "image zoom" }
```

**`OsClickedPublishConfirmation`** — partner clicks continue or cancel in the publish confirmation modal
```json
{ "action": "clickedPublishConfirmation", "context_module": "publishConfirmationModal", "context_page_owner_type": "studioInstagram", "value": "continue" }
```
```json
{ "action": "clickedPublishConfirmation", "context_module": "publishConfirmationModal", "context_page_owner_type": "studioInstagram", "value": "cancel" }
```

**`OsCreatedInstagramContent`** — partner publishes a post or downloads a PNG
```json
{ "action": "createdStudioContent", "context_module": "instagramEditor", "context_page_owner_type": "studioInstagram", "value": "instagram post", "brand_kit": true, "content": { "artworkTitle": "Xpto", "artistNames": ["Jane Doe"], "postCaption": "FooBar", "collaborators": ["bonnie"], "aspectRatio": "4:5", "imageCount": 3 } }
```
```json
{ "action": "createdStudioContent", "context_module": "instagramEditor", "context_page_owner_type": "studioInstagram", "value": "instagram png download", "brand_kit": false, "content": { "aspectRatio": "1:1", "imageCount": 2 } }
```

## Test Plan
- `yarn type-check` passes
- `yarn lint` passes (0 errors)
- `yarn test` passes (58/58)

Assisted-by: Claude:Sonnet-4.6 [claude-code]
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.368.1--canary.711.15094.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/cohesion@4.368.1--canary.711.15094.0
  # or 
  yarn add @artsy/cohesion@4.368.1--canary.711.15094.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
