### PR TITLE
feat: add searchPageResults context module

### DIFF
--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -242,6 +242,7 @@ export enum ContextModule {
   relatedWorksRail = "relatedWorksRail",
   saves = "saves",
   saveWorksCTA = "saveWorksCTA",
+  searchPageResults = "searchPageResults",
   sell = "sell",
   sellFooter = "sellFooter",
   sellHeader = "sellHeader",


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

I plan to add tracking for `SearchedWithNoResults` on the `/search` page itself (not just from the autosuggest input). Right now we only fire it from the autosuggest search input as the user types (context_module: topTab / context_owner_type: home). But we also want to know when someone actually lands on /search and gets an empty result set.

`context_owner_type` was easy - the user is now on the search page, so `search`. But I got a bit confused about which `context_module` to use, since there's currently no search-related module in the enum at all, and the event doesn't really fire from a discrete component here. It fires because the results area rendered empty.

I had two ideas:

1. Reuse header - treat it as "the search bar in the header triggered this". But then you can't tell the autosuggest case apart from the empty /search page by context_module alone (only by context_owner_type - maybe ok actually).
2. Add a new `searchResults` module - semantically it's the results area that came back empty, so context_module: searchResults + context_owner_type: search is a clean self-describing pair. I preferred this option, but open for other opinions.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
