### PR TITLE
feat: Adds new label for show missing details click event

### DIFF
--- a/src/Schema/CMS/Events/CompletenessScoreFlow.ts
+++ b/src/Schema/CMS/Events/CompletenessScoreFlow.ts
@@ -20,6 +20,7 @@ import { CmsActionType } from "."
 export type CmsCompletenessScoreClickLabel =
   | "completeness checklist link"
   | "edit artwork"
+  | "show missing details"
 
 export interface CmsCompletenessScoreClickedEvent {
   action: "click"


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [QA ticket](https://app.notion.com/p/artsy/What-tracking-needs-are-needed-3bfcab0764a080219cbffe428da1a99e)

### Description

feat: Adds new label for show missing details click event

Prep work to fire an even when “Show Missing details” button is clicked as part of homepage checklist V2

<img width="1756" height="653" alt="Screenshot 2026-08-17 at 12 09 48 PM" src="https://github.com/user-attachments/assets/c84f57a0-4634-41a2-8bbe-1210a58ffbee" />



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
