### PR TITLE
feat: add private vr events

### DIFF
--- a/src/Schema/os/Events/InstagramEditor.ts
+++ b/src/Schema/os/Events/InstagramEditor.ts
@@ -167,7 +167,11 @@ export interface OsClickedAspectRatio {
 }
 
 /**
- * A partner clicks "Cancel" or "Continue" in the Instagram post publish confirmation modal.
+ * A partner clicks "Cancel" or "Continue" in a publish confirmation modal.
+ *
+ * Shared across surfaces rather than Instagram-only: the Private Viewing Room
+ * editor sends it from its "Share without a passcode?" confirmation, which is
+ * why `context_page_owner_type` accepts any {@link OsOwnerType}.
  *
  * This schema describes events sent to Segment from [[OsClickedPublishConfirmation]]
  *
@@ -194,7 +198,7 @@ export interface OsClickedAspectRatio {
 export interface OsClickedPublishConfirmation {
   action: OsActionType.clickedPublishConfirmation
   context_module: OsContextModule.publishConfirmationModal
-  context_page_owner_type: OsOwnerType.studioInstagram
+  context_page_owner_type: OsOwnerType
   value: "cancel" | "continue"
 }
 

--- a/src/Schema/os/Events/PrivateViewingRoom.ts
+++ b/src/Schema/os/Events/PrivateViewingRoom.ts
@@ -1,0 +1,147 @@
+import { OsContextModule } from "../Values/OsContextModule"
+import { OsOwnerType } from "../Values/OsOwnerType"
+import { OsActionType } from "."
+
+/**
+ * Schemas describing Art OS Private Viewing Room events
+ *
+ * A Private Viewing Room is a password-protected web page a gallery generates
+ * from a collection and shares with a client by link. It is a `PartnerList`
+ * with `listType: "PRIVATE_VIEWING_ROOM"`, so the generic list events
+ * (`createdList`, `addedArtworksToList`, …) also fire for it — these schemas
+ * cover only what is specific to sharing a room.
+ *
+ * Note the `privateViewingRoom` prefix throughout: `OwnerType.viewingRoom` and
+ * `ContextModule.viewingRoom` already exist for the consumer-facing viewing
+ * rooms on artsy.net, and both feed the same `context_page_owner_type` /
+ * `context_module` columns. Reusing the bare name would merge two unrelated
+ * products downstream.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * A partner opens the Private Viewing Room editor, either to share a room for
+ * the first time or to update one already shared.
+ *
+ * `trigger` separates the three entry points: the Share button on an unshared
+ * room, the Manage panel on a shared one, and the banner shown when a shared
+ * room's artworks have drifted from the snapshot viewers currently see. Pairing
+ * the banner trigger with its `bannerViewed` impression is the only way to tell
+ * whether that nudge gets acted on.
+ *
+ * Fires on open, not on the first edit, so it is the denominator for
+ * share-completion rate when paired with {@link SharedPrivateViewingRoom}.
+ *
+ * This schema describes events sent to Segment from
+ * [[ClickedSharePrivateViewingRoom]]
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedSharePrivateViewingRoom",
+ *   context_module: "listDetail",
+ *   context_page_owner_type: "privateViewingRoom",
+ *   list_id: "5d2b5b5d5e5b5d000e1b5b5d",
+ *   value: "share",
+ *   trigger: "shareButton"
+ * }
+ * ```
+ */
+export interface ClickedSharePrivateViewingRoom {
+  action: OsActionType.clickedSharePrivateViewingRoom
+  context_module: OsContextModule.listDetail
+  context_page_owner_type: OsOwnerType.privateViewingRoom
+  list_id: string
+  value: "share" | "update"
+  trigger: "shareButton" | "manageMenu" | "updateBanner"
+}
+
+/**
+ * A partner successfully shares a Private Viewing Room — past this point the
+ * link works and the client can open the room. Fires from the publish
+ * mutation's success callback, so it means the room is live rather than that
+ * the gallery intended to share it.
+ *
+ * `value` distinguishes a first share from an update to an already-shared room.
+ * Every share goes through the editor: the stale-room banner opens the editor
+ * rather than republishing in one click, so the gallery always reviews the
+ * preview before viewers see a change.
+ *
+ * `has_passcode` is a boolean by design. The passcode itself is a shared access
+ * credential and is never sent.
+ *
+ * `content` is a generic catch-all holding the header choices and the artwork
+ * detail fields the gallery chose to expose — field names only, never their
+ * values. Kept generic on purpose, matching {@link OsCreatedStudioContent}, so
+ * it is parsed ad-hoc downstream rather than maintained as a rigid set of
+ * top-level fields.
+ *
+ * This schema describes events sent to Segment from
+ * [[SharedPrivateViewingRoom]]
+ *
+ * @example
+ * ```
+ * {
+ *   action: "sharedPrivateViewingRoom",
+ *   context_module: "privateViewingRoomEditor",
+ *   context_page_owner_type: "privateViewingRoom",
+ *   value: "shared",
+ *   list_id: "5d2b5b5d5e5b5d000e1b5b5d",
+ *   artwork_count: 12,
+ *   has_passcode: true,
+ *   brand_kit: true,
+ *   content: {
+ *     showGalleryName: true,
+ *     hasHeading: true,
+ *     hasDescription: false,
+ *     artworkFields: ["artistName", "artworkTitle", "year", "medium"]
+ *   }
+ * }
+ * ```
+ */
+export interface SharedPrivateViewingRoom {
+  action: OsActionType.sharedPrivateViewingRoom
+  context_module: OsContextModule.privateViewingRoomEditor
+  context_page_owner_type: OsOwnerType.privateViewingRoom
+  value: "shared" | "updated"
+  list_id: string
+  artwork_count: number
+  /** Whether a passcode is set. The passcode itself is never sent */
+  has_passcode: boolean
+  brand_kit: boolean
+  /** Generic catch-all for the header choices and exposed artwork detail fields */
+  content: Record<string, unknown>
+}
+
+/**
+ * A partner stops sharing a Private Viewing Room, which immediately breaks the
+ * link the client was given. `trigger` distinguishes the Manage panel on the
+ * collection page from the editor's own footer.
+ *
+ * This schema describes events sent to Segment from
+ * [[StoppedSharingPrivateViewingRoom]]
+ *
+ * @example
+ * ```
+ * {
+ *   action: "stoppedSharingPrivateViewingRoom",
+ *   context_module: "listDetail",
+ *   context_page_owner_type: "privateViewingRoom",
+ *   list_id: "5d2b5b5d5e5b5d000e1b5b5d",
+ *   trigger: "manageMenu"
+ * }
+ * ```
+ */
+export interface StoppedSharingPrivateViewingRoom {
+  action: OsActionType.stoppedSharingPrivateViewingRoom
+  context_module: OsContextModule.listDetail
+  context_page_owner_type: OsOwnerType.privateViewingRoom
+  list_id: string
+  trigger: "manageMenu" | "editor"
+}
+
+export type OsPrivateViewingRoom =
+  | ClickedSharePrivateViewingRoom
+  | SharedPrivateViewingRoom
+  | StoppedSharingPrivateViewingRoom

