### PR TITLE
chore: remove viewedDivergenceMarker event

### DIFF
--- a/src/Schema/os/Events/Click.ts
+++ b/src/Schema/os/Events/Click.ts
@@ -54,30 +54,6 @@ export interface ClickedCancelBulkEdit {
 }
 
 /**
- * The divergence marker appears in a syncable cell when the OS value
- * diverges from the downstream destination value (e.g. Artsy CMS). Fires as an
- * impression when the marker first renders for a given artwork/field combination.
- *
- * @example
- * ```
- * {
- *   action: "viewedDivergenceMarker",
- *   context_module: "artworkTable",
- *   context_page_owner_type: "inventory",
- *   artwork_id: "abc123",
- *   field: "availability"
- * }
- * ```
- */
-export interface ViewedDivergenceMarker {
-  action: OsActionType.viewedDivergenceMarker
-  context_module: OsContextModule.artworkTable
-  context_page_owner_type: OsOwnerType
-  artwork_id: string
-  field: "availability" | "medium" | "price"
-}
-
-/**
  * A partner opens a list, either from the Lists surface (a `ListCard`) or from
  * the recent-lists shortcut on the Inventory surface. `source` distinguishes the
  * two entry points (`listsPage` | `inventory`) so they can be compared.
@@ -106,5 +82,4 @@ export interface ClickedOpenList {
 export type OsClickEvent =
   | ClickedActionsDropdown
   | ClickedCancelBulkEdit
-  | ViewedDivergenceMarker
   | ClickedOpenList

--- a/src/Schema/os/Events/__tests__/DistributionSyncFlow.test.ts
+++ b/src/Schema/os/Events/__tests__/DistributionSyncFlow.test.ts
@@ -1,6 +1,5 @@
 import { OsContextModule } from "../../Values/OsContextModule"
 import { OsOwnerType } from "../../Values/OsOwnerType"
-import { ViewedDivergenceMarker } from "../Click"
 import { OsActionType } from "../index"
 import { EditedInventoryField } from "../InventoryTable"
 import { CompletedArtworkDistribution } from "../Submit"
@@ -66,24 +65,6 @@ describe("Distribution Sync & Mapping flow events", () => {
       success_count: 10,
       total_artworks: 12,
       value: "partial",
-    })
-  })
-
-  it("ViewedDivergenceMarker serializes to the expected shape", () => {
-    const event: ViewedDivergenceMarker = {
-      action: OsActionType.viewedDivergenceMarker,
-      artwork_id: "abc123",
-      context_module: OsContextModule.artworkTable,
-      context_page_owner_type: OsOwnerType.inventory,
-      field: "availability",
-    }
-
-    expect(event).toEqual({
-      action: "viewedDivergenceMarker",
-      artwork_id: "abc123",
-      context_module: "artworkTable",
-      context_page_owner_type: "inventory",
-      field: "availability",
     })
   })
 })

--- a/src/Schema/os/Events/index.ts
+++ b/src/Schema/os/Events/index.ts
@@ -324,9 +324,4 @@ export enum OsActionType {
    * Corresponds to {@link UpdatedList}
    */
   updatedList = "updatedList",
-
-  /**
-   * Corresponds to {@link ViewedDivergenceMarker}
-   */
-  viewedDivergenceMarker = "viewedDivergenceMarker",
 }


### PR DESCRIPTION
The type of this PR is: **Enhancement**

Removes the `viewedDivergenceMarker` ArtOS tracking event per the [Remove Divergencemarkerviewed](https://app.notion.com/p/390cab0764a080969dbfc12795d8ec8f) ticket.

### Description

Removes the `ViewedDivergenceMarker` interface, its member from the `OsClickEvent` union, the `viewedDivergenceMarker` member from the `OsActionType` enum, and the corresponding serialization test. The volt emission of this event is removed in a companion PR.

### PR Checklist (tick all before merging)

- [x] If I've added a new file to the tree I've exported it from the common `index.ts` — N/A, removal only
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs — N/A, removal only
- [x] No platform-specific terminology has been used outside of `click` and `tap`

Created with Claude Code
@artsy/amber-devs 