### PR TITLE
feat: add recentSearchesRail, trendingArtworksRail and trendingSearches context modules

### DIFF
--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -233,6 +233,7 @@ export enum ContextModule {
   recentlySavedRail = "recentlySavedRail",
   recentlyViewedRail = "recentlyViewedRail",
   recentPriceRanges = "recentPriceRanges",
+  recentSearchesRail = "recentSearchesRail",
   recommendedArtistsRail = "recommendedArtistsRail",
   recommendedWorksForYouRail = "recommendedWorksForYouRail",
   relatedArticles = "relatedArticles",
@@ -264,7 +265,9 @@ export enum ContextModule {
   topTab = "topTab",
   topWorksRail = "topWorksRail",
   trendingArtistsRail = "trendingArtistsRail",
+  trendingArtworksRail = "trendingArtworksRail",
   trendingLots = "trendingLots",
+  trendingSearches = "trendingSearches",
   troveArtworksRail = "troveArtworksRail",
   upcomingAuctions = "upcomingAuctions",
   upcomingAuctionsRail = "upcomingAuctionsRail",
@@ -386,6 +389,7 @@ export type AuthContextModule =
   | ContextModule.topTab
   | ContextModule.topWorksRail
   | ContextModule.trendingArtistsRail
+  | ContextModule.trendingArtworksRail
   | ContextModule.trendingLots
   | ContextModule.viewingRoom
   | ContextModule.worksByArtistsYouFollowRail


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [ONYX-2233]

### Description

Adds three `ContextModule` members for Force's new search dropdown (recent searches + trending panel):

- `recentSearchesRail` — the recent-search chips shown in the search dropdown's empty state
- `trendingArtworksRail` — the trending artworks rail; also added to the `AuthContextModule` union because saving an artwork from this rail can open the auth dialog
- `trendingSearches` — the panel's time-window tabs (Today / Past 7 Days / Past 30 days)

These modules attribute the panel's `railViewed` impressions, `selectedItemFromSearch` / `clickedArtistGroup` / `clickedArtworkGroup` clicks, and saves. Consumer: artsy/force branch `review-app-trending-searches`, which currently ships these values as cast strings pending this release and will swap to the enum members once the version bump lands.

### PR Checklist (tick all before merging)

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts) _(n/a — no new files, enum additions only)_
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs _(n/a — no new interfaces)_
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ONYX-2233]: https://artsyproduct.atlassian.net/browse/ONYX-2233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