--- a/src/Schema/os/Events/__tests__/PrivateViewingRoom.test.ts
+++ b/src/Schema/os/Events/__tests__/PrivateViewingRoom.test.ts
@@ -1,0 +1,138 @@
+import { OsContextModule } from "../../Values/OsContextModule"
+import { OsOwnerType } from "../../Values/OsOwnerType"
+import { OsActionType } from "../index"
+import {
+  ClickedSharePrivateViewingRoom,
+  SharedPrivateViewingRoom,
+  StoppedSharingPrivateViewingRoom,
+} from "../PrivateViewingRoom"
+
+describe("Private viewing room events", () => {
+  it("ClickedSharePrivateViewingRoom serializes to the expected shape", () => {
+    const event: ClickedSharePrivateViewingRoom = {
+      action: OsActionType.clickedSharePrivateViewingRoom,
+      context_module: OsContextModule.listDetail,
+      context_page_owner_type: OsOwnerType.privateViewingRoom,
+      list_id: "5d2b5b5d5e5b5d000e1b5b5d",
+      trigger: "shareButton",
+      value: "share",
+    }
+
+    expect(event).toEqual({
+      action: "clickedSharePrivateViewingRoom",
+      context_module: "listDetail",
+      context_page_owner_type: "privateViewingRoom",
+      list_id: "5d2b5b5d5e5b5d000e1b5b5d",
+      trigger: "shareButton",
+      value: "share",
+    })
+  })
+
+  it("ClickedSharePrivateViewingRoom distinguishes the stale-room banner", () => {
+    const event: ClickedSharePrivateViewingRoom = {
+      action: OsActionType.clickedSharePrivateViewingRoom,
+      context_module: OsContextModule.listDetail,
+      context_page_owner_type: OsOwnerType.privateViewingRoom,
+      list_id: "5d2b5b5d5e5b5d000e1b5b5d",
+      trigger: "updateBanner",
+      value: "update",
+    }
+
+    expect(event).toEqual({
+      action: "clickedSharePrivateViewingRoom",
+      context_module: "listDetail",
+      context_page_owner_type: "privateViewingRoom",
+      list_id: "5d2b5b5d5e5b5d000e1b5b5d",
+      trigger: "updateBanner",
+      value: "update",
+    })
+  })
+
+  it("SharedPrivateViewingRoom serializes a first share to the expected shape", () => {
+    const event: SharedPrivateViewingRoom = {
+      action: OsActionType.sharedPrivateViewingRoom,
+      artwork_count: 12,
+      brand_kit: true,
+      content: {
+        artworkFields: ["artistName", "artworkTitle", "year", "medium"],
+        hasDescription: false,
+        hasHeading: true,
+        showGalleryName: true,
+      },
+      context_module: OsContextModule.privateViewingRoomEditor,
+      context_page_owner_type: OsOwnerType.privateViewingRoom,
+      has_passcode: true,
+      list_id: "5d2b5b5d5e5b5d000e1b5b5d",
+      value: "shared",
+    }
+
+    expect(event).toEqual({
+      action: "sharedPrivateViewingRoom",
+      artwork_count: 12,
+      brand_kit: true,
+      content: {
+        artworkFields: ["artistName", "artworkTitle", "year", "medium"],
+        hasDescription: false,
+        hasHeading: true,
+        showGalleryName: true,
+      },
+      context_module: "privateViewingRoomEditor",
+      context_page_owner_type: "privateViewingRoom",
+      has_passcode: true,
+      list_id: "5d2b5b5d5e5b5d000e1b5b5d",
+      value: "shared",
+    })
+  })
+
+  it("SharedPrivateViewingRoom reports an unprotected room as has_passcode: false", () => {
+    const event: SharedPrivateViewingRoom = {
+      action: OsActionType.sharedPrivateViewingRoom,
+      artwork_count: 3,
+      brand_kit: false,
+      content: {
+        artworkFields: [],
+        hasDescription: false,
+        hasHeading: false,
+        showGalleryName: false,
+      },
+      context_module: OsContextModule.privateViewingRoomEditor,
+      context_page_owner_type: OsOwnerType.privateViewingRoom,
+      has_passcode: false,
+      list_id: "5d2b5b5d5e5b5d000e1b5b5d",
+      value: "updated",
+    }
+
+    expect(event.has_passcode).toEqual(false)
+    expect(event.value).toEqual("updated")
+  })
+
+  it("StoppedSharingPrivateViewingRoom serializes to the expected shape", () => {
+    const event: StoppedSharingPrivateViewingRoom = {
+      action: OsActionType.stoppedSharingPrivateViewingRoom,
+      context_module: OsContextModule.listDetail,
+      context_page_owner_type: OsOwnerType.privateViewingRoom,
+      list_id: "5d2b5b5d5e5b5d000e1b5b5d",
+      trigger: "manageMenu",
+    }
+
+    expect(event).toEqual({
+      action: "stoppedSharingPrivateViewingRoom",
+      context_module: "listDetail",
+      context_page_owner_type: "privateViewingRoom",
+      list_id: "5d2b5b5d5e5b5d000e1b5b5d",
+      trigger: "manageMenu",
+    })
+  })
+
+  it("StoppedSharingPrivateViewingRoom distinguishes the editor footer", () => {
+    const event: StoppedSharingPrivateViewingRoom = {
+      action: OsActionType.stoppedSharingPrivateViewingRoom,
+      context_module: OsContextModule.listDetail,
+      context_page_owner_type: OsOwnerType.privateViewingRoom,
+      list_id: "5d2b5b5d5e5b5d000e1b5b5d",
+      trigger: "editor",
+    }
+
+    expect(event.trigger).toEqual("editor")
+  })
+})

