### PR TITLE
feat: Add artworkEditDrawer context module and clickedEditArtworkButton event

### DIFF
--- a/src/Schema/os/Events/InventoryTable.ts
+++ b/src/Schema/os/Events/InventoryTable.ts
@@ -56,9 +56,34 @@ export interface OsClickedEditionSetRow {
 }
 
 /**
- * A partner edits a field inline in the inventory table.
+ * A partner clicks the "Edit artwork" button on an inventory table row to open
+ * the Edit Artwork drawer.
+ *
+ * This schema describes events sent to Segment from [[OsClickedEditArtworkButton]]
+ *
+ * @example
+ * ```
+ * {
+ *   action: "clickedEditArtworkButton",
+ *   context_module: "artworkEditDrawer",
+ *   context_page_owner_type: "inventory",
+ *   artwork_id: "abc123"
+ * }
+ * ```
+ */
+export interface OsClickedEditArtworkButton {
+  action: OsActionType.clickedEditArtworkButton
+  context_module: OsContextModule.artworkEditDrawer
+  context_page_owner_type: OsOwnerType
+  artwork_id: string
+}
+
+/**
+ * A partner edits a field inline in the inventory table, or in the Edit Artwork
+ * drawer opened from a table row.
  * Fires on mutation success (not on the toast render).
- * All field edits share this single event; use `field` to distinguish them.
+ * All field edits share this single event; use `field` to distinguish them, and
+ * `context_module` to distinguish which surface the edit was made from.
  *
  * This schema describes events sent to Segment from [[OsEditedArtworkField]]
  *
@@ -101,10 +126,25 @@ export interface OsClickedEditionSetRow {
  *   matched_id: "artist-internal-id"
  * }
  * ```
+ *
+ * @example Edited from the Edit Artwork drawer
+ * ```
+ * {
+ *   action: "editedArtworkField",
+ *   context_module: "artworkEditDrawer",
+ *   context_page_owner_type: "inventory",
+ *   artwork_id: "abc123",
+ *   field: "title",
+ *   old_value: "Untitled",
+ *   new_value: "Blue"
+ * }
+ * ```
  */
 export interface OsEditedArtworkField {
   action: OsActionType.editedArtworkField
-  context_module: OsContextModule.artworkTable
+  context_module:
+    | OsContextModule.artworkTable
+    | OsContextModule.artworkEditDrawer
   context_page_owner_type: OsOwnerType
   artwork_id: string
   /** Present only for edition-set variant rows in the Artsy CMS sub-row */
@@ -438,6 +478,7 @@ export type OsInventoryTable =
   | OsAddedLocation
   | OsClickedActionsDropdown
   | OsClickedArtworkRow
+  | OsClickedEditArtworkButton
   | OsClickedEditionSetRow
   | OsClickedImagesModal
   | OsEditedArtworkField

--- a/src/Schema/os/Events/__tests__/InventoryTable.test.ts
+++ b/src/Schema/os/Events/__tests__/InventoryTable.test.ts
@@ -1,9 +1,51 @@
 import { OsContextModule } from "../../Values/OsContextModule"
 import { OsOwnerType } from "../../Values/OsOwnerType"
 import { OsActionType } from "../index"
-import { OsReorderedInventoryTableColumns } from "../InventoryTable"
+import {
+  OsClickedEditArtworkButton,
+  OsEditedArtworkField,
+  OsReorderedInventoryTableColumns,
+} from "../InventoryTable"
 
 describe("Inventory Table events", () => {
+  it("OsClickedEditArtworkButton serializes to the expected shape", () => {
+    const event: OsClickedEditArtworkButton = {
+      action: OsActionType.clickedEditArtworkButton,
+      artwork_id: "abc123",
+      context_module: OsContextModule.artworkEditDrawer,
+      context_page_owner_type: OsOwnerType.inventory,
+    }
+
+    expect(event).toEqual({
+      action: "clickedEditArtworkButton",
+      artwork_id: "abc123",
+      context_module: "artworkEditDrawer",
+      context_page_owner_type: "inventory",
+    })
+  })
+
+  it("OsEditedArtworkField accepts the Edit Artwork drawer as a context_module", () => {
+    const event: OsEditedArtworkField = {
+      action: OsActionType.editedArtworkField,
+      artwork_id: "abc123",
+      context_module: OsContextModule.artworkEditDrawer,
+      context_page_owner_type: OsOwnerType.inventory,
+      field: "title",
+      new_value: "Blue",
+      old_value: "Untitled",
+    }
+
+    expect(event).toEqual({
+      action: "editedArtworkField",
+      artwork_id: "abc123",
+      context_module: "artworkEditDrawer",
+      context_page_owner_type: "inventory",
+      field: "title",
+      new_value: "Blue",
+      old_value: "Untitled",
+    })
+  })
+
   it("OsReorderedInventoryTableColumns serializes to the expected shape", () => {
     const event: OsReorderedInventoryTableColumns = {
       action: OsActionType.reorderedInventoryTableColumns,

--- a/src/Schema/os/Events/index.ts
+++ b/src/Schema/os/Events/index.ts
@@ -147,6 +147,11 @@ export enum OsActionType {
   clickedConnectModal = "clickedConnectModal",
 
   /**
+   * Corresponds to {@link OsClickedEditArtworkButton}
+   */
+  clickedEditArtworkButton = "clickedEditArtworkButton",
+
+  /**
    * Corresponds to {@link OsInventoryTable}
    */
   clickedEditionSetRow = "clickedEditionSetRow",

--- a/src/Schema/os/Values/OsContextModule.ts
+++ b/src/Schema/os/Values/OsContextModule.ts
@@ -10,6 +10,7 @@ export enum OsContextModule {
   addArtworkDropdown = "addArtworkDropdown",
   addLocationModal = "addLocationModal",
   addToListModal = "addToListModal",
+  artworkEditDrawer = "artworkEditDrawer",
   artworkFilters = "artworkFilters",
   artworkSearch = "artworkSearch",
   artworkTable = "artworkTable",


### PR DESCRIPTION
## Summary
- Adds `OsContextModule.artworkEditDrawer`
- Adds `OsClickedEditArtworkButton` event for the "Edit artwork" button click that opens the drawer
- Widens `OsEditedArtworkField.context_module` to accept `artworkEditDrawer` alongside `artworkTable`

## Why
Volt's `EditArtworkDrawer` opens from an "Edit artwork" button on an inventory table row and reuses the same field-edit cell components as the inline inventory table. Today, edits made inside the drawer fire the identical `editedArtworkField` event as edits made inline in the table (`context_module` hardcoded to `artworkTable`), so the two surfaces are indistinguishable in analytics. There's also no event for opening the drawer.

## What changed
- `OsContextModule`: new `artworkEditDrawer` value
- `OsEditedArtworkField`: `context_module` now accepts `artworkTable | artworkEditDrawer`
- New `OsClickedEditArtworkButton` event, `OsActionType.clickedEditArtworkButton`
- Tests covering both new/changed shapes

## Test plan
- [x] `yarn type-check`
- [x] `yarn jest InventoryTable`
- [x] `yarn lint`

Volt-side wiring is tracked separately and will land once this is merged and released.