### PR TITLE
fix: allow CompletedArtworkDistribution to fire on any owner type

### DIFF
--- a/src/Schema/os/Events/Submit.ts
+++ b/src/Schema/os/Events/Submit.ts
@@ -105,7 +105,7 @@ export interface DistributedArtworks {
 export interface CompletedArtworkDistribution {
   action: OsActionType.completedArtworkDistribution
   context_module: OsContextModule.artworkTable
-  context_page_owner_type: OsOwnerType.inventory
+  context_page_owner_type: OsOwnerType
   /** Destination marketplaces (currently Artsy only; extensible) */
   destination: string[]
   total_artworks: number

--- a/src/Schema/os/Events/__tests__/DistributionSyncFlow.test.ts
+++ b/src/Schema/os/Events/__tests__/DistributionSyncFlow.test.ts
@@ -91,4 +91,28 @@ describe("Distribution Sync & Mapping flow events", () => {
       value: "partial",
     })
   })
+
+  it("CompletedArtworkDistribution serializes to the expected shape for a collection", () => {
+    const event: CompletedArtworkDistribution = {
+      action: OsActionType.completedArtworkDistribution,
+      context_module: OsContextModule.artworkTable,
+      context_page_owner_type: OsOwnerType.collection,
+      destination: ["artsy"],
+      skipped_count: 2,
+      success_count: 10,
+      total_artworks: 12,
+      value: "partial",
+    }
+
+    expect(event).toEqual({
+      action: "completedArtworkDistribution",
+      context_module: "artworkTable",
+      context_page_owner_type: "collection",
+      destination: ["artsy"],
+      skipped_count: 2,
+      success_count: 10,
+      total_artworks: 12,
+      value: "partial",
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- `CompletedArtworkDistribution` was hardcoded to `context_page_owner_type: OsOwnerType.inventory`, so it could only be fired from the inventory surface.
- Widen the field to `OsOwnerType` (matching the sibling `DistributedArtworks` event) so the event can also fire from `collection`, consistent with the ArtOS convention of differentiating surfaces via owner type rather than a module field.
- Added a test asserting the event serializes correctly with `context_page_owner_type: "collection"`.

🤖  Created with Claude Code
@artsy/amber-devs 