### PR TITLE
feat: Add OsReorderedInventoryTableColumns event for column drag-reorder

### DIFF
--- a/src/Schema/os/Events/InventoryTable.ts
+++ b/src/Schema/os/Events/InventoryTable.ts
@@ -394,6 +394,40 @@ export interface EditedInventoryField {
   did_push_to_cms: boolean
 }
 
+/**
+ * A partner drags a column header and drops it in a new position in the inventory
+ * table. Fires once per completed drop (not per drag-over). The new order is
+ * persisted to localStorage, keyed per browser/device.
+ *
+ * This schema describes events sent to Segment from [[OsReorderedInventoryTableColumns]]
+ *
+ * @example
+ * ```
+ * {
+ *   action: "reorderedInventoryTableColumns",
+ *   context_module: "artworkTable",
+ *   context_page_owner_type: "inventory",
+ *   column: "price",
+ *   from_index: 4,
+ *   to_index: 1,
+ *   new_order: ["title", "price", "artist", "medium", "dimensions"]
+ * }
+ * ```
+ */
+export interface OsReorderedInventoryTableColumns {
+  action: OsActionType.reorderedInventoryTableColumns
+  context_module: OsContextModule.artworkTable
+  context_page_owner_type: OsOwnerType
+  /** The key of the column that was dragged */
+  column: string
+  /** 0-based position among reorderable (non-pinned) columns before the move */
+  from_index: number
+  /** 0-based position among reorderable (non-pinned) columns after the move */
+  to_index: number
+  /** Full resulting column key order (reorderable columns only, pinned columns excluded) */
+  new_order: string[]
+}
+
 export type OsInventoryTable =
   | EditedInventoryField
   | OsAddedArtist
@@ -405,4 +439,5 @@ export type OsInventoryTable =
   | OsClickedImagesModal
   | OsEditedArtworkField
   | OsRemovedArtworkDocument
+  | OsReorderedInventoryTableColumns
   | OsSavedArtworkImages

--- a/src/Schema/os/Events/__tests__/InventoryTable.test.ts
+++ b/src/Schema/os/Events/__tests__/InventoryTable.test.ts
@@ -1,0 +1,28 @@
+import { OsContextModule } from "../../Values/OsContextModule"
+import { OsOwnerType } from "../../Values/OsOwnerType"
+import { OsActionType } from "../index"
+import { OsReorderedInventoryTableColumns } from "../InventoryTable"
+
+describe("Inventory Table events", () => {
+  it("OsReorderedInventoryTableColumns serializes to the expected shape", () => {
+    const event: OsReorderedInventoryTableColumns = {
+      action: OsActionType.reorderedInventoryTableColumns,
+      column: "price",
+      context_module: OsContextModule.artworkTable,
+      context_page_owner_type: OsOwnerType.inventory,
+      from_index: 4,
+      new_order: ["title", "price", "artist", "medium", "dimensions"],
+      to_index: 1,
+    }
+
+    expect(event).toEqual({
+      action: "reorderedInventoryTableColumns",
+      column: "price",
+      context_module: "artworkTable",
+      context_page_owner_type: "inventory",
+      from_index: 4,
+      new_order: ["title", "price", "artist", "medium", "dimensions"],
+      to_index: 1,
+    })
+  })
+})

--- a/src/Schema/os/Events/index.ts
+++ b/src/Schema/os/Events/index.ts
@@ -296,6 +296,11 @@ export enum OsActionType {
   removedArtworksFromList = "removedArtworksFromList",
 
   /**
+   * Corresponds to {@link OsInventoryTable}
+   */
+  reorderedInventoryTableColumns = "reorderedInventoryTableColumns",
+
+  /**
    * Corresponds to {@link ResumedArtworkImport}
    */
   resumedArtworkImport = "resumedArtworkImport",


### PR DESCRIPTION
https://artsy.slack.com/archives/C05F8TNKGAV/p1786355586924309

Tracking for [artsy/volt#11863](https://github.com/artsy/volt/pull/11863) — drag-and-drop column reordering in the ArtOS inventory table.

## Description

Adds a single event fired once per completed column drag-drop. Volt's implementation persists the new order to localStorage; this event captures the moved column, its position before/after the move, and the full resulting column order for adoption/pattern analysis.

```
/**
 * A partner drags a column header and drops it in a new position in the inventory
 * table. Fires once per completed drop (not per drag-over). The new order is
 * persisted to localStorage, keyed per browser/device.
 *
 * This schema describes events sent to Segment from [[OsReorderedInventoryTableColumns]]
 *
 * @example
 * ```
 * {
 *   action: "reorderedInventoryTableColumns",
 *   context_module: "artworkTable",
 *   context_page_owner_type: "inventory",
 *   column: "price",
 *   from_index: 4,
 *   to_index: 1,
 *   new_order: ["title", "price", "artist", "medium", "dimensions"]
 * }
 * ```
 */
```

## Changes
- Add `OsReorderedInventoryTableColumns` to `src/Schema/os/Events/InventoryTable.ts`
- Add `reorderedInventoryTableColumns` to `OsActionType`
- Add serialization test

## Test Plan
- `yarn type-check`, `yarn test`, `yarn lint` all pass

Assisted-by: Claude:Sonnet-5 [claude-code]

@artsy/amber-devs 