### PR TITLE
feat: add edition_set_id to EditedInventoryField event

### DIFF
--- a/src/Schema/os/Events/InventoryTable.ts
+++ b/src/Schema/os/Events/InventoryTable.ts
@@ -371,6 +371,7 @@ export interface OsClickedActionsDropdown {
  *   context_page_owner_type: "inventory",
  *   destination: ["artsy"],
  *   artwork_id: "abc123",
+ *   edition_set_id: "xyz789",
  *   field: "availability",
  *   did_push_to_cms: false
  * }
@@ -383,6 +384,8 @@ export interface EditedInventoryField {
   /** Downstream destinations the value was pushed to (e.g. ["artsy"]) */
   destination: string[]
   artwork_id: string
+  /** The edition set the edited value belongs to, when the edit targets an edition set row */
+  edition_set_id?: string
   field: "availability" | "medium" | "price"
   /** false e.g. for "Not For Sale" (OS-only value that does not push to the destination) */
   did_push_to_cms: boolean

--- a/src/Schema/os/Events/__tests__/DistributionSyncFlow.test.ts
+++ b/src/Schema/os/Events/__tests__/DistributionSyncFlow.test.ts
@@ -44,6 +44,30 @@ describe("Distribution Sync & Mapping flow events", () => {
     })
   })
 
+  it("EditedInventoryField includes edition_set_id when editing an edition set row", () => {
+    const event: EditedInventoryField = {
+      action: OsActionType.editedInventoryField,
+      artwork_id: "abc123",
+      context_module: OsContextModule.artworkTable,
+      context_page_owner_type: OsOwnerType.inventory,
+      destination: ["artsy"],
+      did_push_to_cms: true,
+      edition_set_id: "xyz789",
+      field: "price",
+    }
+
+    expect(event).toEqual({
+      action: "editedInventoryField",
+      artwork_id: "abc123",
+      context_module: "artworkTable",
+      context_page_owner_type: "inventory",
+      destination: ["artsy"],
+      did_push_to_cms: true,
+      edition_set_id: "xyz789",
+      field: "price",
+    })
+  })
+
   it("CompletedArtworkDistribution serializes to the expected shape", () => {
     const event: CompletedArtworkDistribution = {
       action: OsActionType.completedArtworkDistribution,


### PR DESCRIPTION
Adds an optional \`edition_set_id\` field to the \`EditedInventoryField\` ArtOS event so edition-set edits can report which edition set the edited value belongs to.

### Description
- Adds \`edition_set_id?: string\` to the \`EditedInventoryField\` interface (\`src/Schema/os/Events/InventoryTable.ts\`), documented as the edition set the edited value belongs to when the edit targets an edition set row.
- Updates the TypeDoc \`@example\` block to include \`edition_set_id\`.
- Adds a test case covering the event with \`edition_set_id\` set.

The field is optional since only edition-set row edits carry it; regular artwork edits omit it.

Ref: [Notion — Add edition_set_id EditedInventoryField and send it from edition events](https://app.notion.com/p/392cab0764a0807fbc55d6954b11d10d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
cc @artsy/amber-devs 