### PR TITLE
feat: add curator-note tracking (has_curator_note + tapped/clicked events)

### DIFF
--- a/src/Schema/Events/Click.ts
+++ b/src/Schema/Events/Click.ts
@@ -184,6 +184,7 @@ export interface ClickedArtistSeriesGroup extends ClickedEntityGroup {
  */
 export interface ClickedArtworkGroup extends ClickedEntityGroup {
   action: ActionType.clickedArtworkGroup
+  has_curator_note?: boolean
   signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
@@ -722,6 +723,7 @@ export interface ClickedMainArtworkGrid {
   destination_page_owner_type: PageOwnerType
   destination_page_owner_id: string
   destination_page_owner_slug: string
+  has_curator_note?: boolean
   type: "thumbnail" | "immersive"
   position?: number
   sort?: string
@@ -729,6 +731,35 @@ export interface ClickedMainArtworkGrid {
   signal_lot_watcher_count?: number
   signal_bid_count?: number
   label?: string
+}
+
+/**
+ * A user clicks a curator's note shown on an artwork within a marketing collection
+ * (opens a dialog with the full note). Web.
+ *
+ * This schema describes events sent to Segment from [[clickedCuratorNote]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "clickedCuratorNote",
+ *    context_module: "artworkGrid",
+ *    context_page_owner_type: "collection",
+ *    context_page_owner_id: "5f80bfefe8d808000ea212c1",
+ *    context_page_owner_slug: "curators-picks-emerging",
+ *    artwork_id: "53188b0d8b3b8192bb0005ae",
+ *    artwork_slug: "damien-hirst-anatomy-of-an-angel"
+ *  }
+ * ```
+ */
+export interface ClickedCuratorNote {
+  action: ActionType.clickedCuratorNote
+  artwork_id?: string
+  artwork_slug?: string
+  context_module: ContextModule
+  context_page_owner_type: PageOwnerType
+  context_page_owner_id?: string
+  context_page_owner_slug?: string
 }
 
 /**

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -180,6 +180,7 @@ export interface TappedHeroUnitGroup extends TappedEntityGroup {
  */
 export interface TappedArtworkGroup extends TappedEntityGroup {
   action: ActionType.tappedArtworkGroup
+  has_curator_note?: boolean
   signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
@@ -587,6 +588,7 @@ export interface TappedMainArtworkGrid {
   destination_screen_owner_type: ScreenOwnerType
   destination_screen_owner_id: string
   destination_screen_owner_slug: string
+  has_curator_note?: boolean
   position?: number
   sort?: string
   type: "thumbnail"
@@ -594,6 +596,35 @@ export interface TappedMainArtworkGrid {
   signal_label?: string
   signal_lot_watcher_count?: number
   signal_bid_count?: number
+}
+
+/**
+ * A user taps a curator's note shown on an artwork within a marketing collection
+ * (opens a sheet with the full note). iOS.
+ *
+ * This schema describes events sent to Segment from [[tappedCuratorNote]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedCuratorNote",
+ *    context_module: "collectionRail",
+ *    context_screen_owner_type: "collection",
+ *    context_screen_owner_id: "5f80bfefe8d808000ea212c1",
+ *    context_screen_owner_slug: "curators-picks-emerging",
+ *    artwork_id: "53188b0d8b3b8192bb0005ae",
+ *    artwork_slug: "damien-hirst-anatomy-of-an-angel"
+ *  }
+ * ```
+ */
+export interface TappedCuratorNote {
+  action: ActionType.tappedCuratorNote
+  artwork_id?: string
+  artwork_slug?: string
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  context_screen_owner_id?: string
+  context_screen_owner_slug?: string
 }
 
 /**

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -67,6 +67,7 @@ import {
   ClickedConversationsFilter,
   ClickedCounterOfferOption,
   ClickedCreateAlert,
+  ClickedCuratorNote,
   ClickedCV,
   ClickedDeliveryMethod,
   ClickedDismissInquiry,
@@ -287,6 +288,7 @@ import {
   TappedConsignmentInquiry,
   TappedContactGallery,
   TappedCreateAlert,
+  TappedCuratorNote,
   TappedExploreGroup,
   TappedFairCard,
   TappedFairGroup,
@@ -379,6 +381,7 @@ export type Event =
   | ClickedConversationsFilter
   | ClickedCounterOfferOption
   | ClickedCreateAlert
+  | ClickedCuratorNote
   | ClickedCV
   | ClickedDeliveryMethod
   | ClickedDismissInquiry
@@ -566,6 +569,7 @@ export type Event =
   | TappedConsignmentInquiry
   | TappedContactGallery
   | TappedCreateAlert
+  | TappedCuratorNote
   | TappedEditedProfile
   | TappedExploreGroup
   | TappedExploreMyCollection
@@ -826,6 +830,10 @@ export enum ActionType {
    * Corresponds to {@link ClickedCreateAlert}
    */
   clickedCreateAlert = "clickedCreateAlert",
+  /**
+   * Corresponds to {@link ClickedCuratorNote}
+   */
+  clickedCuratorNote = "clickedCuratorNote",
   /**
    * Corresponds to {@link ClickedDeliveryMethod}
    */
@@ -1672,6 +1680,10 @@ export enum ActionType {
    * Corresponds to {@link TappedCreateAlertHeader}
    */
   tappedCreateAlertHeader = "tappedCreateAlertHeader",
+  /**
+   * Corresponds to {@link TappedCuratorNote}
+   */
+  tappedCuratorNote = "tappedCuratorNote",
   /**
    * Corresponds to {@link TappedEditedProfile}
    */


### PR DESCRIPTION
### What

Analytics schema for the curator's note feature on marketing collections (eigen artsy/eigen#13770, force artsy/force#17490).

**1. `has_curator_note?: boolean` on the artwork tap/click events** — so we can tell whether a tapped/clicked artwork carried a curator note (to compare performance of artworks with vs. without notes):
- `TappedArtworkGroup`, `TappedMainArtworkGrid` (iOS / eigen)
- `ClickedArtworkGroup`, `ClickedMainArtworkGrid` (web / force)

**2. New events for tapping/clicking the note itself** (opens the sheet/dialog):
- `TappedCuratorNote` (iOS / eigen) + `ActionType.tappedCuratorNote`
- `ClickedCuratorNote` (web / force) + `ActionType.clickedCuratorNote`

Each carries `context_module`, the collection as `context_*_owner_*`, and the artwork as `artwork_id`/`artwork_slug`.

All new fields are optional and follow the existing snake_case convention; the new events mirror the standalone-event pattern (e.g. `TappedAskSpecialist`). Wired into the `ActionType` enum, the import block, and the `Event` union in `src/Schema/Events/index.ts`.

### Consumers

Once this is published (canary or released) and eigen/force bump `@artsy/cohesion`, they'll reference these to:
- set `has_curator_note` on the artwork tap/click payloads, and
- fire `TappedCuratorNote`/`ClickedCuratorNote` when the note badge is tapped/clicked.

### Not merging yet

Draft — opened for review, not to be merged. The consuming eigen/force PRs reference these symbols and will type-check once this publishes and they bump the dependency.

### CI note

Authored without `node_modules`, so `yarn type-check` / `yarn lint` / `yarn test` were not run locally — please rely on CI. In particular `yarn lint` (sort-keys-fix / simple-import-sort) may reorder the new enum member / import / union entries; I placed them in best-guess alphabetical position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2iHtPiKHN91ghgcJWyJjC)_