### PR TITLE
chore: add oneTap account creation Intent

### DIFF
--- a/src/Schema/Values/Intent.ts
+++ b/src/Schema/Values/Intent.ts
@@ -19,6 +19,7 @@ export enum Intent {
   seePriceAuctionRecords = "seePriceAuctionRecords",
   seeRealizedPriceAuctionRecords = "seeRealizedPriceAuctionRecords",
   makeOffer = "makeOffer",
+  oneTap = "oneTap",
   registerToBid = "registerToBid",
   requestConditionReport = "requestConditionReport",
   saveArtwork = "saveArtwork",
@@ -50,6 +51,7 @@ export type AuthIntent =
   | Intent.seePriceAuctionRecords
   | Intent.seeRealizedPriceAuctionRecords
   | Intent.makeOffer
+  | Intent.oneTap
   | Intent.registerToBid
   | Intent.requestConditionReport
   | Intent.saveArtwork


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->



### Description

Need: our Account Creation Intent [graph](https://artsy.looker.com/explore/analytics/session_experiments?qid=rygT6fDT3K5NYiwGcc7Ovo&origin_space=1276&toggle=dat,vis) is having a strong `signup` bucket, coming from one tap. We want this graph to split out One Tap into its own group, because this is our main way of actually grouping user intents. 

<img width="1197" height="483" alt="Screenshot 2026-07-07 at 10 50 01 AM" src="https://github.com/user-attachments/assets/d5df8329-58f3-4f27-bb2b-074fb5f70079" />

**Solution 1, discussed on call:** Add a new `AuthIntent` for `oneTap`, which will now log this as its own intent rather than `signup`. (Implemented in this PR)


**Solution 2, PREFERRED after thinking more about it:** Manually account for this in `analytics.users` [model](https://github.com/artsy/degas/blob/dfbbae5b6f804caa5c307f7c490ef8f50fc095de/dbt/models/analytics/core_tables/users.sql#L319) using the `coalesced_account_creation_intent` field, which is where this graph is coming from. I will now order as: `one_tap, account_creation_intent, sign_up_intent`
- Why: the raw event table will still maintain the `signup` intent, which really is the user's intent, but this graph will display `one-tap` as its own separate category. 
<br>
<img width="904" height="52" alt="Screenshot 2026-07-07 at 10 54 11 AM" src="https://github.com/user-attachments/assets/0a972070-1048-4e2b-93aa-4531f929064f" />
<br>
<br>
@brainbicycle let me know what you think about solution 2. It solves the business need while keeping our `intent` field the same—which feels preferable because `one-tap` would have been recorded twice otherwise.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [ ] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [ ] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