--- a/src/Schema/os/Events/index.ts
+++ b/src/Schema/os/Events/index.ts
@@ -13,6 +13,7 @@ import { OsMailchimpEditor } from "./MailchimpEditor"
 import { OsMaterialsEditor } from "./MaterialsEditor"
 import { OsMultiAddFlow } from "./MultiAddFlow"
 import { OsOnboardingFlow } from "./OnboardingFlow"
+import { OsPrivateViewingRoom } from "./PrivateViewingRoom"
 import { OsSubmitEvent } from "./Submit"
 import { OsToggleEvent } from "./Toggle"
 
@@ -35,6 +36,7 @@ export type OsEvent =
   | OsMaterialsEditor
   | OsMultiAddFlow
   | OsOnboardingFlow
+  | OsPrivateViewingRoom
   | OsSubmitEvent
   | OsToggleEvent
 
@@ -185,6 +187,11 @@ export enum OsActionType {
   clickedPublishConfirmation = "clickedPublishConfirmation",
 
   /**
+   * Corresponds to {@link ClickedSharePrivateViewingRoom}
+   */
+  clickedSharePrivateViewingRoom = "clickedSharePrivateViewingRoom",
+
+  /**
    * Corresponds to {@link ClickedShowMeHow}
    */
   clickedShowMeHow = "clickedShowMeHow",
@@ -321,6 +328,11 @@ export enum OsActionType {
   searchedArtworks = "searchedArtworks",
 
   /**
+   * Corresponds to {@link SharedPrivateViewingRoom}
+   */
+  sharedPrivateViewingRoom = "sharedPrivateViewingRoom",
+
+  /**
    * Corresponds to {@link OsFilterSortSearch}
    */
   sortedColumn = "sortedColumn",
@@ -329,6 +341,11 @@ export enum OsActionType {
    * Corresponds to {@link StartedArtworkImport}
    */
   startedArtworkImport = "startedArtworkImport",
+
+  /**
+   * Corresponds to {@link StoppedSharingPrivateViewingRoom}
+   */
+  stoppedSharingPrivateViewingRoom = "stoppedSharingPrivateViewingRoom",
 
   /**
    * Corresponds to {@link ToggledDistributionSync}

--- a/src/Schema/os/Values/OsContextModule.ts
+++ b/src/Schema/os/Values/OsContextModule.ts
@@ -35,6 +35,7 @@ export enum OsContextModule {
   multiAdd = "multiAdd",
   multiAddReview = "multiAddReview",
   onboardingFlow = "onboardingFlow",
+  privateViewingRoomEditor = "privateViewingRoomEditor",
   publishConfirmationModal = "publishConfirmationModal",
   sendConfirmationModal = "sendConfirmationModal",
   tableActions = "tableActions",

--- a/src/Schema/os/Values/OsOwnerType.ts
+++ b/src/Schema/os/Values/OsOwnerType.ts
@@ -7,6 +7,7 @@ export enum OsOwnerType {
   collection = "collection",
   connectedApps = "connectedApps",
   inventory = "inventory",
+  privateViewingRoom = "privateViewingRoom",
   studio = "studio",
   studioInstagram = "studioInstagram",
   studioMailchimp = "studioMailchimp",


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CO-]

### Description
Adding data for ArtOS private viewing rooms tracking 
<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)

cc @artsy/amber-devs 