### PR TITLE
feat: Add ArtOS column visibility tracking events

### DIFF
--- a/src/Schema/os/Events/Click.ts
+++ b/src/Schema/os/Events/Click.ts
@@ -92,25 +92,6 @@ export interface ClickedCancelBulkEdit {
 }
 
 /**
- * A partner clicks the column-visibility dropdown icon in the inventory table
- * header to open the show/hide column panel.
- *
- * @example
- * ```
- * {
- *   action: "clickedColumnVisibilityDropdown",
- *   context_module: "artworkTable",
- *   context_page_owner_type: "inventory"
- * }
- * ```
- */
-export interface ClickedColumnVisibilityDropdown {
-  action: OsActionType.clickedColumnVisibilityDropdown
-  context_module: OsContextModule.artworkTable
-  context_page_owner_type: OsOwnerType
-}
-
-/**
  * A partner opens a list, either from the Lists surface (a `ListCard`) or from
  * the recent-lists shortcut on the Inventory surface. `source` distinguishes the
  * two entry points (`listsPage` | `inventory`) so they can be compared.
@@ -141,5 +122,4 @@ export type OsClickEvent =
   | ClickedAddEditionSet
   | ClickedAddUniqueWork
   | ClickedCancelBulkEdit
-  | ClickedColumnVisibilityDropdown
   | ClickedOpenList

--- a/src/Schema/os/Events/Click.ts
+++ b/src/Schema/os/Events/Click.ts
@@ -92,6 +92,25 @@ export interface ClickedCancelBulkEdit {
 }
 
 /**
+ * A partner clicks the column-visibility dropdown icon in the inventory table
+ * header to open the show/hide column panel.
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedColumnVisibilityDropdown",
+ *   context_module: "artworkTable",
+ *   context_page_owner_type: "inventory"
+ * }
+ * ```
+ */
+export interface ClickedColumnVisibilityDropdown {
+  action: OsActionType.clickedColumnVisibilityDropdown
+  context_module: OsContextModule.artworkTable
+  context_page_owner_type: OsOwnerType
+}
+
+/**
  * A partner opens a list, either from the Lists surface (a `ListCard`) or from
  * the recent-lists shortcut on the Inventory surface. `source` distinguishes the
  * two entry points (`listsPage` | `inventory`) so they can be compared.
@@ -119,7 +138,8 @@ export interface ClickedOpenList {
 
 export type OsClickEvent =
   | ClickedActionsDropdown
-  | ClickedAddUniqueWork
   | ClickedAddEditionSet
+  | ClickedAddUniqueWork
   | ClickedCancelBulkEdit
+  | ClickedColumnVisibilityDropdown
   | ClickedOpenList

--- a/src/Schema/os/Events/InventoryTable.ts
+++ b/src/Schema/os/Events/InventoryTable.ts
@@ -394,6 +394,40 @@ export interface EditedInventoryField {
   did_push_to_cms: boolean
 }
 
+/**
+ * A partner drags a column header and drops it in a new position in the inventory
+ * table. Fires once per completed drop (not per drag-over). The new order is
+ * persisted to localStorage, keyed per browser/device.
+ *
+ * This schema describes events sent to Segment from [[OsReorderedInventoryTableColumns]]
+ *
+ * @example
+ * ```
+ * {
+ *   action: "reorderedInventoryTableColumns",
+ *   context_module: "artworkTable",
+ *   context_page_owner_type: "inventory",
+ *   column: "price",
+ *   from_index: 4,
+ *   to_index: 1,
+ *   new_order: ["title", "price", "artist", "medium", "dimensions"]
+ * }
+ * ```
+ */
+export interface OsReorderedInventoryTableColumns {
+  action: OsActionType.reorderedInventoryTableColumns
+  context_module: OsContextModule.artworkTable
+  context_page_owner_type: OsOwnerType
+  /** The key of the column that was dragged */
+  column: string
+  /** 0-based position among reorderable (non-pinned) columns before the move */
+  from_index: number
+  /** 0-based position among reorderable (non-pinned) columns after the move */
+  to_index: number
+  /** Full resulting column key order (reorderable columns only, pinned columns excluded) */
+  new_order: string[]
+}
+
 export type OsInventoryTable =
   | EditedInventoryField
   | OsAddedArtist
@@ -405,4 +439,5 @@ export type OsInventoryTable =
   | OsClickedImagesModal
   | OsEditedArtworkField
   | OsRemovedArtworkDocument
