### PR TITLE
feat: Add new click events for artist feature badges

### DIFF
--- a/src/Schema/CMS/Events/ArtistFlow.ts
+++ b/src/Schema/CMS/Events/ArtistFlow.ts
@@ -1,0 +1,33 @@
+/**
+ * Schemas describing CMS Artist events
+ * @packageDocumentation
+ */
+
+import { CmsContextModule } from "../Values/CmsContextModule"
+import { CmsOwnerType } from "../Values/CmsOwnerType"
+import { CmsActionType } from "."
+
+/**
+ * Fired when a user clicks the "Featured in Editorial" badge on the artist list
+ * or artist show page, navigating to the associated article.
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedFeaturedInEditorialBadge",
+ *   context_module: "artistList",
+ *   context_page_owner_id: "derrick-adams",
+ *   context_page_owner_type: "artist",
+ *   destination_path: "/article/some-editorial-slug",
+ * }
+ * ```
+ */
+export interface CmsClickedFeaturedInEditorialBadge {
+  action: CmsActionType.clickedFeaturedInEditorialBadge
+  context_module: CmsContextModule.artistShow | CmsContextModule.artistList
+  context_page_owner_id: string
+  context_page_owner_type: CmsOwnerType.artist
+  destination_path: string
+}
+
+export type CmsArtistFlow = CmsClickedFeaturedInEditorialBadge

--- a/src/Schema/CMS/Events/__tests__/ArtistFlow.test.ts
+++ b/src/Schema/CMS/Events/__tests__/ArtistFlow.test.ts
@@ -1,0 +1,42 @@
+import { CmsContextModule } from "../../Values/CmsContextModule"
+import { CmsOwnerType } from "../../Values/CmsOwnerType"
+import { CmsClickedFeaturedInEditorialBadge } from "../ArtistFlow"
+import { CmsActionType } from "../index"
+
+describe("ArtistFlow events", () => {
+  it("CmsClickedFeaturedInEditorialBadge serializes to the expected shape (artist list)", () => {
+    const event: CmsClickedFeaturedInEditorialBadge = {
+      action: CmsActionType.clickedFeaturedInEditorialBadge,
+      context_module: CmsContextModule.artistList,
+      context_page_owner_id: "derrick-adams",
+      context_page_owner_type: CmsOwnerType.artist,
+      destination_path: "/article/some-editorial-slug",
+    }
+
+    expect(event).toEqual({
+      action: "clickedFeaturedInEditorialBadge",
+      context_module: "artistList",
+      context_page_owner_id: "derrick-adams",
+      context_page_owner_type: "artist",
+      destination_path: "/article/some-editorial-slug",
+    })
+  })
+
+  it("CmsClickedFeaturedInEditorialBadge serializes to the expected shape (artist header)", () => {
+    const event: CmsClickedFeaturedInEditorialBadge = {
+      action: CmsActionType.clickedFeaturedInEditorialBadge,
+      context_module: CmsContextModule.artistShow,
+      context_page_owner_id: "derrick-adams",
+      context_page_owner_type: CmsOwnerType.artist,
+      destination_path: "/article/some-editorial-slug",
+    }
+
+    expect(event).toEqual({
+      action: "clickedFeaturedInEditorialBadge",
+      context_module: "artistShow",
+      context_page_owner_id: "derrick-adams",
+      context_page_owner_type: "artist",
+      destination_path: "/article/some-editorial-slug",
+    })
+  })
+})

--- a/src/Schema/CMS/Events/index.ts
+++ b/src/Schema/CMS/Events/index.ts
@@ -1,4 +1,5 @@
 import { CmsAnalyticsPage } from "./AnalyticsPage"
+import { CmsArtistFlow } from "./ArtistFlow"
 import { CmsArtworkFilter } from "./ArtworkFilter"
 import { CmsArtworkTemplatesPage } from "./ArtworkTemplatesPage"
 import { CmsBatchImportFlow } from "./BatchImportFlow"
@@ -17,6 +18,7 @@ import { CmsUploadArtworkFlow } from "./UploadArtworkFlow"
  */
 export type CmsEvent =
   | CmsAnalyticsPage
+  | CmsArtistFlow
   | CmsArtworkFilter
   | CmsArtworkTemplatesPage
   | CmsBulkEditFlow
@@ -73,6 +75,11 @@ export enum CmsActionType {
    * Corresponds to {@link CmsArtworkTemplatesPage}
    */
   clickedArtworkNavigationTab = "clickedArtworkNavigationTab",
+
+  /**
+   * Corresponds to {@link CmsClickedFeaturedInEditorialBadge}
+   */
+  clickedFeaturedInEditorialBadge = "clickedFeaturedInEditorialBadge",
 
   /**
    * Corresponds to {@link CmsAnalytics}

--- a/src/Schema/CMS/Values/CmsContextModule.ts
+++ b/src/Schema/CMS/Values/CmsContextModule.ts
@@ -6,6 +6,8 @@
  */
 export enum CmsContextModule {
   addArtworkToShow = "Add artwork to show",
+  artistList = "artistList",
+  artistShow = "artistShow",
   analyticsAudience = "analyticsAudience",
   analyticsInquiries = "analyticsInquiries",
   analyticsMostViewed = "analyticsMostViewed",

--- a/src/Schema/CMS/Values/CmsOwnerType.ts
+++ b/src/Schema/CMS/Values/CmsOwnerType.ts
@@ -4,6 +4,7 @@
  * @packageDocumentation
  */
 export enum CmsOwnerType {
+  artist = "artist",
   artwork = "artwork",
   analytics = "analytics",
   bulkEdit = "bulkEdit",

--- a/src/Schema/index.ts
+++ b/src/Schema/index.ts
@@ -40,6 +40,7 @@ export * from "./Values/Tab"
 
 export * from "./CMS/Events"
 export * from "./CMS/Events/AnalyticsPage"
+export * from "./CMS/Events/ArtistFlow"
 export * from "./CMS/Events/ArtworkFilter"
 export * from "./CMS/Events/BatchImportFlow"
 export * from "./CMS/Events/BulkEditFlow"


### PR DESCRIPTION
The type of this PR is: **FEAT**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [Shape Up Bet](https://app.notion.com/p/artsy/Artist-Editorial-Feature-Callout-3bbcab0764a080b6b2fdddf4533a02a4)

### Description

Adding a new event to the schema for when a user clicks the new `Featured in Editorial` badge

These badges are viewable in CMS on the Artist list and Artist Show pages, clicking on them will take the user to the article

<img width="1499" height="694" alt="Screenshot 2026-08-26 at 12 47 49 PM" src="https://github.com/user-attachments/assets/9a5516c0-382a-492d-a7b2-4c223cf470a4" />

<img width="2003" height="776" alt="Screenshot 2026-08-26 at 12 11 03 PM" src="https://github.com/user-attachments/assets/d13db532-d818-4913-83ec-f2e43a67ffe5" />


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
