### PR TITLE
feat: counter offer tracking

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -2653,7 +2653,7 @@ export interface SubmittedOffer {
 }
 
 /**
- * A user submits a counter offer in response to a gallery counter offer. Does not fire for accept/reject actions.
+ * A user submits a counter offer in response to a gallery counter offer.
  *
  * This schema describes events sent to Segment from [[SubmittedCounterOffer]]
  *
@@ -2669,6 +2669,50 @@ export interface SubmittedOffer {
  */
 export interface SubmittedCounterOffer {
   action: ActionType.submittedCounterOffer
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id: string
+}
+
+/**
+ * A user accepts a gallery's counter offer.
+ *
+ * This schema describes events sent to Segment from [[AcceptedOffer]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "acceptedOffer",
+ *    context_module: "ordersReview",
+ *    context_page_owner_type: "orders-respond",
+ *    context_page_owner_id: "b0ac7b78-ee9b-4fa8-b0ca-b726169db217",
+ *  }
+ * ```
+ */
+export interface AcceptedOffer {
+  action: ActionType.acceptedOffer
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id: string
+}
+
+/**
+ * A user declines a gallery's counter offer.
+ *
+ * This schema describes events sent to Segment from [[DeclinedOffer]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "declinedOffer",
+ *    context_module: "ordersReview",
+ *    context_page_owner_type: "orders-respond",
+ *    context_page_owner_id: "b0ac7b78-ee9b-4fa8-b0ca-b726169db217",
+ *  }
+ * ```
+ */
+export interface DeclinedOffer {
+  action: ActionType.declinedOffer
   context_module: ContextModule
   context_page_owner_type: PageOwnerType
   context_page_owner_id: string

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -812,7 +812,7 @@ export interface ClickedOfferOption {
 }
 
 /**
- * A user clicks a counteroffer option on the counteroffer page
+ * A user clicks a counter offer option on the counter offer page
  *
  * This schema describes events sent to Segment from [[ClickedCounterOfferOption]]
  *
@@ -2653,7 +2653,7 @@ export interface SubmittedOffer {
 }
 
 /**
- * A user submits a counteroffer in response to a gallery counteroffer.
+ * A user submits a counter offer in response to a gallery counter offer.
  *
  * This schema describes events sent to Segment from [[SubmittedCounterOffer]]
  *
@@ -2904,7 +2904,7 @@ export interface ClickedArtistArtworkImage {
 }
 
 /**
- * A user clicks on Terms and Conditions link during checkout or counteroffer flow
+ * A user clicks on Terms and Conditions link during checkout or counter offer flow
  *
  * This schema describes events sent to Segment from [[ClickedTermsAndConditions]]
  *

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -812,6 +812,34 @@ export interface ClickedOfferOption {
 }
 
 /**
+ * A user clicks a counteroffer option on the counteroffer page
+ *
+ * This schema describes events sent to Segment from [[ClickedCounterOfferOption]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedCounterOfferOption",
+ *    context_module: "ordersCounter",
+ *    context_page_owner_type: "orders-respond",
+ *    context_page_owner_id: "dd0cbbb5-300b-4c49-92a1-fed55b077fa9",
+ *    option: "accept" | "counter" | "decline",
+ *    amount?: 2000,
+ *    currency?: "USD"
+ *  }
+ * ```
+ */
+export interface ClickedCounterOfferOption {
+  action: ActionType.clickedCounterOfferOption
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id: string
+  option: "accept" | "counter" | "decline"
+  amount?: number
+  currency?: string
+}
+
+/**
  * A Partner clicks on Artwork weight (without packaging) bar in the artwork edit page
  * in CMS.
  *
@@ -2622,6 +2650,30 @@ export interface SubmittedOffer {
   order_id: string
   flow: string
   credit_card_wallet_type?: string
+}
+
+/**
+ * A user submits a counteroffer in response to a gallery counteroffer.
+ *
+ * This schema describes events sent to Segment from [[SubmittedCounterOffer]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "submittedCounterOffer",
+ *    context_module: "ordersReview",
+ *    context_page_owner_type: "orders-respond",
+ *    context_page_owner_id: "b0ac7b78-ee9b-4fa8-b0ca-b726169db217",
+ *    option: "accept" | "decline" | "counter"
+ *  }
+ * ```
+ */
+export interface SubmittedCounterOffer {
+  action: ActionType.submittedCounterOffer
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id: string
+  option: "accept" | "decline" | "counter"
 }
 
 /**

--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -2653,7 +2653,7 @@ export interface SubmittedOffer {
 }
 
 /**
- * A user submits a counter offer in response to a gallery counter offer.
+ * A user submits a counter offer in response to a gallery counter offer. Does not fire for accept/reject actions.
  *
  * This schema describes events sent to Segment from [[SubmittedCounterOffer]]
  *
@@ -2664,7 +2664,6 @@ export interface SubmittedOffer {
  *    context_module: "ordersReview",
  *    context_page_owner_type: "orders-respond",
  *    context_page_owner_id: "b0ac7b78-ee9b-4fa8-b0ca-b726169db217",
- *    option: "accept" | "decline" | "counter"
  *  }
  * ```
  */
@@ -2673,7 +2672,6 @@ export interface SubmittedCounterOffer {
   context_module: ContextModule
   context_page_owner_type: PageOwnerType
   context_page_owner_id: string
-  option: "accept" | "decline" | "counter"
 }
 
 /**

--- a/src/Schema/Events/Toggle.ts
+++ b/src/Schema/Events/Toggle.ts
@@ -115,7 +115,7 @@ export interface ToggledArtistBio {
 }
 
 /**
- * A user toggles the offer history section on the counteroffer flow
+ * A user toggles the offer history section on the counter offer flow
  *
  * This schema describes events sent to Segment from [[ToggledOfferHistory]]
  *

--- a/src/Schema/Events/Toggle.ts
+++ b/src/Schema/Events/Toggle.ts
@@ -113,3 +113,27 @@ export interface ToggledArtistBio {
   context_page_owner_slug: string
   expand: boolean
 }
+
+/**
+ * A user toggles the offer history section on the counteroffer flow
+ *
+ * This schema describes events sent to Segment from [[ToggledOfferHistory]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "toggledOfferHistory",
+ *    context_module : "ordersCounter",
+ *    context_page_owner_type: "orders-respond",
+ *    context_page_owner_id: "57e60c68-a198-431e-8a02-6ecb01e3a99b",
+ *    expanded: true | false
+ *  }
+ * ```
+ */
+export interface ToggledOfferHistory {
+  action: ActionType.toggledOfferHistory
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id: string
+  expanded: boolean
+}

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -64,6 +64,7 @@ import {
   ClickedCompleteYourProfile,
   ClickedContactGallery,
   ClickedConversationsFilter,
+  ClickedCounterOfferOption,
   ClickedCreateAlert,
   ClickedCV,
   ClickedDeliveryMethod,
@@ -133,6 +134,7 @@ import {
   ClickedViewingRoomCard,
   ClickedViewWork,
   ClickedVisitHelpCenter,
+  SubmittedCounterOffer,
   SubmittedOffer,
   SubmittedOrder,
 } from "./Click"
@@ -316,6 +318,7 @@ import {
   ToggledArtistBio,
   ToggledCollapsibleOrderSummary,
   ToggledNotification,
+  ToggledOfferHistory,
   ToggledSavedSearch,
 } from "./Toggle"
 import { UploadSizeLimitExceeded } from "./UploadSizeLimitExceeded"
@@ -371,6 +374,7 @@ export type Event =
   | ClickedCompleteYourProfile
   | ClickedContactGallery
   | ClickedConversationsFilter
+  | ClickedCounterOfferOption
   | ClickedCreateAlert
   | ClickedCV
   | ClickedDeliveryMethod
@@ -524,6 +528,7 @@ export type Event =
   | ShippingQuoteViewed
   | StartedOnboarding
   | SubmitAnotherArtwork
+  | SubmittedCounterOffer
   | SubmittedOffer
   | SubmittedOrder
   | SuccessfullyLoggedIn
@@ -607,6 +612,7 @@ export type Event =
   | ToggledArtistBio
   | ToggledCollapsibleOrderSummary
   | ToggledNotification
+  | ToggledOfferHistory
   | ToggledPresentationModeSetting
   | ToggledSavedSearch
   | TooltipViewed
@@ -804,6 +810,10 @@ export enum ActionType {
    * Corresponds to {@link ClickedContactGallery}
    */
   clickedContactGallery = "clickedContactGallery",
+  /**
+   * Corresponds to {@link ClickedCounterOfferOption}
+   */
+  clickedCounterOfferOption = "clickedCounterOfferOption",
   /**
    * Corresponds to {@link ClickedCreateAlert}
    */
@@ -1506,6 +1516,10 @@ export enum ActionType {
    */
   submitAnotherArtwork = "submitAnotherArtwork",
   /**
+   * Corresponds to {@link SubmittedCounterOffer}
+   */
+  submittedCounterOffer = "submittedCounterOffer",
+  /**
    * Corresponds to {@link SubmittedOffer}
    */
   submittedOffer = "submittedOffer",
@@ -1894,6 +1908,10 @@ export enum ActionType {
    * Corresponds to {@link ToggledNotification}
    */
   toggledNotification = "toggledNotification",
+  /**
+   * Corresponds to {@link ToggledOfferHistory}
+   */
+  toggledOfferHistory = "toggledOfferHistory",
   /**
    * Corresponds to {@link ToggledPresentationModeSetting}
    */

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -35,6 +35,7 @@ import {
   SuccessfullyLoggedIn,
 } from "./Authentication"
 import {
+  AcceptedOffer,
   CheckedAccountBalance,
   ClickedAddFilters,
   ClickedAddMissingArtworksDetails,
@@ -134,6 +135,7 @@ import {
   ClickedViewingRoomCard,
   ClickedViewWork,
   ClickedVisitHelpCenter,
+  DeclinedOffer,
   SubmittedCounterOffer,
   SubmittedOffer,
   SubmittedOrder,
@@ -331,6 +333,7 @@ import { ViewedVideo } from "./Video"
  * Each event describes one ActionType
  */
 export type Event =
+  | AcceptedOffer
   | AddCollectedArtwork
   | AddedArtworkToArtworkList
   | AddedToAlbum
@@ -462,6 +465,7 @@ export type Event =
   | CreatedAlbum
   | CreatedArtworkList
   | DarkModeOptionUpdated
+  | DeclinedOffer
   | DeleteCollectedArtwork
   | DeletedArtworkList
   | DeletedSavedSearch
@@ -634,6 +638,10 @@ export type Event =
  * Each ActionType corresponds with a table in Redshift.
  */
 export enum ActionType {
+  /**
+   * Corresponds to {@link AcceptedOffer}
+   */
+  acceptedOffer = "acceptedOffer",
   /**
    * Corresponds to {@link AddedArtworkToArtworkList}
    */
@@ -1211,6 +1219,10 @@ export enum ActionType {
    * Corresponds to {@link DarkModeOptionUpdated}
    */
   darkModeOptionUpdated = "darkModeOptionUpdated",
+  /**
+   * Corresponds to {@link DeclinedOffer}
+   */
+  declinedOffer = "declinedOffer",
   /**
    * Corresponds to {@link DeleteCollectedArtwork}
    */


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [AS-5655]

### Description

Adds tracking for **five** new events we introduce: `clickedCounterOfferOption`, `SubmittedCounterOffer` (was a DeprecatedSchema event), `AcceptedOffer`, `DeclinedOffer`, and `ToggledOfferHistory`. We have a deprecated `SubmittedCounterOffer` -> `submitted_counter_offer` event already, so I follow that convention of **two words.**

I also bit the bullet and added an `AcceptedOffer` and `DeclinedOffer` event, **which we previously didn't fire events for.** This gives me better modeling ability in Degas, rather than hacking together something with the most recent `ClickedOfferOption` event and a `ordersReview ClickedOrderProgression` event. 

_I am consciously naming it AcceptedOffer and DeclinedOffer, not AcceptedCounterOffer and DeclinedCounterOffer, to potentially keep it reusable for C2C, which I would want to reuse all existing events for, rather than introducing a new set of C2C specific events. The 5 events: `SubmitOrder`, `SubmitOffer`, `SubmitCounterOffer`, `AcceptedOffer`, `DeclinedOffer` would be the full extent of events needed for our traditional e-com implementation._

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[AS-5655]: https://artsyproduct.atlassian.net/browse/AS-5655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