+  | OsReorderedInventoryTableColumns
   | OsSavedArtworkImages

--- a/src/Schema/os/Events/InventoryTable.ts
+++ b/src/Schema/os/Events/InventoryTable.ts
@@ -1,10 +1,7 @@
 import { OsContextModule } from "../Values/OsContextModule"
 import { OsOwnerType } from "../Values/OsOwnerType"
 import { OsActionType } from "."
-import {
-  ChangedInventoryTableColumnVisibility,
-  HidInventoryTableColumn,
-} from "./Submit"
+import { ChangedInventoryTableColumnVisibility } from "./Submit"
 
 /**
  * Schemas describing Art OS Inventory Table events
@@ -435,7 +432,6 @@ export interface OsReorderedInventoryTableColumns {
 export type OsInventoryTable =
   | ChangedInventoryTableColumnVisibility
   | EditedInventoryField
-  | HidInventoryTableColumn
   | OsAddedArtist
   | OsAddedArtworkDocument
   | OsAddedLocation

--- a/src/Schema/os/Events/InventoryTable.ts
+++ b/src/Schema/os/Events/InventoryTable.ts
@@ -1,6 +1,10 @@
 import { OsContextModule } from "../Values/OsContextModule"
 import { OsOwnerType } from "../Values/OsOwnerType"
 import { OsActionType } from "."
+import {
+  ChangedInventoryTableColumnVisibility,
+  HidInventoryTableColumn,
+} from "./Submit"
 
 /**
  * Schemas describing Art OS Inventory Table events
@@ -429,7 +433,9 @@ export interface OsReorderedInventoryTableColumns {
 }
 
 export type OsInventoryTable =
+  | ChangedInventoryTableColumnVisibility
   | EditedInventoryField
+  | HidInventoryTableColumn
   | OsAddedArtist
   | OsAddedArtworkDocument
   | OsAddedLocation

--- a/src/Schema/os/Events/Submit.ts
+++ b/src/Schema/os/Events/Submit.ts
@@ -367,18 +367,33 @@ export interface UpdatedEditionSet {
 }
 
 /**
- * A partner applies column visibility changes by clicking "Done" in the
- * column-settings dropdown panel. Fires on persist to localStorage.
- * `hidden_columns` and `visible_columns` capture the resulting state.
+ * A partner changes column visibility either by clicking "Done" in the
+ * column-visibility dropdown panel or by right-clicking a header and selecting
+ * "Hide column". Fires on persist to localStorage. `mode` distinguishes the two
+ * entry points: `dropdown` for the panel's "Done" button, `header` for the
+ * right-click context menu.
  *
- * @example
+ * @example Dropdown mode
  * ```
  * {
  *   action: "changedInventoryTableColumnVisibility",
  *   context_module: "artworkTable",
  *   context_page_owner_type: "inventory",
  *   hidden_columns: ["inventoryId", "provenance"],
- *   visible_columns: ["title", "artist", "price", "medium", "dimensions"]
+ *   visible_columns: ["title", "artist", "price", "medium", "dimensions"],
+ *   mode: "dropdown"
+ * }
+ * ```
+ *
+ * @example Header context menu mode
+ * ```
+ * {
+ *   action: "changedInventoryTableColumnVisibility",
+ *   context_module: "artworkTable",
+ *   context_page_owner_type: "inventory",
+ *   hidden_columns: ["provenance"],
+ *   visible_columns: ["title", "artist", "price", "medium", "dimensions"],
+ *   mode: "header"
  * }
  * ```
  */
@@ -387,6 +402,7 @@ export interface ChangedInventoryTableColumnVisibility {
   context_module: OsContextModule.artworkTable
   context_page_owner_type: OsOwnerType
   hidden_columns: string[]
+  mode: "dropdown" | "header"
   visible_columns: string[]
 }
 
@@ -413,27 +429,6 @@ export interface ConvertedArtworkToUnique {
   value: "confirm" | "cancel"
 }
 
-/**
- * A partner hides a column immediately via the right-click header context menu
- * ("Hide column"). Fires on persist to localStorage.
- *
- * @example
- * ```
- * {
- *   action: "hidInventoryTableColumn",
- *   context_module: "artworkTable",
- *   context_page_owner_type: "inventory",
- *   column: "provenance"
- * }
- * ```
- */
-export interface HidInventoryTableColumn {
-  action: OsActionType.hidInventoryTableColumn
-  context_module: OsContextModule.artworkTable
-  context_page_owner_type: OsOwnerType
-  column: string
-}
-
 export type OsSubmitEvent =
   | AddedArtworksToList
   | BulkEditedArtworks
