### PR TITLE
chore: Remove list from os owner type

### DIFF
--- a/src/Schema/os/Events/__tests__/Click.test.ts
+++ b/src/Schema/os/Events/__tests__/Click.test.ts
@@ -33,14 +33,14 @@ describe("Bulk-action click events", () => {
       action: OsActionType.clickedCancelBulkEdit,
       artwork_ids: ["5d2b5b5d5e5b5d000e1b5b5d", "5d2b5b5d5e5b5d000e1b5b5e"],
       context_module: OsContextModule.bulkEditDrawer,
-      context_page_owner_type: OsOwnerType.list,
+      context_page_owner_type: OsOwnerType.collection,
     }
 
     expect(event).toEqual({
       action: "clickedCancelBulkEdit",
       artwork_ids: ["5d2b5b5d5e5b5d000e1b5b5d", "5d2b5b5d5e5b5d000e1b5b5e"],
       context_module: "bulkEditDrawer",
-      context_page_owner_type: "list",
+      context_page_owner_type: "collection",
     })
   })
 

--- a/src/Schema/os/Values/OsOwnerType.ts
+++ b/src/Schema/os/Values/OsOwnerType.ts
@@ -7,7 +7,6 @@ export enum OsOwnerType {
   collection = "collection",
   connectedApps = "connectedApps",
   inventory = "inventory",
-  list = "list",
   studio = "studio",
   studioInstagram = "studioInstagram",
   studioMaterials = "studioMaterials",


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves []

### Description
This PR removes `list` from OS Owner Type after updating the URLs from List to Collection


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
