### PR TITLE
chore: add Add Artwork tracking events

### DIFF
--- a/src/Schema/os/Events/Click.ts
+++ b/src/Schema/os/Events/Click.ts
@@ -34,6 +34,44 @@ export interface ClickedActionsDropdown {
 }
 
 /**
+ * A partner clicks "Unique Work" in the Add Artworks dropdown to create a
+ * single new artwork.
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedAddUniqueWork",
+ *   context_module: "addArtworkDropdown",
+ *   context_page_owner_type: "inventory"
+ * }
+ * ```
+ */
+export interface ClickedAddUniqueWork {
+  action: OsActionType.clickedAddUniqueWork
+  context_module: OsContextModule.addArtworkDropdown
+  context_page_owner_type: OsOwnerType
+}
+
+/**
+ * A partner clicks "Edition Set" in the Add Artworks dropdown to open the
+ * add-edition-set modal.
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedAddEditionSet",
+ *   context_module: "addArtworkDropdown",
+ *   context_page_owner_type: "inventory"
+ * }
+ * ```
+ */
+export interface ClickedAddEditionSet {
+  action: OsActionType.clickedAddEditionSet
+  context_module: OsContextModule.addArtworkDropdown
+  context_page_owner_type: OsOwnerType
+}
+
+/**
  * A partner cancels the bulk-edit drawer without applying changes.
  *
  * @example
@@ -105,6 +143,8 @@ export interface ClickedOpenList {
 
 export type OsClickEvent =
   | ClickedActionsDropdown
+  | ClickedAddUniqueWork
+  | ClickedAddEditionSet
   | ClickedCancelBulkEdit
   | ViewedDivergenceMarker
   | ClickedOpenList

--- a/src/Schema/os/Events/__tests__/Click.test.ts
+++ b/src/Schema/os/Events/__tests__/Click.test.ts
@@ -2,6 +2,8 @@ import { OsContextModule } from "../../Values/OsContextModule"
 import { OsOwnerType } from "../../Values/OsOwnerType"
 import {
   ClickedActionsDropdown,
+  ClickedAddEditionSet,
+  ClickedAddUniqueWork,
   ClickedCancelBulkEdit,
   ClickedOpenList,
 } from "../Click"
@@ -25,6 +27,34 @@ describe("Bulk-action click events", () => {
       context_page_owner_type: "inventory",
       label: "action button",
       value: "Add to Artsy (as Draft)",
+    })
+  })
+
+  it("ClickedAddUniqueWork serializes to the expected shape", () => {
+    const event: ClickedAddUniqueWork = {
+      action: OsActionType.clickedAddUniqueWork,
+      context_module: OsContextModule.addArtworkDropdown,
+      context_page_owner_type: OsOwnerType.inventory,
+    }
+
+    expect(event).toEqual({
+      action: "clickedAddUniqueWork",
+      context_module: "addArtworkDropdown",
+      context_page_owner_type: "inventory",
+    })
+  })
+
+  it("ClickedAddEditionSet serializes to the expected shape", () => {
+    const event: ClickedAddEditionSet = {
+      action: OsActionType.clickedAddEditionSet,
+      context_module: OsContextModule.addArtworkDropdown,
+      context_page_owner_type: OsOwnerType.inventory,
+    }
+
+    expect(event).toEqual({
+      action: "clickedAddEditionSet",
+      context_module: "addArtworkDropdown",
+      context_page_owner_type: "inventory",
     })
   })
 

--- a/src/Schema/os/Events/index.ts
+++ b/src/Schema/os/Events/index.ts
@@ -85,9 +85,19 @@ export enum OsActionType {
   clickedActionsDropdown = "clickedActionsDropdown",
 
   /**
+   * Corresponds to {@link ClickedAddEditionSet}
+   */
+  clickedAddEditionSet = "clickedAddEditionSet",
+
+  /**
    * Corresponds to {@link ClickedAddFromFile}
    */
   clickedAddFromFile = "clickedAddFromFile",
+
+  /**
+   * Corresponds to {@link ClickedAddUniqueWork}
+   */
+  clickedAddUniqueWork = "clickedAddUniqueWork",
 
   /*
    * Corresponds to {@link OsInventoryTable}

--- a/src/Schema/os/Values/OsContextModule.ts
+++ b/src/Schema/os/Values/OsContextModule.ts
@@ -7,6 +7,7 @@
 export enum OsContextModule {
   actionsDropdown = "actionsDropdown",
   addArtistModal = "addArtistModal",
+  addArtworkDropdown = "addArtworkDropdown",
   addLocationModal = "addLocationModal",
   addToListModal = "addToListModal",
   artworkFilters = "artworkFilters",


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [Notion Card]

### Description
This PR adds new tracking events for clicking Add Artwork in the Inventory Table


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)


[Notion Card]: https://app.notion.com/p/artsy/Add-Artwork-dropdown-only-tracks-Import-from-File-click-clicking-Unique-Artwork-Edition-s-390cab0764a080cf8858f3526a88f242
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.382.0--canary.726.15590.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/cohesion@4.382.0--canary.726.15590.0
  # or 
  yarn add @artsy/cohesion@4.382.0--canary.726.15590.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