@@ -450,7 +445,6 @@ export type OsSubmitEvent =
   | DistributedArtworks
   | DistributedArtworks
   | DistributedList
-  | HidInventoryTableColumn
   | MovedArtworksBetweenLists
   | RemovedArtworksFromList
   | UpdatedEditionSet

--- a/src/Schema/os/Events/Submit.ts
+++ b/src/Schema/os/Events/Submit.ts
@@ -367,6 +367,30 @@ export interface UpdatedEditionSet {
 }
 
 /**
+ * A partner applies column visibility changes by clicking "Done" in the
+ * column-settings dropdown panel. Fires on persist to localStorage.
+ * `hidden_columns` and `visible_columns` capture the resulting state.
+ *
+ * @example
+ * ```
+ * {
+ *   action: "changedInventoryTableColumnVisibility",
+ *   context_module: "artworkTable",
+ *   context_page_owner_type: "inventory",
+ *   hidden_columns: ["inventoryId", "provenance"],
+ *   visible_columns: ["title", "artist", "price", "medium", "dimensions"]
+ * }
+ * ```
+ */
+export interface ChangedInventoryTableColumnVisibility {
+  action: OsActionType.changedInventoryTableColumnVisibility
+  context_module: OsContextModule.artworkTable
+  context_page_owner_type: OsOwnerType
+  hidden_columns: string[]
+  visible_columns: string[]
+}
+
+/**
  * A partner confirms or cancels reverting an edition-set artwork to a unique
  * work in the Convert to Unique confirmation modal.
  *
@@ -389,10 +413,32 @@ export interface ConvertedArtworkToUnique {
   value: "confirm" | "cancel"
 }
 
+/**
+ * A partner hides a column immediately via the right-click header context menu
+ * ("Hide column"). Fires on persist to localStorage.
+ *
+ * @example
+ * ```
+ * {
+ *   action: "hidInventoryTableColumn",
+ *   context_module: "artworkTable",
+ *   context_page_owner_type: "inventory",
+ *   column: "provenance"
+ * }
+ * ```
+ */
+export interface HidInventoryTableColumn {
+  action: OsActionType.hidInventoryTableColumn
+  context_module: OsContextModule.artworkTable
+  context_page_owner_type: OsOwnerType
+  column: string
+}
+
 export type OsSubmitEvent =
   | AddedArtworksToList
   | BulkEditedArtworks
   | BulkEditedArtworks
+  | ChangedInventoryTableColumnVisibility
   | CompletedArtworkDistribution
   | ConvertedArtworkToUnique
   | CreatedEditionSet
@@ -404,6 +450,7 @@ export type OsSubmitEvent =
   | DistributedArtworks
   | DistributedArtworks
   | DistributedList
+  | HidInventoryTableColumn
   | MovedArtworksBetweenLists
   | RemovedArtworksFromList
   | UpdatedEditionSet

--- a/src/Schema/os/Events/__tests__/Click.test.ts
+++ b/src/Schema/os/Events/__tests__/Click.test.ts
@@ -5,7 +5,6 @@ import {
   ClickedAddEditionSet,
   ClickedAddUniqueWork,
   ClickedCancelBulkEdit,
-  ClickedColumnVisibilityDropdown,
   ClickedOpenList,
 } from "../Click"
 import { OsActionType } from "../index"
@@ -72,20 +71,6 @@ describe("Bulk-action click events", () => {
       artwork_ids: ["5d2b5b5d5e5b5d000e1b5b5d", "5d2b5b5d5e5b5d000e1b5b5e"],
       context_module: "bulkEditDrawer",
       context_page_owner_type: "collection",
-    })
-  })
-
-  it("ClickedColumnVisibilityDropdown serializes to the expected shape", () => {
-    const event: ClickedColumnVisibilityDropdown = {
-      action: OsActionType.clickedColumnVisibilityDropdown,
-      context_module: OsContextModule.artworkTable,
-      context_page_owner_type: OsOwnerType.inventory,
-    }
-
-    expect(event).toEqual({
-      action: "clickedColumnVisibilityDropdown",
-      context_module: "artworkTable",
-      context_page_owner_type: "inventory",
     })
   })
 

