### PR TITLE
feat: add Artsy Lens image search events

### DIFF
--- a/src/Schema/Events/Search.ts
+++ b/src/Schema/Events/Search.ts
@@ -157,6 +157,58 @@ export interface SearchedWithResults {
 }
 
 /**
+ * A user searches by image via Artsy Lens and is shown a grid of visually similar
+ * artworks. `photo_source` records whether the photo was taken with the camera or
+ * picked from the photo library.
+ *
+ * Unlike [[searchedWithResults]] there is no `query`, and there is no
+ * `context_module`: the search is initiated by taking a photo rather than from a
+ * module on a page.
+ *
+ * This schema describes events sent to Segment from [[searchedByImageWithResults]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "searchedByImageWithResults",
+ *    context_owner_type: "searchByImage",
+ *    photo_source: "camera"
+ *  }
+ * ```
+ */
+export interface SearchedByImageWithResults {
+  action: ActionType.searchedByImageWithResults
+  context_owner_type: OwnerType.searchByImage
+  /** Where the photo the user searched with came from */
+  photo_source: "camera" | "photo_library"
+}
+
+/**
+ * A user searches by image via Artsy Lens and no visually similar artworks are found.
+ *
+ * Unlike [[searchedWithNoResults]] there is no `query`, and there is no
+ * `context_module`: the search is initiated by taking a photo rather than from a
+ * module on a page.
+ *
+ * This schema describes events sent to Segment from [[searchedByImageWithNoResults]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "searchedByImageWithNoResults",
+ *    context_owner_type: "searchByImage",
+ *    photo_source: "photo_library"
+ *  }
+ * ```
+ */
+export interface SearchedByImageWithNoResults {
+  action: ActionType.searchedByImageWithNoResults
+  context_owner_type: OwnerType.searchByImage
+  /** Where the photo the user searched with came from */
+  photo_source: "camera" | "photo_library"
+}
+
+/**
  * A user is shown a suggested filter row for what they typed into search
  *
  * This schema describes events sent to Segment from [[searchedWithSuggestedFilter]]

--- a/src/Schema/Events/Tap.ts
+++ b/src/Schema/Events/Tap.ts
@@ -1527,6 +1527,32 @@ export interface TappedGlobalSearchBar {
 }
 
 /**
+ * A user taps an entry point into Artsy Lens, the image search flow, and is taken
+ * to the camera. `type` names the entry point that was tapped.
+ *
+ * This schema describes events sent to Segment from [[tappedSearchByImage]]
+ *
+ *  @example
+ *  ```
+ *  {
+ *    action: "tappedSearchByImage",
+ *    context_module: "header",
+ *    context_screen_owner_type: "home",
+ *    destination_screen_owner_type: "searchByImage",
+ *    type: "search_input_icon"
+ *  }
+ * ```
+ */
+export interface TappedSearchByImage {
+  action: ActionType.tappedSearchByImage
+  context_module: ContextModule
+  context_screen_owner_type: ScreenOwnerType
+  destination_screen_owner_type: OwnerType.searchByImage
+  /** The entry point that was tapped */
+  type: "search_input_icon" | "search_overlay_button"
+}
+
+/**
  * A user taps a grouping of navigation pills on App
  *
  * This schema describes events sent to Segment from [[tappedNavigationPillsGroup]]

--- a/src/Schema/Events/index.ts
+++ b/src/Schema/Events/index.ts
@@ -249,6 +249,8 @@ import {
   FocusedOnPriceDatabaseSearchInput,
   FocusedOnSearchInput,
   PastedIntoSearchInput,
+  SearchedByImageWithNoResults,
+  SearchedByImageWithResults,
   SearchedPriceDatabase,
   SearchedWithNoResults,
   SearchedWithResults,
@@ -303,6 +305,7 @@ import {
   TappedOrderArtworkImage,
   TappedPartnerCard,
   TappedPromoSpace,
+  TappedSearchByImage,
   TappedSeeFewerWorks,
   TappedSell,
   TappedSellArtwork,
@@ -511,6 +514,8 @@ export type Event =
   | SavedPaymentMethodViewed
   | SavedPriceRange
   | Screen
+  | SearchedByImageWithNoResults
+  | SearchedByImageWithResults
   | SearchedPriceDatabase
   | SearchedWithNoResults
   | SearchedWithResults
@@ -599,6 +604,7 @@ export type Event =
   | TappedProductCapabilitiesGroup
   | TappedPromoSpace
   | TappedRequestPriceEstimate
+  | TappedSearchByImage
   | TappedSeeFewerWorks
   | TappedSell
   | TappedSellArtwork
@@ -1430,6 +1436,14 @@ export enum ActionType {
    */
   sentContent = "sentContent",
   /**
+   * Corresponds to {@link SearchedByImageWithNoResults}
+   */
+  searchedByImageWithNoResults = "searchedByImageWithNoResults",
+  /**
+   * Corresponds to {@link SearchedByImageWithResults}
+   */
+  searchedByImageWithResults = "searchedByImageWithResults",
+  /**
    * Corresponds to {@link SearchedPriceDatabase}
    */
   searchedPriceDatabase = "searchedPriceDatabase",
