### PR TITLE
feat(os): Rename Change Collection to Move to Collection in actions dropdown tracking

### DIFF
--- a/src/Schema/os/Events/InventoryTable.ts
+++ b/src/Schema/os/Events/InventoryTable.ts
@@ -328,14 +328,14 @@ export interface OsClickedActionsDropdown {
    * Top-bar "Add to": "Add to Artsy" | "Add to Collection"
    * Top-bar "Open in Studio": "Tearsheet" | "Checklist" | "Instagram Post" | "Mailchimp Campaign"
    * Top-bar "More": "Delete"
-   * Row/context menu only: "Remove from Artsy" | "Change Collection" | "Remove from Collection" |
+   * Row/context menu only: "Remove from Artsy" | "Move to Collection" | "Remove from Collection" |
    *   "Convert to Edition Set" | "Edit Edition Set" | "Convert to Unique"
    * Distribution: "Distribute to Artsy"
    */
   value:
     | "Add to Artsy"
     | "Add to Collection"
-    | "Change Collection"
+    | "Move to Collection"
     | "Checklist"
     | "Convert to Edition Set"
     | "Convert to Unique"


### PR DESCRIPTION
Resolves [Change the CTA in the action menu from Change Collection to Move To Collection](https://app.notion.com/p/artsy/Change-the-CTA-in-the-action-menu-from-Change-Collection-to-Move-To-Collection-38acab0764a08092b80ac32230aa04ef)


https://github.com/artsy/volt/pull/11660

## Description

Updates the `OsClickedActionsDropdown` `value` literal to match the renamed inventory action-menu CTA ("Move to Collection" replaces "Change Collection").

## Changes
- Replace `"Change Collection"` with `"Move to Collection"` in `OsClickedActionsDropdown.value`
- Update the JSDoc list of row/context menu action values

## Test Plan
- `yarn type-check`
- `yarn test`
- `yarn lint`

Assisted-by: Claude:Sonnet-4.6 [claude-code]


@artsy/amber-devs 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.379.0--canary.725.15494.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/cohesion@4.379.0--canary.725.15494.0
  # or 
  yarn add @artsy/cohesion@4.379.0--canary.725.15494.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