--- a/src/Schema/os/Events/__tests__/Click.test.ts
+++ b/src/Schema/os/Events/__tests__/Click.test.ts
@@ -5,6 +5,7 @@ import {
   ClickedAddEditionSet,
   ClickedAddUniqueWork,
   ClickedCancelBulkEdit,
+  ClickedColumnVisibilityDropdown,
   ClickedOpenList,
 } from "../Click"
 import { OsActionType } from "../index"
@@ -71,6 +72,20 @@ describe("Bulk-action click events", () => {
       artwork_ids: ["5d2b5b5d5e5b5d000e1b5b5d", "5d2b5b5d5e5b5d000e1b5b5e"],
       context_module: "bulkEditDrawer",
       context_page_owner_type: "collection",
+    })
+  })
+
+  it("ClickedColumnVisibilityDropdown serializes to the expected shape", () => {
+    const event: ClickedColumnVisibilityDropdown = {
+      action: OsActionType.clickedColumnVisibilityDropdown,
+      context_module: OsContextModule.artworkTable,
+      context_page_owner_type: OsOwnerType.inventory,
+    }
+
+    expect(event).toEqual({
+      action: "clickedColumnVisibilityDropdown",
+      context_module: "artworkTable",
+      context_page_owner_type: "inventory",
     })
   })
 

--- a/src/Schema/os/Events/__tests__/InventoryTable.test.ts
+++ b/src/Schema/os/Events/__tests__/InventoryTable.test.ts
@@ -1,0 +1,28 @@
+import { OsContextModule } from "../../Values/OsContextModule"
+import { OsOwnerType } from "../../Values/OsOwnerType"
+import { OsActionType } from "../index"
+import { OsReorderedInventoryTableColumns } from "../InventoryTable"
+
+describe("Inventory Table events", () => {
+  it("OsReorderedInventoryTableColumns serializes to the expected shape", () => {
+    const event: OsReorderedInventoryTableColumns = {
+      action: OsActionType.reorderedInventoryTableColumns,
+      column: "price",
+      context_module: OsContextModule.artworkTable,
+      context_page_owner_type: OsOwnerType.inventory,
+      from_index: 4,
+      new_order: ["title", "price", "artist", "medium", "dimensions"],
+      to_index: 1,
+    }
+
+    expect(event).toEqual({
+      action: "reorderedInventoryTableColumns",
+      column: "price",
+      context_module: "artworkTable",
+      context_page_owner_type: "inventory",
+      from_index: 4,
+      new_order: ["title", "price", "artist", "medium", "dimensions"],
+      to_index: 1,
+    })
+  })
+})

--- a/src/Schema/os/Events/__tests__/Submit.test.ts
+++ b/src/Schema/os/Events/__tests__/Submit.test.ts
@@ -4,6 +4,7 @@ import { OsActionType } from "../index"
 import {
   AddedArtworksToList,
   BulkEditedArtworks,
+  ChangedInventoryTableColumnVisibility,
   ConvertedArtworkToUnique,
   CreatedEditionSet,
   CreatedList,
@@ -11,6 +12,7 @@ import {
   DeletedList,
   DistributedArtworks,
   DistributedList,
+  HidInventoryTableColumn,
   MovedArtworksBetweenLists,
   RemovedArtworksFromList,
   UpdatedEditionSet,
@@ -293,6 +295,42 @@ describe("List submit events", () => {
       list_id: "5d2b5b5d5e5b5d000e1b5b5d",
       list_type: "SHOW",
       partner_show_id: "5d2b5b5d5e5b5d000e1b5b5e",
+    })
+  })
+})
+
+describe("Inventory table column submit events", () => {
+  it("ChangedInventoryTableColumnVisibility serializes to the expected shape", () => {
+    const event: ChangedInventoryTableColumnVisibility = {
+      action: OsActionType.changedInventoryTableColumnVisibility,
+      context_module: OsContextModule.artworkTable,
+      context_page_owner_type: OsOwnerType.inventory,
+      hidden_columns: ["inventoryId", "provenance"],
+      visible_columns: ["title", "artist", "price", "medium", "dimensions"],
+    }
+
+    expect(event).toEqual({
+      action: "changedInventoryTableColumnVisibility",
+      context_module: "artworkTable",
+      context_page_owner_type: "inventory",
+      hidden_columns: ["inventoryId", "provenance"],
+      visible_columns: ["title", "artist", "price", "medium", "dimensions"],
+    })
+  })
+
+  it("HidInventoryTableColumn serializes to the expected shape", () => {
+    const event: HidInventoryTableColumn = {
+      action: OsActionType.hidInventoryTableColumn,
+      column: "provenance",
+      context_module: OsContextModule.artworkTable,
+      context_page_owner_type: OsOwnerType.inventory,
+    }
+
+    expect(event).toEqual({
+      action: "hidInventoryTableColumn",
+      column: "provenance",
+      context_module: "artworkTable",
+      context_page_owner_type: "inventory",
     })
   })
 })