@@ -1810,6 +1824,10 @@ export enum ActionType {
    * Corresponds to {@link TappedRewind}
    */
   tappedRewind = "tappedRewind",
+  /**
+   * Corresponds to {@link TappedSearchByImage}
+   */
+  tappedSearchByImage = "tappedSearchByImage",
   /**
    * Corresponds to {@link TappedConfirmSeeFewerWorks}
    */

--- a/src/Schema/Values/ContextModule.ts
+++ b/src/Schema/Values/ContextModule.ts
@@ -243,6 +243,7 @@ export enum ContextModule {
   relatedWorksRail = "relatedWorksRail",
   saves = "saves",
   saveWorksCTA = "saveWorksCTA",
+  searchOverlay = "searchOverlay",
   searchPageResults = "searchPageResults",
   sell = "sell",
   sellFooter = "sellFooter",

--- a/src/Schema/Values/OwnerType.ts
+++ b/src/Schema/Values/OwnerType.ts
@@ -141,6 +141,7 @@ export enum OwnerType {
   savesAndFollows = "savesAndFollows",
   savesInfoModal = "savesInfoModal",
   search = "search",
+  searchByImage = "searchByImage",
   sell = "sell",
   sendOffers = "sendOffers",
   settings = "settings",
@@ -296,6 +297,7 @@ export type ScreenOwnerType =
   | OwnerType.savesAndFollows
   | OwnerType.savesInfoModal
   | OwnerType.search
+  | OwnerType.searchByImage
   | OwnerType.sell
   | OwnerType.settings
   | OwnerType.show
@@ -383,6 +385,7 @@ export type PageOwnerType =
   | OwnerType.savedSearches
   | OwnerType.saves
   | OwnerType.search
+  | OwnerType.searchByImage
   | OwnerType.sendOffers
   | OwnerType.show
   | OwnerType.shows


### PR DESCRIPTION
Assisted-by: Claude Code

The type of this PR is: **Feature**

### Description

Adds schema for Artsy Lens. The user opens the camera from the search bar / search overlay, takes a photo or picks one from their library, and gets a grid of visually similar artworks.

New owner type:

- `searchByImage` - covers the whole flow. Added to both `ScreenOwnerType` and `PageOwnerType`.

New context module:

- `searchOverlay` - the full-screen search overlay the app opens over Home or Search when the user taps the search bar. 

New events:

- `tappedSearchByImage` - Entry point into the camera. Entry points are distinguished by `type: "search_input_icon" | "search_overlay_button"`.
- `searchedByImageWithResults` - Fires when the similar-artwork grid is returned
- `searchedByImageWithNoResults` - Fires when nothing visually similar is found
 
**No new events for the results screen.** Eigen fires the existing `screen` and `tappedMainArtworkGrid` events with `context_screen_owner_type: "searchByImage"`.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)
