### PR TITLE
chore: Allow Duplicate functionality to be tracked in ArtOS

### DIFF
--- a/src/Schema/os/Events/InventoryTable.ts
+++ b/src/Schema/os/Events/InventoryTable.ts
@@ -333,7 +333,7 @@ export interface OsClickedActionsDropdown {
    * Top-bar "Open in Studio": "Tearsheet" | "Checklist" | "Instagram Post" | "Mailchimp Campaign"
    * Top-bar "More": "Delete"
    * Row/context menu only: "Remove from Artsy" | "Move to Collection" | "Remove from Collection" |
-   *   "Convert to Edition Set" | "Edit Edition Set" | "Convert to Unique"
+   *   "Convert to Edition Set" | "Edit Edition Set" | "Convert to Unique" | "Duplicate"
    * Distribution: "Distribute to Artsy"
    */
   value:
@@ -345,6 +345,7 @@ export interface OsClickedActionsDropdown {
     | "Convert to Unique"
     | "Delete"
     | "Distribute to Artsy"
+    | "Duplicate"
     | "Edit Edition Set"
     | "Instagram Post"
     | "Mailchimp Campaign"


### PR DESCRIPTION

The type of this PR is: **chore**

This PR resolves [notion card](https://app.notion.com/p/artsy/Add-Duplicate-Function-to-Action-Bar-Row-Level-3a7cab0764a080619928f8ed0b945498)

### Description

Allow Duplicate item in the Inventory table menu to be tracked in ArtOS

_Assisted-by: Claude Sonnet 5 [claude-code]_


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. #cohesion warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] If I've added a new file to the tree I've exported it from the common [`index.ts`](https://github.com/artsy/cohesion/blob/main/src/Schema/Events/index.ts)
- [x] I've added comments with examples for any new interfaces and ensured that they're in the docs
- [x] No platform-specific terminology has been used outside of `click` and `tap` (platform is inferred by the DB storing events)

cc @artsy/amber-devs 