--- a/src/Schema/os/Events/__tests__/Submit.test.ts
+++ b/src/Schema/os/Events/__tests__/Submit.test.ts
@@ -12,7 +12,6 @@ import {
   DeletedList,
   DistributedArtworks,
   DistributedList,
-  HidInventoryTableColumn,
   MovedArtworksBetweenLists,
   RemovedArtworksFromList,
   UpdatedEditionSet,
@@ -300,12 +299,13 @@ describe("List submit events", () => {
 })
 
 describe("Inventory table column submit events", () => {
-  it("ChangedInventoryTableColumnVisibility serializes to the expected shape", () => {
+  it("ChangedInventoryTableColumnVisibility (dropdown mode) serializes to the expected shape", () => {
     const event: ChangedInventoryTableColumnVisibility = {
       action: OsActionType.changedInventoryTableColumnVisibility,
       context_module: OsContextModule.artworkTable,
       context_page_owner_type: OsOwnerType.inventory,
       hidden_columns: ["inventoryId", "provenance"],
+      mode: "dropdown",
       visible_columns: ["title", "artist", "price", "medium", "dimensions"],
     }
 
@@ -314,23 +314,28 @@ describe("Inventory table column submit events", () => {
       context_module: "artworkTable",
       context_page_owner_type: "inventory",
       hidden_columns: ["inventoryId", "provenance"],
+      mode: "dropdown",
       visible_columns: ["title", "artist", "price", "medium", "dimensions"],
     })
   })
 
-  it("HidInventoryTableColumn serializes to the expected shape", () => {
-    const event: HidInventoryTableColumn = {
-      action: OsActionType.hidInventoryTableColumn,
-      column: "provenance",
+  it("ChangedInventoryTableColumnVisibility (header mode) serializes to the expected shape", () => {
+    const event: ChangedInventoryTableColumnVisibility = {
+      action: OsActionType.changedInventoryTableColumnVisibility,
       context_module: OsContextModule.artworkTable,
       context_page_owner_type: OsOwnerType.inventory,
+      hidden_columns: ["provenance"],
+      mode: "header",
+      visible_columns: ["title", "artist", "price", "medium", "dimensions"],
     }
 
     expect(event).toEqual({
-      action: "hidInventoryTableColumn",
-      column: "provenance",
+      action: "changedInventoryTableColumnVisibility",
       context_module: "artworkTable",
       context_page_owner_type: "inventory",
+      hidden_columns: ["provenance"],
+      mode: "header",
+      visible_columns: ["title", "artist", "price", "medium", "dimensions"],
     })
   })
 })

--- a/src/Schema/os/Events/index.ts
+++ b/src/Schema/os/Events/index.ts
@@ -45,14 +45,14 @@ export type OsEvent =
  */
 export enum OsActionType {
   /**
-   * Corresponds to {@link OsFilterSortSearch}
-   */
-  appliedFilter = "appliedFilter",
-
-  /**
    * Corresponds to {@link OsInventoryTable}
    */
   addedArtist = "addedArtist",
+
+  /**
+   * Corresponds to {@link OsFilterSortSearch}
+   */
+  appliedFilter = "appliedFilter",
 
   /**
    * Corresponds to {@link OsInventoryTable}
@@ -78,6 +78,11 @@ export enum OsActionType {
    * Corresponds to {@link CancelledArtworkImport}
    */
   cancelledArtworkImport = "cancelledArtworkImport",
+
+  /**
+   * Corresponds to {@link ChangedInventoryTableColumnVisibility}
+   */
+  changedInventoryTableColumnVisibility = "changedInventoryTableColumnVisibility",
 
   /**
    * Corresponds to {@link OsClickedActionsDropdown}
@@ -120,9 +125,9 @@ export enum OsActionType {
   clickedCancelBulkEdit = "clickedCancelBulkEdit",
 
   /**
-   * Corresponds to {@link OsFilterSortSearch}
+   * Corresponds to {@link ClickedColumnVisibilityDropdown}
    */
-  clickedFilterDrawer = "clickedFilterDrawer",
+  clickedColumnVisibilityDropdown = "clickedColumnVisibilityDropdown",
 
   /**
    * Corresponds to {@link ClickedConnectAccount}
@@ -133,6 +138,11 @@ export enum OsActionType {
    * Corresponds to {@link ClickedConnectAccountModal}
    */
   clickedConnectAccountModal = "clickedConnectAccountModal",
+
+  /**
+   * Corresponds to {@link OsFilterSortSearch}
+   */
+  clickedFilterDrawer = "clickedFilterDrawer",
 
   /**
    * Corresponds to {@link OsInstagramEditor}
@@ -269,6 +279,11 @@ export enum OsActionType {
    * Corresponds to {@link EditedInventoryField}
    */
   editedInventoryField = "editedInventoryField",
+
+  /**
+   * Corresponds to {@link HidInventoryTableColumn}
+   */
+  hidInventoryTableColumn = "hidInventoryTableColumn",
 
   /**
    * Corresponds to {@link MovedArtworksBetweenLists}

--- a/src/Schema/os/Events/index.ts
+++ b/src/Schema/os/Events/index.ts
@@ -125,11 +125,6 @@ export enum OsActionType {
   clickedCancelBulkEdit = "clickedCancelBulkEdit",
 
   /**
-   * Corresponds to {@link ClickedColumnVisibilityDropdown}
-   */
-  clickedColumnVisibilityDropdown = "clickedColumnVisibilityDropdown",
-
-  /**
    * Corresponds to {@link ClickedConnectAccount}
    */
   clickedConnectAccount = "clickedConnectAccount",
@@ -279,11 +274,6 @@ export enum OsActionType {
    * Corresponds to {@link EditedInventoryField}
    */
   editedInventoryField = "editedInventoryField",
-
-  /**
-   * Corresponds to {@link HidInventoryTableColumn}
-   */
-  hidInventoryTableColumn = "hidInventoryTableColumn",
 
   /**
    * Corresponds to {@link MovedArtworksBetweenLists}

--- a/src/Schema/os/Events/index.ts
+++ b/src/Schema/os/Events/index.ts
@@ -296,6 +296,11 @@ export enum OsActionType {
   removedArtworksFromList = "removedArtworksFromList",
 
   /**
+   * Corresponds to {@link OsInventoryTable}
+   */
+  reorderedInventoryTableColumns = "reorderedInventoryTableColumns",
+
+  /**
    * Corresponds to {@link ResumedArtworkImport}
    */
   resumedArtworkImport = "resumedArtworkImport",


### PR DESCRIPTION
https://artsy.slack.com/archives/C05F8TNKGAV/p1786630438616759

## Summary

Add tracking event for the inventory table column show/hide feature (artsy/volt#11917):

- **ChangedInventoryTableColumnVisibility** — Fires when column visibility changes are persisted to localStorage. `mode` field distinguishes the trigger:
  - `mode: "dropdown"` — Applied via "Done" button in the column-visibility panel
  - `mode: "header"` — Applied via right-click "Hide column" on header

Reuses existing `OsReorderedInventoryTableColumns` for drag-reorder tracking.

## Example

**Dropdown mode** (panel "Done" button):
```json
{
  "action": "changedInventoryTableColumnVisibility",
  "context_module": "artworkTable",
  "context_page_owner_type": "inventory",
  "hidden_columns": ["inventoryId", "provenance"],
  "visible_columns": ["title", "artist", "price", "medium", "dimensions"],
  "mode": "dropdown"
}
```

**Header mode** (right-click context menu):
```json
{
  "action": "changedInventoryTableColumnVisibility",
  "context_module": "artworkTable",
  "context_page_owner_type": "inventory",
  "hidden_columns": ["provenance"],
  "visible_columns": ["title", "artist", "price", "medium", "dimensions"],
  "mode": "header"
}
```

@artsy/amber-devs 

🤖 Generated with [Claude Code](https://claude.com/claude-code)