### PR TITLE
feat: add "fairs" as a SelectedFromDrawerSubject

### DIFF
--- a/src/Schema/Events/Favorites.ts
+++ b/src/Schema/Events/Favorites.ts
@@ -74,8 +74,9 @@ export interface TappedArtworkList {
  */
 export type SelectedFromDrawerSubject =
   | "artists"
-  | "galleries"
   | "categories"
+  | "fairs"
+  | "galleries"
   | "shows"
 export interface SelectedFromDrawer {
   action: ActionType.selectedFromDrawer


### PR DESCRIPTION
The type of this PR is: **Enhancement**

### Description

Eigen is adding a "Fairs" option to the Favorites → Follows drawer, alongside the existing Artists/Galleries/Categories/Shows options. `SelectedFromDrawerSubject` (used by `selectedFromDrawer`) didn't include `"fairs"`, so Eigen couldn't type the tracking call for selecting it without an unsafe cast. This adds `"fairs"` to the union.

No other tracking gap was found — cohesion already has full `FollowedFair`/`UnfollowedFair` event support for the actual follow/unfollow action.

### PR Checklist (tick all before merging)

- [x] N/A — no new file added, just a type union extension in an existing, already-exported file
- [x] N/A — no new interface added
- [x] No platform-specific terminology used outside of `click`/`tap`


---
_Generated by [Claude Code](https://claude.ai/code/session_01N93KEHv3nKGRZXqwLTf2S9)_